### PR TITLE
Cambio perfil y header común feat: Standardize header and widen profile page layout

### DIFF
--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -18,15 +18,35 @@
 <body>
     <div class="app-logo-container">
     <a href="Index.html" title="Ir a la página de inicio">
-        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo"> <!-- ¡Asegúrate de que la ruta src sea correcta! -->
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
     </a>
+</div>
+
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
+        </button>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+        </div>
+    </div>
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
 </div>
 
     <main>
         <div class="container">
-                <button id="theme-toggle-button" class="theme-toggle-button" title="Cambiar tema">
-                    <i class="fas fa-moon"></i> <!-- Icono inicial, cambiará con JS -->
-                </button>
+            <!-- Removed theme-toggle-button from here -->
             <a href="list-view.html" class="back-button">← Volver al Ranking</a> <!-- JS will update href -->
             <p class="detail-list-name" id="detail-list-name">Estás viendo en Listopic: [Cargando...]</p>
             

--- a/public/grouped-detail-view.html
+++ b/public/grouped-detail-view.html
@@ -17,16 +17,36 @@
 </head>
 <body>
     <div class="app-logo-container">
-        <a href="Index.html" title="Ir a la página de inicio">
-            <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
-        </a>
+    <a href="Index.html" title="Ir a la página de inicio">
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
+    </a>
+</div>
+
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
+        </button>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+        </div>
     </div>
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
+</div>
 
     <main>
         <div class="container">
-            <button id="theme-toggle-button" class="theme-toggle-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
-            </button>
+            <!-- Removed theme-toggle-button from here -->
             <a href="#" class="back-button" id="back-to-list-view"><i class="fas fa-arrow-left"></i> Volver a la Lista</a>
             
             <div class="grouped-detail-header">

--- a/public/js/page-profile.js
+++ b/public/js/page-profile.js
@@ -25,7 +25,7 @@ ListopicApp.pageProfile = {
         // </div>
         // We'll need to adjust the HTML or create these elements if they don't exist.
         // For now, directly get the planned icon from profile.html
-        this.elements.profilePictureIcon = this.elements.profilePicturePlaceholder.querySelector('i'); 
+        this.elements.profilePictureIcon = this.elements.profilePicturePlaceholder.querySelector('i');
         // Let's add an img tag dynamically for now if needed, or ensure it's in the HTML.
         // For now, let's assume an img tag will be dynamically created or use one if present.
         // To simplify, the HTML has a placeholder icon. We'll hide it and show an img if photoURL exists.
@@ -68,7 +68,7 @@ ListopicApp.pageProfile = {
                     });
             });
         }
