### PR TITLE
Add tabbed index prototype

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,15 +66,56 @@
     <main>
         <div class="container">
             <h1 class="brand-title"> <span class="logo-petal p1"></span> <span class="logo-petal p2"></span> Hmm...<span class="logo-petal p4"></span> <span class="logo-petal p5"></span> </h1>
-            <nav class="list-collection-container">
-                <ul id="list-circles-ul">
-                    <li><p>Cargando listas...</p></li>
-                </ul>
-                <a href="list-form.html" class="add-list-button" title="Crear nueva lista">
-                    <i class="fas fa-plus-circle"></i>
-                    <span>Crear Nueva Lista</span>
-                </a>
-            </nav>
+
+            <div class="tabs">
+                <button class="tab-button active" data-tab="explore">Explorar</button>
+                <button class="tab-button" data-tab="following">Novedades</button>
+            </div>
+
+            <div class="tab-content active" id="explore">
+                <section>
+                    <h2>Listas populares</h2>
+                    <ul class="placeholder-list">
+                        <li>Ejemplo de lista popular</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>Listas recientes</h2>
+                    <nav class="list-collection-container">
+                        <ul id="list-circles-ul">
+                            <li><p>Cargando listas...</p></li>
+                        </ul>
+                        <a href="list-form.html" class="add-list-button" title="Crear nueva lista">
+                            <i class="fas fa-plus-circle"></i>
+                            <span>Crear Nueva Lista</span>
+                        </a>
+                    </nav>
+                </section>
+
+                <section>
+                    <h2>Lugares destacados cerca de ti</h2>
+                    <ul class="placeholder-list">
+                        <li>Ejemplo de lugar cercano</li>
+                    </ul>
+                </section>
+            </div>
+
+            <div class="tab-content" id="following">
+                <section>
+                    <h2>Novedades de perfiles que sigues</h2>
+                    <ul class="placeholder-list">
+                        <li>Tu amigo creó una nueva lista</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>Novedades de lugares que sigues</h2>
+                    <ul class="placeholder-list">
+                        <li>El café de la esquina tiene una nueva reseña</li>
+                    </ul>
+                </section>
+            </div>
         </div>
     </main>
 

--- a/public/js/page-index.js
+++ b/public/js/page-index.js
@@ -55,7 +55,7 @@ ListopicApp.pageIndex = (() => {
         const createListBtn = document.querySelector('.add-list-button');
         if (createListBtn) {
             createListBtn.addEventListener('click', (e) => {
-                e.preventDefault(); 
+                e.preventDefault();
                 if (auth.currentUser) {
                     window.location.href = 'list-form.html';
                 } else {
@@ -64,6 +64,22 @@ ListopicApp.pageIndex = (() => {
                 }
             });
         }
+
+        // Manejo de pestañas
+        const tabButtons = document.querySelectorAll('.tab-button');
+        const tabContents = document.querySelectorAll('.tab-content');
+        tabButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const target = btn.dataset.tab;
+                tabButtons.forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                tabContents.forEach(c => c.classList.remove('active'));
+                const targetContent = document.getElementById(target);
+                if (targetContent) {
+                    targetContent.classList.add('active');
+                }
+            });
+        });
     }
 
     return {

--- a/public/style.css
+++ b/public/style.css
@@ -5641,5 +5641,34 @@ body.light-theme .leaflet-popup-tip {
     font-weight: bold;
     color: var(--title-color);
 }
+
+/* Estilos para pestañas del index */
+.tabs {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.tab-button {
+    padding: 0.5rem 1rem;
+    background: var(--container-bg-secondary);
+    border: none;
+    border-radius: var(--border-radius-small);
+    color: var(--text-color);
+    cursor: pointer;
+}
+
+.tab-button.active {
+    background: var(--accent-color-primary);
+    color: var(--main-button-text);
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
 /* Resto de estilos del archivo style.css */
 /* ... */


### PR DESCRIPTION
## Summary
- Add tabbed layout to index page with Explore and Novedades sections
- Introduce basic styles for tab buttons and content
- Handle tab switching in page-index script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe2bdc50c8326a9d6aea9d5bc82c8