### PR TITLE
Fix Firebase script order on detail pages

### DIFF
--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -19,29 +19,30 @@
     <meta property="og:image" content="https://listopic.web.app/public/img/listopic-logo400.png"> 
     <meta property="og:url" content="https://listopic.web.app/index.html"> <meta property="og:type" content="website">
 
-     <!-- Main application orchestrator -->
-   <script src="js/main.js" defer></script>
-    <!-- Listopic App Modules -->
-   <script src="js/config.js" defer></script>
-   <script src="js/firebaseService.js" defer></script>
-   <script src="js/uiUtils.js" defer></script>
-   <script src="js/themeManager.js" defer></script>
-   <script src="js/places-service.js" defer></script>
-   <script src="js/authService.js" defer></script>
-   <script src="js/page-index.js" defer></script>
-   <script src="js/page-auth.js" defer></script>
-   <script src="js/page-list-form.js" defer></script>
-   <script src="js/page-review-form.js" defer></script>
-   <script src="js/page-list-view.js" defer></script>
-   <script src="js/page-detail-view.js" defer></script>
-   <script src="js/page-grouped-detail-view.js" defer></script>
-
-    <!-- Firebase SDKs - Asegúrate de que app.js los utilice o inicialice Firebase -->
+    <!-- Firebase SDKs - deben cargarse antes de nuestros módulos -->
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js" defer></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <!-- Núcleo de Listopic -->
+    <script src="js/config.js" defer></script>
+    <script src="js/firebaseService.js" defer></script>
+    <script src="js/authService.js" defer></script>
+    <script src="js/uiUtils.js" defer></script>
+    <script src="js/themeManager.js" defer></script>
+    <script src="js/places-service.js" defer></script>
+
+    <!-- Orquestador y módulos de página -->
+    <script src="js/main.js" defer></script>
+    <script src="js/page-index.js" defer></script>
+    <script src="js/page-auth.js" defer></script>
+    <script src="js/page-list-form.js" defer></script>
+    <script src="js/page-review-form.js" defer></script>
+    <script src="js/page-list-view.js" defer></script>
+    <script src="js/page-detail-view.js" defer></script>
+    <script src="js/page-grouped-detail-view.js" defer></script>
     
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 

--- a/public/grouped-detail-view.html
+++ b/public/grouped-detail-view.html
@@ -18,29 +18,30 @@
     <meta property="og:image" content="https://listopic.web.app/public/img/listopic-logo400.png"> 
     <meta property="og:url" content="https://listopic.web.app/index.html"> <meta property="og:type" content="website">
 
-     <!-- Main application orchestrator -->
-   <script src="js/main.js" defer></script>
-    <!-- Listopic App Modules -->
-   <script src="js/config.js" defer></script>
-   <script src="js/firebaseService.js" defer></script>
-   <script src="js/uiUtils.js" defer></script>
-   <script src="js/themeManager.js" defer></script>
-   <script src="js/places-service.js" defer></script>
-   <script src="js/authService.js" defer></script>
-   <script src="js/page-index.js" defer></script>
-   <script src="js/page-auth.js" defer></script>
-   <script src="js/page-list-form.js" defer></script>
-   <script src="js/page-review-form.js" defer></script>
-   <script src="js/page-list-view.js" defer></script>
-   <script src="js/page-detail-view.js" defer></script>
-   <script src="js/page-grouped-detail-view.js" defer></script>
-
-    <!-- Firebase SDKs - Asegúrate de que app.js los utilice o inicialice Firebase -->
+    <!-- Firebase SDKs - deben inicializarse antes que nuestros módulos -->
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js" defer></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <!-- Núcleo de Listopic -->
+    <script src="js/config.js" defer></script>
+    <script src="js/firebaseService.js" defer></script>
+    <script src="js/authService.js" defer></script>
+    <script src="js/uiUtils.js" defer></script>
+    <script src="js/themeManager.js" defer></script>
+    <script src="js/places-service.js" defer></script>
+
+    <!-- Orquestador y módulos de página -->
+    <script src="js/main.js" defer></script>
+    <script src="js/page-index.js" defer></script>
+    <script src="js/page-auth.js" defer></script>
+    <script src="js/page-list-form.js" defer></script>
+    <script src="js/page-review-form.js" defer></script>
+    <script src="js/page-list-view.js" defer></script>
+    <script src="js/page-detail-view.js" defer></script>
+    <script src="js/page-grouped-detail-view.js" defer></script>
     
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -21,7 +21,15 @@ const app = firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
 const auth = firebase.auth();
 const storage = firebase.storage();
-const functions = firebase.functions();
+let functions = null;
+
+if (typeof firebase.functions === 'function') {
+    functions = firebase.functions();
+} else if (firebase.app && typeof firebase.app === 'function' && typeof firebase.app().functions === 'function') {
+    functions = firebase.app().functions();
+} else {
+    console.warn('[config] Firebase Functions SDK no disponible. Algunas funcionalidades podrían no estar activas.');
+}
 
 // 3. LÓGICA PARA CONECTAR A LOS EMULADORES EN LOCAL (sin cambios)
 /*


### PR DESCRIPTION
## Summary
- guard Firebase Functions initialization so config.js no longer crashes when the SDK is unavailable
- reorder Firebase SDK and Listopic scripts on the detail and grouped-detail pages so the Firebase namespace is ready before app code runs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3c3541c4883268b8d68697fbf4057