-        
+
         // Also add listener to the user menu logout button if it exists on this page
         if (this.elements.userMenuLogoutButton) {
              this.elements.userMenuLogoutButton.addEventListener('click', () => {

--- a/public/list-form.html
+++ b/public/list-form.html
@@ -21,14 +21,35 @@
 <body>
     <div class="app-logo-container">
     <a href="Index.html" title="Ir a la página de inicio">
-        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo"> <!-- ¡Asegúrate de que la ruta src sea correcta! -->
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
     </a>
-</div> <!-- Cierre del app-logo-container que faltaba o estaba mal ubicado -->
+</div>
+
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
+        </button>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+        </div>
+    </div>
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
+</div>
+
     <main>
         <div class="container form-container">
-                <button id="theme-toggle-button" class="theme-toggle-button" title="Cambiar tema">
-                    <i class="fas fa-moon"></i> <!-- Icono inicial, cambiará con JS -->
-                </button>
+            <!-- Removed theme-toggle-button from here -->
             <a href="index.html" class="back-button">← Cancelar y Volver a Mis Listas</a>
             <h2>Crear Nueva Lista de Valoración</h2> <!-- JS cambiará esto si es editar -->
             <form id="list-form" action="#" method="POST">

--- a/public/list-view.html
+++ b/public/list-view.html
@@ -19,14 +19,35 @@
 <body>
     <div class="app-logo-container">
     <a href="Index.html" title="Ir a la página de inicio">
-        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo"> <!-- ¡Asegúrate de que la ruta src sea correcta! -->
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
     </a>
-</div> <!-- Cierre del app-logo-container que faltaba o estaba mal ubicado -->
+</div>
+
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
+        </button>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+        </div>
+    </div>
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
+</div>
+
     <main>
         <div class="container">
-                <button id="theme-toggle-button" class="theme-toggle-button" title="Cambiar tema">
-                    <i class="fas fa-moon"></i> <!-- Icono inicial, cambiará con JS -->
-                </button>
+            <!-- Removed theme-toggle-button from here -->
             <a href="index.html" class="back-button">← Volver a Mis Listas</a>
             <div class="list-header-actions">
                  <h2 id="list-title">[Cargando nombre de la lista...]</h2>

--- a/public/profile.html
+++ b/public/profile.html
@@ -14,33 +14,35 @@
 </head>
 <body>
     <div class="app-logo-container">
-        <a href="index.html">
-            <img src="listopic-logo-transparent.png" alt="Listopic Logo" class="app-logo">
-        </a>
-    </div>
+    <a href="Index.html" title="Ir a la página de inicio">
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
+    </a>
+</div>
 
-    <!-- New container for header action buttons -->
-    <div class="header-actions-container">
-        <button id="search-button" class="header-action-button" aria-label="Search">
-            <i class="fas fa-search"></i>
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
         </button>
-        <div class="user-profile-menu-container"> <!-- Keep original container for its specific JS logic -->
-            <button id="user-profile-button" class="user-profile-button header-action-button" aria-label="User menu" aria-haspopup="true" aria-expanded="false">
-                <i class="fas fa-user-circle"></i>
-            </button>
-            <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="user-profile-button">
-                <a href="profile.html" role="menuitem" id="user-menu-profile-link">Perfil</a>
-                <hr class="user-menu-divider">
-                <button id="user-menu-logout-button" role="menuitem">Cerrar Sesión</button>
-            </div>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
         </div>
-        <button id="theme-toggle-button" class="theme-toggle-button header-action-button" aria-label="Toggle theme">
-            <i class="fas fa-sun"></i> 
-        </button>
     </div>
-    
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
+</div>
+
     <main>
-        <div class="container">
+        <div class="container profile-page-container">
             <h1 class="brand-title section-title">User Profile</h1>
 
             <div id="profile-picture-placeholder" style="text-align: center; margin-bottom: 20px;">
@@ -88,7 +90,7 @@
     <script src="js/authService.js"></script>
     <script src="js/themeManager.js"></script>
     <script src="js/uiUtils.js"></script>
-    <script src="js/page-profile.js"></script> 
+    <script src="js/page-profile.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/public/review-form.html
+++ b/public/review-form.html
@@ -20,14 +20,35 @@
 <body>
     <div class="app-logo-container">
     <a href="Index.html" title="Ir a la página de inicio">
-        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo"> <!-- ¡Asegúrate de que la ruta src sea correcta! -->
+        <img src="listopic-logo.png" alt="Listopic Logo" class="app-logo">
     </a>
-</div> <!-- Cierre del app-logo-container que faltaba o estaba mal ubicado -->
+</div>
+
+<div class="header-actions-container">
+    <button id="search-button" class="header-action-button" aria-label="Search">
+        <i class="fas fa-search"></i>
+    </button>
+    <div class="user-profile-menu-container">
+        <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+            <i class="fas fa-user-circle"></i>
+        </button>
+        <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+            <a href="profile.html" role="menuitem">Perfil</a>
+            <a href="profile.html#profile-email" role="menuitem">Datos</a>
+            <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+            <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+            <hr class="user-menu-divider">
+            <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+        </div>
+    </div>
+    <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+        <i class="fas fa-moon"></i>
+    </button>
+</div>
+
     <main>
         <div class="container form-container">
-                <button id="theme-toggle-button" class="theme-toggle-button" title="Cambiar tema">
-                    <i class="fas fa-moon"></i> <!-- Icono inicial, cambiará con JS -->
-                </button>
+            <!-- Removed theme-toggle-button from here -->
             <a href="list-view.html" class="back-button">← Cancelar y Volver al Ranking</a> <!-- JS will update href -->
             <h2>Añadir Nueva Reseña</h2>
             <form id="review-form" action="#" method="POST">

--- a/public/style.css
+++ b/public/style.css
@@ -543,7 +543,7 @@ small.non-weighted-detail { font-size: 0.85em; opacity: 0.7; font-style: italic;
     .detail-content { flex-direction: column; }
     .criterion-item input[name="criteria_title[]"] { flex-basis: 100%; }
     .criterion-item input[name="criteria_label_left[]"], .criterion-item input[name="criteria_label_right[]"] { flex-basis: calc(50% - 1rem); }
-    
+
     /* Logo adjustments for medium screens */
     .app-logo-container {
         top: 10px;
@@ -639,7 +639,7 @@ body.light-theme .search-input::placeholder {
 
 /* UPDATED: Specific styles for list circles in light theme for better icon contrast */
 body.light-theme #list-circles-ul a {
-    background-color: rgba(0,0,0,0.04); 
+    background-color: rgba(0,0,0,0.04);
     border: 1px solid rgba(0,0,0,0.08);
 }
 body.light-theme #list-circles-ul a:hover {
@@ -1015,6 +1015,7 @@ body.light-theme .user-menu-divider {
     cursor: pointer;
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
     box-sizing: border-box; /* Ensure padding/border don't affect final size unexpectedly */
+    flex-shrink: 0; /* Prevent buttons from shrinking if container space is tight */
 }
 
 .header-action-button:hover {
@@ -1047,6 +1048,7 @@ body.light-theme .user-menu-divider {
     /* display: flex;      Removed: Let parent flex container handle alignment of this block */
     /* align-items: center; Removed: Button inside has fixed size, should align correctly */
     box-sizing: border-box; /* Ensure padding/border don't affect final size unexpectedly */
+    flex-shrink: 0; /* Also prevent this container from shrinking */
     /* Purpose of this container is to be a positioned anchor for the absolute .user-menu */
     /* and a flex item in .header-actions-container. Its size will be that of its child button. */
 }
@@ -1067,7 +1069,7 @@ body.light-theme .header-action-button {
 body.light-theme .header-action-button:hover {
   background-color: var(--accent-color-primary); /* Uses light theme accent */
   /* Ensure main-button-text for light theme is set correctly for light theme accent bg */
-  color: var(--main-button-text); 
+  color: var(--main-button-text);
   border-color: var(--accent-color-primary);
 }
 
@@ -1203,6 +1205,13 @@ body.light-theme #profile-picture-placeholder img {
     border: 3px solid var(--input-border); /* Uses light theme input border */
 }
 
+/* --- Profile Page Specific Container Width --- */
+.profile-page-container {
+    max-width: 1100px !important; /* Increased from default 900px for .container. Using !important to ensure override if needed. */
+}
+/* End Profile Page Specific Container Width */
+
+
 /* Style for dynamically created profile image */
 .profile-image-dynamic {
     width: 120px; /* Matches existing #profile-picture-placeholder img style */
@@ -1216,13 +1225,13 @@ body.light-theme #profile-picture-placeholder img {
 }
 
 
-body.light-theme #profile-my-lists, 
+body.light-theme #profile-my-lists,
 body.light-theme #profile-my-reviews {
     background-color: rgba(0,0,0,0.03); /* Very light background for sections */
     border: 1px solid var(--input-border);
 }
 
-body.light-theme #profile-my-lists h3, 
+body.light-theme #profile-my-lists h3,
 body.light-theme #profile-my-reviews h3 {
     border-bottom: 1px solid var(--input-border); /* Uses light theme input border */
 }


### PR DESCRIPTION
This commit introduces two main improvements based on your feedback:

1.  **Common Header Standardization:**
    *   The header structure from `index.html` (including the app logo, search button, user profile menu, and theme toggle button) has been consistently applied across all relevant pages:
        *   `profile.html`
        *   `list-form.html`
        *   `review-form.html`
        *   `list-view.html`
        *   `detail-view.html`
        *   `grouped-detail-view.html`
    *   This replaces previous unique header elements on these pages, ensuring a unified look and feel for global navigation elements.

2.  **Profile Page Layout Widening:**
    *   The main content area of `profile.html` (specifically `.profile-page-container`) has been widened by increasing its `max-width` to `1100px`.
    *   This addresses feedback that the profile page content appeared too narrow on larger screens, while maintaining responsiveness on smaller devices.

These changes enhance UI consistency and improve the layout of the user profile page.