### PR TITLE
Add chats page with private and group conversation support

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "chats",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "memberIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "memberIds", "arrayConfig": "CONTAINS" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "recipientIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/public/chats.html
+++ b/public/chats.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chats - Listopic</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="manifest" href="/site.webmanifest">
+
+    <link rel="icon" href="img/favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
+
+    <!-- Firebase SDKs -->
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <!-- App scripts -->
+    <script src="js/config.js" defer></script>
+    <script src="js/firebaseService.js" defer></script>
+    <script src="js/uiUtils.js" defer></script>
+    <script src="js/themeManager.js" defer></script>
+    <script src="js/places-service.js" defer></script>
+    <script src="js/authService.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <script src="js/page-chats.js" defer></script>
+</head>
+<body>
+    <div class="header-actions-container">
+        <div class="header-left-content">
+            <div class="app-logo-container">
+                <a href="Index.html" title="Ir a la página de inicio">
+                    <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
+                </a>
+            </div>
+            <div class="header-dynamic-page-info">
+                <span>Mensajería</span>
+            </div>
+        </div>
+        <div class="header-right-actions">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Buscar">
+                <i class="fas fa-search"></i>
+            </a>
+            <div class="user-profile-menu-container">
+                <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+                    <i class="fas fa-user-circle"></i>
+                </button>
+                <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+                    <a href="profile.html" role="menuitem">Perfil</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
+                    <hr class="user-menu-divider">
+                    <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+                </div>
+            </div>
+            <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+                <i class="fas fa-moon"></i>
+            </button>
+        </div>
+    </div>
+
+    <main class="chat-main">
+        <div class="chat-page">
+            <aside class="chat-sidebar" aria-label="Lista de chats">
+                <div class="chat-sidebar-header">
+                    <h1 class="chat-sidebar-title">Mis conversaciones</h1>
+                    <button id="new-chat-btn" class="button primary-button">
+                        <i class="fas fa-comments"></i>
+                        <span>Nuevo chat</span>
+                    </button>
+                </div>
+                <div id="chat-list" class="chat-list" role="listbox" aria-live="polite">
+                    <div class="chat-empty-state">
+                        <i class="fas fa-comments"></i>
+                        <p>Aún no tienes conversaciones.</p>
+                        <p class="hint">Crea un chat privado o un grupo para empezar a hablar.</p>
+                    </div>
+                </div>
+            </aside>
+            <section class="chat-content" aria-live="polite">
+                <div class="chat-content-header">
+                    <div>
+                        <h2 id="chat-title">Selecciona un chat</h2>
+                        <p id="chat-subtitle">Elige una conversación para ver los mensajes.</p>
+                    </div>
+                    <div id="chat-members" class="chat-members"></div>
+                </div>
+                <div id="chat-messages" class="chat-messages" aria-live="polite">
+                    <div class="chat-empty-state">
+                        <i class="fas fa-message"></i>
+                        <p>No hay mensajes</p>
+                        <p class="hint">Selecciona un chat para comenzar la conversación.</p>
+                    </div>
+                </div>
+                <form id="message-form" class="chat-message-form" aria-label="Enviar mensaje">
+                    <input id="message-input" type="text" class="form-input" placeholder="Escribe tu mensaje" autocomplete="off" disabled>
+                    <button type="submit" class="button primary-button" disabled>
+                        <span>Enviar</span>
+                        <i class="fas fa-paper-plane"></i>
+                    </button>
+                </form>
+            </section>
+        </div>
+    </main>
+
+    <div id="new-chat-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="new-chat-title">
+        <div class="modal-content chat-modal-content">
+            <button class="close-button" id="close-new-chat-modal" aria-label="Cerrar">
+                <span>&times;</span>
+            </button>
+            <h2 id="new-chat-title">Crear nueva conversación</h2>
+            <form id="new-chat-form">
+                <div class="form-group">
+                    <label class="form-label">Tipo de chat</label>
+                    <div class="chat-type-options">
+                        <label class="chat-type-option">
+                            <input type="radio" name="chat-type" value="private" checked>
+                            <span>Privado (1 a 1)</span>
+                        </label>
+                        <label class="chat-type-option">
+                            <input type="radio" name="chat-type" value="group">
+                            <span>Grupo</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group" id="group-name-field" hidden>
+                    <label for="group-name-input" class="form-label">Nombre del grupo</label>
+                    <input id="group-name-input" type="text" class="form-input" placeholder="Ej. Planes del fin de semana">
+                </div>
+                <div class="form-group">
+                    <label for="chat-participants-input" class="form-label">Personas</label>
+                    <textarea id="chat-participants-input" class="form-textarea" rows="3" placeholder="Introduce los nombres de usuario, correos o IDs separados por comas"></textarea>
+                    <p class="form-hint">Puedes invitar a varios usuarios para crear un grupo. Tú siempre estarás incluido.</p>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="button primary-button">
+                        <i class="fas fa-check"></i>
+                        <span>Crear chat</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/public/chats.html
+++ b/public/chats.html
@@ -46,6 +46,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -64,6 +64,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/developer.html
+++ b/public/developer.html
@@ -23,8 +23,38 @@
 </head>
 <body>
     <div class="header-actions-container">
-        <div class="header-left-content"> <div class="app-logo-container"><a href="Index.html" title="Ir a la página de inicio"><img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo"></a></div> </div>
-        <div class="header-right-actions"> <a href="search.html" class="search-button header-action-button" aria-label="Search"><i class="fas fa-search"></i></a> <div class="user-profile-menu-container"> <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario"><i class="fas fa-user-circle"></i></button> <div class="user-menu" id="userMenuDropdown"><a href="profile.html">Perfil</a><a href="profile.html#profile-my-lists">Mis Listas</a><hr class="user-menu-divider"><button type="button" id="logoutBtnUserMenu">Cerrar sesión</button></div> </div> <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema"><i class="fas fa-moon"></i></button> </div>
+        <div class="header-left-content">
+            <div class="app-logo-container">
+                <a href="Index.html" title="Ir a la página de inicio">
+                    <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
+                </a>
+            </div>
+        </div>
+        <div class="header-right-actions">
+            <a href="search.html" class="search-button header-action-button" aria-label="Search">
+                <i class="fas fa-search"></i>
+            </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
+            <div class="user-profile-menu-container">
+                <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario">
+                    <i class="fas fa-user-circle"></i>
+                </button>
+                <div class="user-menu" id="userMenuDropdown">
+                    <a href="profile.html">Perfil</a>
+                    <a href="profile.html#profile-my-lists">Mis Listas</a>
+                    <hr class="user-menu-divider">
+                    <button type="button" id="logoutBtnUserMenu">Cerrar sesión</button>
+                </div>
+            </div>
+            <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+                <i class="fas fa-moon"></i>
+            </button>
+        </div>
     </div>
     <main class="dev-container">
         <h1><i class="fas fa-tools"></i> Panel de Desarrollador</h1>

--- a/public/grouped-detail-view.html
+++ b/public/grouped-detail-view.html
@@ -63,6 +63,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/js/firebaseService.js
+++ b/public/js/firebaseService.js
@@ -11,6 +11,7 @@ ListopicApp.services = (() => {
     const auth = firebase.auth();
     const storage = firebase.storage();
     const db = firebase.firestore();
+    const serverTimestamp = firebase.firestore.FieldValue.serverTimestamp;
 
     // Función para mostrar notificaciones
     function showNotification(message, type = 'info') {
@@ -208,6 +209,195 @@ ListopicApp.services = (() => {
         }
     };
 
+    const listenToUserChats = (userId, callback) => {
+        if (!userId || !callback) {
+            console.warn('[firebaseService] listenToUserChats requiere un userId y un callback');
+            return () => {};
+        }
+        return db.collection('chats')
+            .where('memberIds', 'array-contains', userId)
+            .orderBy('updatedAt', 'desc')
+            .onSnapshot(snapshot => {
+                const chats = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                callback(chats);
+            }, error => {
+                console.error('[firebaseService] Error escuchando chats del usuario:', error);
+            });
+    };
+
+    const listenToChatMessages = (chatId, callback) => {
+        if (!chatId || !callback) {
+            console.warn('[firebaseService] listenToChatMessages requiere un chatId y un callback');
+            return () => {};
+        }
+        return db.collection('chats')
+            .doc(chatId)
+            .collection('messages')
+            .orderBy('sentAt', 'asc')
+            .onSnapshot(snapshot => {
+                const messages = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                callback(messages);
+            }, error => {
+                console.error('[firebaseService] Error escuchando mensajes del chat:', error);
+            });
+    };
+
+    const sendChatMessage = async (chatId, senderId, text) => {
+        if (!chatId || !senderId || !text) {
+            throw new Error('Todos los campos son obligatorios para enviar un mensaje.');
+        }
+        const trimmedText = text.trim();
+        if (!trimmedText) {
+            return;
+        }
+        const chatRef = db.collection('chats').doc(chatId);
+        await chatRef.collection('messages').add({
+            text: trimmedText,
+            senderId,
+            sentAt: serverTimestamp(),
+            type: 'text'
+        });
+        await chatRef.update({
+            lastMessage: {
+                text: trimmedText,
+                senderId,
+                sentAt: serverTimestamp()
+            },
+            updatedAt: serverTimestamp()
+        });
+    };
+
+    const getOrCreatePrivateChat = async (currentUserId, otherUserId) => {
+        if (!currentUserId || !otherUserId) {
+            throw new Error('Los identificadores de usuario son obligatorios.');
+        }
+        if (currentUserId === otherUserId) {
+            throw new Error('No puedes iniciar un chat contigo mismo.');
+        }
+        const snapshot = await db.collection('chats')
+            .where('type', '==', 'private')
+            .where('memberIds', 'array-contains', currentUserId)
+            .get();
+        let existingChat = null;
+        snapshot.forEach(doc => {
+            const data = doc.data();
+            if (Array.isArray(data.memberIds) && data.memberIds.includes(otherUserId)) {
+                existingChat = { id: doc.id, ...data };
+            }
+        });
+        if (existingChat) {
+            return existingChat;
+        }
+        const chatData = {
+            type: 'private',
+            memberIds: [currentUserId, otherUserId],
+            createdBy: currentUserId,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        };
+        const chatRef = await db.collection('chats').add(chatData);
+        return { id: chatRef.id, ...chatData };
+    };
+
+    const createGroupChat = async (name, memberIds = [], createdBy) => {
+        if (!createdBy) {
+            throw new Error('Debe indicarse el creador del grupo.');
+        }
+        const uniqueMembers = Array.from(new Set([createdBy, ...memberIds]));
+        if (uniqueMembers.length < 3) {
+            throw new Error('Un grupo necesita al menos tres participantes.');
+        }
+        const chatData = {
+            type: 'group',
+            name: name || 'Nuevo grupo',
+            memberIds: uniqueMembers,
+            createdBy,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        };
+        const chatRef = await db.collection('chats').add(chatData);
+        return { id: chatRef.id, ...chatData };
+    };
+
+    const addMembersToChat = async (chatId, memberIds = []) => {
+        if (!chatId || !memberIds.length) {
+            throw new Error('Se requiere chatId y al menos un usuario para agregar.');
+        }
+        const chatRef = db.collection('chats').doc(chatId);
+        await chatRef.update({
+            memberIds: firebase.firestore.FieldValue.arrayUnion(...memberIds),
+            updatedAt: serverTimestamp()
+        });
+    };
+
+    const getUserProfileById = async (userId) => {
+        if (!userId) {
+            return null;
+        }
+        try {
+            const doc = await db.collection('users').doc(userId).get();
+            if (!doc.exists) {
+                return null;
+            }
+            return { id: doc.id, ...doc.data() };
+        } catch (error) {
+            console.error('[firebaseService] Error obteniendo usuario por ID:', error);
+            return null;
+        }
+    };
+
+    const getUserProfilesByIds = async (userIds = []) => {
+        const result = {};
+        if (!Array.isArray(userIds) || !userIds.length) {
+            return result;
+        }
+        const promises = userIds.map(async (userId) => {
+            const profile = await getUserProfileById(userId);
+            if (profile) {
+                result[userId] = profile;
+            }
+        });
+        await Promise.all(promises);
+        return result;
+    };
+
+    const findUserByIdentifier = async (identifier) => {
+        if (!identifier) {
+            return null;
+        }
+        const cleanedIdentifier = identifier.trim();
+        let queryField = 'username';
+        if (cleanedIdentifier.includes('@')) {
+            queryField = 'email';
+        }
+        try {
+            const snapshot = await db.collection('users')
+                .where(queryField, '==', cleanedIdentifier)
+                .limit(1)
+                .get();
+            if (snapshot.empty && queryField === 'username') {
+                // Intentar también por email si no se encontró por nombre de usuario
+                const emailSnapshot = await db.collection('users')
+                    .where('email', '==', cleanedIdentifier)
+                    .limit(1)
+                    .get();
+                if (!emailSnapshot.empty) {
+                    const doc = emailSnapshot.docs[0];
+                    return { id: doc.id, ...doc.data() };
+                }
+                return null;
+            }
+            if (snapshot.empty) {
+                return null;
+            }
+            const doc = snapshot.docs[0];
+            return { id: doc.id, ...doc.data() };
+        } catch (error) {
+            console.error('[firebaseService] Error buscando usuario por identificador:', error);
+            return null;
+        }
+    };
+
     return {
         auth: auth,
         storage: storage,
@@ -216,6 +406,15 @@ ListopicApp.services = (() => {
         getReviewsByUserId: getReviewsByUserId,
         createUserInAuthAndFirestore: createUserInAuthAndFirestore,
         showNotification: showNotification,
-        ensureUserProfileExists: ensureUserProfileExists // Exportar la nueva función
+        ensureUserProfileExists: ensureUserProfileExists,
+        listenToUserChats: listenToUserChats,
+        listenToChatMessages: listenToChatMessages,
+        sendChatMessage: sendChatMessage,
+        getOrCreatePrivateChat: getOrCreatePrivateChat,
+        createGroupChat: createGroupChat,
+        addMembersToChat: addMembersToChat,
+        getUserProfileById: getUserProfileById,
+        getUserProfilesByIds: getUserProfilesByIds,
+        findUserByIdentifier: findUserByIdentifier
     };
 })();

--- a/public/js/firebaseService.js
+++ b/public/js/firebaseService.js
@@ -398,6 +398,32 @@ ListopicApp.services = (() => {
         }
     };
 
+    const getUserNotifications = async (userId, options = {}) => {
+        if (!userId) {
+            console.warn('[firebaseService] getUserNotifications requiere un userId.');
+            return [];
+        }
+
+        const { limit = 20 } = options;
+
+        try {
+            let query = db
+                .collection('notifications')
+                .where('recipientIds', 'array-contains', userId)
+                .orderBy('createdAt', 'desc');
+
+            if (typeof limit === 'number' && limit > 0) {
+                query = query.limit(limit);
+            }
+
+            const snapshot = await query.get();
+            return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        } catch (error) {
+            console.error('[firebaseService] Error al obtener notificaciones del usuario:', error);
+            throw error;
+        }
+    };
+
     return {
         auth: auth,
         storage: storage,
@@ -415,6 +441,7 @@ ListopicApp.services = (() => {
         addMembersToChat: addMembersToChat,
         getUserProfileById: getUserProfileById,
         getUserProfilesByIds: getUserProfilesByIds,
-        findUserByIdentifier: findUserByIdentifier
+        findUserByIdentifier: findUserByIdentifier,
+        getUserNotifications: getUserNotifications
     };
 })();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -19,6 +19,246 @@ ListopicApp.state = {
     // Firebase services no deberían estar en state, se acceden desde ListopicApp.services
 };
 
+const notificationsRelativeTimeFormatter = (typeof Intl !== 'undefined' && typeof Intl.RelativeTimeFormat !== 'undefined')
+    ? new Intl.RelativeTimeFormat('es', { numeric: 'auto' })
+    : null;
+
+function formatRelativeTimeForNotifications(date) {
+    if (!(date instanceof Date)) {
+        return '';
+    }
+
+    if (!notificationsRelativeTimeFormatter) {
+        const diffMinutes = Math.round((Date.now() - date.getTime()) / 60000);
+        if (Math.abs(diffMinutes) <= 1) {
+            return 'justo ahora';
+        }
+        const suffix = diffMinutes >= 0 ? 'hace' : 'en';
+        return `${suffix} ${Math.abs(diffMinutes)} min`;
+    }
+
+    const timeUnits = [
+        { unit: 'year', ms: 1000 * 60 * 60 * 24 * 365 },
+        { unit: 'month', ms: 1000 * 60 * 60 * 24 * 30 },
+        { unit: 'week', ms: 1000 * 60 * 60 * 24 * 7 },
+        { unit: 'day', ms: 1000 * 60 * 60 * 24 },
+        { unit: 'hour', ms: 1000 * 60 * 60 },
+        { unit: 'minute', ms: 1000 * 60 },
+        { unit: 'second', ms: 1000 }
+    ];
+
+    const diff = date.getTime() - Date.now();
+    for (const { unit, ms } of timeUnits) {
+        if (Math.abs(diff) >= ms || unit === 'second') {
+            const value = Math.round(diff / ms);
+            return notificationsRelativeTimeFormatter.format(value, unit);
+        }
+    }
+
+    return '';
+}
+
+function ensureNotificationsModalElements() {
+    let modal = document.getElementById('notificationsModal');
+    if (!modal) {
+        modal = document.createElement('div');
+        modal.id = 'notificationsModal';
+        modal.className = 'modal notifications-modal';
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-labelledby', 'notificationsModalTitle');
+        modal.innerHTML = `
+            <div class="modal-content notifications-modal-content">
+                <button type="button" class="close-button close-notifications-modal" aria-label="Cerrar notificaciones">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h2 id="notificationsModalTitle">Notificaciones</h2>
+                <div class="notifications-modal-body">
+                    <p class="notifications-loading-state">Cargando notificaciones...</p>
+                    <ul class="notifications-list" role="list"></ul>
+                    <p class="notifications-empty-state" hidden>No tienes notificaciones nuevas.</p>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(modal);
+    }
+
+    const listElement = modal.querySelector('.notifications-list');
+    const loadingElement = modal.querySelector('.notifications-loading-state');
+    const emptyElement = modal.querySelector('.notifications-empty-state');
+    const closeButton = modal.querySelector('.close-notifications-modal');
+
+    return {
+        modal,
+        listElement,
+        loadingElement,
+        emptyElement,
+        closeButton
+    };
+}
+
+function setupNotificationsUI(currentUser) {
+    const notificationsButton = document.getElementById('notificationsButton');
+    if (!notificationsButton || notificationsButton.dataset.notificationsSetup === 'true') {
+        return;
+    }
+
+    const {
+        modal,
+        listElement,
+        loadingElement,
+        emptyElement,
+        closeButton
+    } = ensureNotificationsModalElements();
+
+    const closeModal = () => {
+        modal.classList.remove('active');
+        document.body.classList.remove('modal-open');
+        notificationsButton.setAttribute('aria-expanded', 'false');
+        notificationsButton.disabled = false;
+        delete notificationsButton.dataset.loading;
+        notificationsButton.focus();
+    };
+
+    const handleKeyDown = (event) => {
+        if (event.key === 'Escape' && modal.classList.contains('active')) {
+            closeModal();
+        }
+    };
+
+    if (!modal.dataset.listenersAttached) {
+        modal.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                closeModal();
+            }
+        });
+
+        if (closeButton) {
+            closeButton.addEventListener('click', closeModal);
+        }
+
+        document.addEventListener('keydown', handleKeyDown);
+        modal.dataset.listenersAttached = 'true';
+    }
+
+    const renderNotifications = (notifications) => {
+        listElement.innerHTML = '';
+
+        notifications.forEach(notification => {
+            const item = document.createElement('li');
+            item.className = 'notifications-item';
+
+            const iconWrapper = document.createElement('div');
+            iconWrapper.className = 'notification-icon';
+            const iconElement = document.createElement('i');
+            iconElement.className = notification.icon || 'fas fa-bell';
+            iconWrapper.appendChild(iconElement);
+
+            const mainWrapper = document.createElement('div');
+            mainWrapper.className = 'notification-main';
+
+            if (notification.title) {
+                const titleElement = document.createElement('h3');
+                titleElement.className = 'notification-title';
+                titleElement.textContent = notification.title;
+                mainWrapper.appendChild(titleElement);
+            }
+
+            const messageElement = document.createElement('p');
+            messageElement.className = 'notification-message';
+            messageElement.textContent = notification.message || notification.text || 'Tienes una nueva notificación.';
+            mainWrapper.appendChild(messageElement);
+
+            if (notification.url) {
+                const linkElement = document.createElement('a');
+                linkElement.className = 'notification-link';
+                linkElement.href = notification.url;
+                linkElement.target = '_blank';
+                linkElement.rel = 'noopener noreferrer';
+                linkElement.textContent = 'Ver detalles';
+                mainWrapper.appendChild(linkElement);
+            }
+
+            const timestamp = notification.createdAt;
+            let notificationDate = null;
+            if (timestamp && typeof timestamp.toDate === 'function') {
+                notificationDate = timestamp.toDate();
+            } else if (timestamp instanceof Date) {
+                notificationDate = timestamp;
+            } else if (typeof timestamp === 'number' || typeof timestamp === 'string') {
+                const parsedDate = new Date(timestamp);
+                if (!isNaN(parsedDate)) {
+                    notificationDate = parsedDate;
+                }
+            }
+
+            if (notificationDate instanceof Date && !isNaN(notificationDate)) {
+                const timeElement = document.createElement('time');
+                timeElement.className = 'notification-time';
+                timeElement.dateTime = notificationDate.toISOString();
+                timeElement.textContent = formatRelativeTimeForNotifications(notificationDate) || notificationDate.toLocaleString();
+                mainWrapper.appendChild(timeElement);
+            }
+
+            item.appendChild(iconWrapper);
+            item.appendChild(mainWrapper);
+            listElement.appendChild(item);
+        });
+    };
+
+    const openModal = async () => {
+        notificationsButton.disabled = true;
+        notificationsButton.setAttribute('aria-expanded', 'true');
+        notificationsButton.dataset.loading = 'true';
+        modal.classList.add('active');
+        document.body.classList.add('modal-open');
+
+        listElement.innerHTML = '';
+        emptyElement.hidden = true;
+        emptyElement.textContent = 'No tienes notificaciones nuevas.';
+        loadingElement.hidden = false;
+
+        if (!currentUser) {
+            loadingElement.hidden = true;
+            emptyElement.hidden = false;
+            emptyElement.textContent = 'Inicia sesión para ver tus notificaciones.';
+            notificationsButton.disabled = false;
+            return;
+        }
+
+        if (!ListopicApp.services || typeof ListopicApp.services.getUserNotifications !== 'function') {
+            loadingElement.hidden = true;
+            emptyElement.hidden = false;
+            emptyElement.textContent = 'El servicio de notificaciones no está disponible en este momento.';
+            notificationsButton.disabled = false;
+            return;
+        }
+
+        try {
+            const notifications = await ListopicApp.services.getUserNotifications(currentUser.uid, { limit: 30 });
+            loadingElement.hidden = true;
+
+            if (!notifications || notifications.length === 0) {
+                emptyElement.hidden = false;
+                return;
+            }
+
+            renderNotifications(notifications);
+        } catch (error) {
+            console.error('main.js: No se pudieron cargar las notificaciones:', error);
+            loadingElement.hidden = true;
+            emptyElement.hidden = false;
+            emptyElement.textContent = 'No pudimos cargar tus notificaciones. Intenta nuevamente más tarde.';
+        } finally {
+            notificationsButton.disabled = false;
+            delete notificationsButton.dataset.loading;
+        }
+    };
+
+    notificationsButton.addEventListener('click', openModal);
+    notificationsButton.dataset.notificationsSetup = 'true';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log("MAIN.JS: DOMContentLoaded disparado."); // <--- LOG 1
 
@@ -65,6 +305,12 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log("MAIN.JS: Esperando resolución de onAuthStateChangedPromise..."); // <--- LOG 10
     ListopicApp.authService.onAuthStateChangedPromise().then(user => {
         console.log("MAIN.JS: onAuthStateChangedPromise resuelta. Usuario:", user ? user.uid : 'No hay usuario'); // <--- LOG 11
+
+        try {
+            setupNotificationsUI(user);
+        } catch (notificationsError) {
+            console.error('MAIN.JS: Error inicializando el modal de notificaciones:', notificationsError);
+        }
 
         if (pageName === 'auth.html') {
             console.log("MAIN.JS: Es auth.html, intentando inicializar pageAuth..."); // <--- LOG 12

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -115,6 +115,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 } else {
                     console.error("MAIN.JS: ListopicApp.pageProfile.init no encontrado!"); // Log de error
                 }
+            } else if (pageName === 'chats.html') {
+                if (ListopicApp.pageChats && ListopicApp.pageChats.init) {
+                    ListopicApp.pageChats.init();
+                }
             } else if (pageName === 'search.html') { // NUEVA CONDICIÓN
                 if (ListopicApp.pageSearch && ListopicApp.pageSearch.init) {
                     ListopicApp.pageSearch.init();

--- a/public/js/page-chats.js
+++ b/public/js/page-chats.js
@@ -1,0 +1,549 @@
+window.ListopicApp = window.ListopicApp || {};
+
+ListopicApp.pageChats = (() => {
+    const state = {
+        currentUser: null,
+        chats: [],
+        activeChatId: null,
+        participantsCache: {},
+        unsubscribers: {
+            chats: null,
+            messages: null
+        },
+        pendingChatSelection: null
+    };
+
+    const elements = {
+        chatList: null,
+        chatMessages: null,
+        chatTitle: null,
+        chatSubtitle: null,
+        chatMembers: null,
+        messageForm: null,
+        messageInput: null,
+        newChatButton: null,
+        newChatModal: null,
+        closeNewChatModalButton: null,
+        newChatForm: null,
+        newChatTypeInputs: [],
+        groupNameField: null,
+        groupNameInput: null,
+        participantsInput: null
+    };
+
+    function init() {
+        cacheElements();
+        attachEventListeners();
+        hydrateFromAuth();
+    }
+
+    function cacheElements() {
+        elements.chatList = document.getElementById('chat-list');
+        elements.chatMessages = document.getElementById('chat-messages');
+        elements.chatTitle = document.getElementById('chat-title');
+        elements.chatSubtitle = document.getElementById('chat-subtitle');
+        elements.chatMembers = document.getElementById('chat-members');
+        elements.messageForm = document.getElementById('message-form');
+        elements.messageInput = document.getElementById('message-input');
+        elements.newChatButton = document.getElementById('new-chat-btn');
+        elements.newChatModal = document.getElementById('new-chat-modal');
+        elements.closeNewChatModalButton = document.getElementById('close-new-chat-modal');
+        elements.newChatForm = document.getElementById('new-chat-form');
+        elements.newChatTypeInputs = Array.from(document.querySelectorAll('input[name="chat-type"]'));
+        elements.groupNameField = document.getElementById('group-name-field');
+        elements.groupNameInput = document.getElementById('group-name-input');
+        elements.participantsInput = document.getElementById('chat-participants-input');
+    }
+
+    function attachEventListeners() {
+        elements.messageForm?.addEventListener('submit', handleSendMessage);
+        elements.newChatButton?.addEventListener('click', () => openNewChatModal());
+        elements.closeNewChatModalButton?.addEventListener('click', () => closeNewChatModal());
+        elements.newChatModal?.addEventListener('click', (event) => {
+            if (event.target === elements.newChatModal) {
+                closeNewChatModal();
+            }
+        });
+        elements.newChatForm?.addEventListener('submit', handleNewChatSubmit);
+        elements.newChatTypeInputs.forEach(input => {
+            input.addEventListener('change', updateNewChatTypeVisibility);
+        });
+
+        window.addEventListener('beforeunload', cleanup);
+    }
+
+    function hydrateFromAuth() {
+        ListopicApp.authService.onAuthStateChangedPromise().then(async (user) => {
+            if (!user) {
+                window.location.href = 'auth.html';
+                return;
+            }
+            state.currentUser = user;
+            startChatsListener();
+            handleInitialQueryParams();
+        }).catch(error => {
+            console.error('[page-chats] Error obtaining authenticated user:', error);
+            ListopicApp.services.showNotification('No se pudo cargar tu sesión. Inténtalo de nuevo.', 'error');
+        });
+    }
+
+    function startChatsListener() {
+        cleanupChatsListener();
+        state.unsubscribers.chats = ListopicApp.services.listenToUserChats(state.currentUser.uid, async (chats) => {
+            state.chats = Array.isArray(chats) ? chats : [];
+            await populateParticipantsCache(state.chats);
+            renderChatList();
+            autoSelectChat();
+        });
+    }
+
+    function cleanupChatsListener() {
+        if (state.unsubscribers.chats) {
+            state.unsubscribers.chats();
+            state.unsubscribers.chats = null;
+        }
+    }
+
+    async function populateParticipantsCache(chats) {
+        if (!Array.isArray(chats) || chats.length === 0) {
+            return;
+        }
+        const idsToLoad = new Set();
+        chats.forEach(chat => {
+            if (!Array.isArray(chat.memberIds)) {
+                return;
+            }
+            chat.memberIds.forEach(memberId => {
+                if (memberId !== state.currentUser.uid && !state.participantsCache[memberId]) {
+                    idsToLoad.add(memberId);
+                }
+            });
+        });
+        if (idsToLoad.size === 0) {
+            return;
+        }
+        try {
+            const profilesMap = await ListopicApp.services.getUserProfilesByIds(Array.from(idsToLoad));
+            Object.assign(state.participantsCache, profilesMap);
+        } catch (error) {
+            console.error('[page-chats] Error loading participant profiles:', error);
+        }
+    }
+
+    function renderChatList() {
+        if (!elements.chatList) {
+            return;
+        }
+        elements.chatList.innerHTML = '';
+        if (!state.chats.length) {
+            const empty = document.createElement('div');
+            empty.className = 'chat-empty-state';
+            empty.innerHTML = `
+                <i class="fas fa-comments"></i>
+                <p>Aún no tienes conversaciones.</p>
+                <p class="hint">Crea un chat privado o un grupo para empezar a hablar.</p>
+            `;
+            elements.chatList.appendChild(empty);
+            return;
+        }
+
+        state.chats.forEach(chat => {
+            const chatItem = buildChatListItem(chat);
+            elements.chatList.appendChild(chatItem);
+        });
+    }
+
+    function buildChatListItem(chat) {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'chat-list-item';
+        if (chat.id === state.activeChatId) {
+            item.classList.add('active');
+        }
+        item.dataset.chatId = chat.id;
+
+        const info = getChatDisplayInfo(chat);
+        const lastMessageText = chat.lastMessage?.text || 'Sin mensajes aún';
+        const lastMessageTime = formatTimestamp(chat.lastMessage?.sentAt);
+
+        item.innerHTML = `
+            <div class="chat-list-item-main">
+                <span class="chat-list-item-title">${info.title}</span>
+                <span class="chat-list-item-time">${lastMessageTime}</span>
+            </div>
+            <div class="chat-list-item-meta">
+                <span class="chat-list-item-subtitle">${info.subtitle}</span>
+                <span class="chat-list-item-preview">${lastMessageText}</span>
+            </div>
+        `;
+
+        item.addEventListener('click', () => {
+            setActiveChat(chat.id);
+        });
+
+        return item;
+    }
+
+    function getChatDisplayInfo(chat) {
+        const defaultInfo = {
+            title: 'Chat',
+            subtitle: ''
+        };
+        if (!chat) {
+            return defaultInfo;
+        }
+        if (chat.type === 'group') {
+            const title = chat.name || 'Grupo sin nombre';
+            const subtitle = `${Array.isArray(chat.memberIds) ? chat.memberIds.length : 0} participantes`;
+            return { title, subtitle };
+        }
+        const otherMemberId = Array.isArray(chat.memberIds)
+            ? chat.memberIds.find(id => id !== state.currentUser.uid)
+            : null;
+        if (!otherMemberId) {
+            return defaultInfo;
+        }
+        const profile = state.participantsCache[otherMemberId];
+        const title = profile?.username || profile?.displayName || profile?.email || 'Chat privado';
+        return {
+            title,
+            subtitle: profile?.bio ? profile.bio.substring(0, 60) : 'Chat privado'
+        };
+    }
+
+    function setActiveChat(chatId) {
+        if (!chatId || chatId === state.activeChatId) {
+            return;
+        }
+        state.activeChatId = chatId;
+        updateChatListSelection();
+        updateMessageFormState(true);
+        const chat = state.chats.find(item => item.id === chatId);
+        renderActiveChatHeader(chat);
+        subscribeToMessages(chatId);
+    }
+
+    function updateChatListSelection() {
+        if (!elements.chatList) {
+            return;
+        }
+        const items = elements.chatList.querySelectorAll('.chat-list-item');
+        items.forEach(item => {
+            item.classList.toggle('active', item.dataset.chatId === state.activeChatId);
+        });
+    }
+
+    function renderActiveChatHeader(chat) {
+        if (!chat) {
+            elements.chatTitle.textContent = 'Selecciona un chat';
+            elements.chatSubtitle.textContent = 'Elige una conversación para ver los mensajes.';
+            elements.chatMembers.innerHTML = '';
+            updateMessageFormState(false);
+            clearMessages();
+            return;
+        }
+        const info = getChatDisplayInfo(chat);
+        elements.chatTitle.textContent = info.title;
+        elements.chatSubtitle.textContent = info.subtitle || '';
+        renderChatMembers(chat);
+    }
+
+    function renderChatMembers(chat) {
+        if (!elements.chatMembers) {
+            return;
+        }
+        elements.chatMembers.innerHTML = '';
+        if (!Array.isArray(chat.memberIds)) {
+            return;
+        }
+        const fragment = document.createDocumentFragment();
+        chat.memberIds.forEach(memberId => {
+            const member = memberId === state.currentUser.uid
+                ? { username: 'Tú', photoUrl: state.currentUser.photoURL }
+                : state.participantsCache[memberId];
+            const badge = document.createElement('span');
+            badge.className = 'chat-member-badge';
+            badge.textContent = member?.username || member?.displayName || member?.email || 'Usuario';
+            fragment.appendChild(badge);
+        });
+        elements.chatMembers.appendChild(fragment);
+    }
+
+    function subscribeToMessages(chatId) {
+        cleanupMessagesListener();
+        if (!chatId) {
+            clearMessages();
+            return;
+        }
+        state.unsubscribers.messages = ListopicApp.services.listenToChatMessages(chatId, (messages) => {
+            renderMessages(messages || []);
+        });
+    }
+
+    function cleanupMessagesListener() {
+        if (state.unsubscribers.messages) {
+            state.unsubscribers.messages();
+            state.unsubscribers.messages = null;
+        }
+    }
+
+    function clearMessages() {
+        if (!elements.chatMessages) {
+            return;
+        }
+        elements.chatMessages.innerHTML = `
+            <div class="chat-empty-state">
+                <i class="fas fa-message"></i>
+                <p>No hay mensajes</p>
+                <p class="hint">Selecciona un chat para comenzar la conversación.</p>
+            </div>
+        `;
+    }
+
+    function renderMessages(messages) {
+        if (!elements.chatMessages) {
+            return;
+        }
+        if (!Array.isArray(messages) || messages.length === 0) {
+            clearMessages();
+            return;
+        }
+        const fragment = document.createDocumentFragment();
+        messages.forEach(message => {
+            const messageRow = document.createElement('div');
+            const isOwnMessage = message.senderId === state.currentUser.uid;
+            messageRow.className = `chat-message-row ${isOwnMessage ? 'own' : 'other'}`;
+
+            const bubble = document.createElement('div');
+            bubble.className = 'chat-message-bubble';
+            const text = document.createElement('p');
+            text.className = 'chat-message-text';
+            text.textContent = message.text || '';
+
+            const meta = document.createElement('span');
+            meta.className = 'chat-message-meta';
+            const senderProfile = !isOwnMessage ? state.participantsCache[message.senderId] : null;
+            const senderName = isOwnMessage
+                ? 'Tú'
+                : senderProfile?.username || senderProfile?.displayName || senderProfile?.email || 'Usuario';
+            meta.textContent = `${senderName} • ${formatTimestamp(message.sentAt)}`;
+
+            bubble.appendChild(text);
+            bubble.appendChild(meta);
+            messageRow.appendChild(bubble);
+            fragment.appendChild(messageRow);
+        });
+        elements.chatMessages.innerHTML = '';
+        elements.chatMessages.appendChild(fragment);
+        elements.chatMessages.scrollTop = elements.chatMessages.scrollHeight;
+    }
+
+    function formatTimestamp(timestamp) {
+        if (!timestamp) {
+            return '';
+        }
+        try {
+            const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+            return date.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+        } catch (error) {
+            return '';
+        }
+    }
+
+    function handleSendMessage(event) {
+        event.preventDefault();
+        if (!state.activeChatId) {
+            return;
+        }
+        const messageText = elements.messageInput?.value.trim();
+        if (!messageText) {
+            return;
+        }
+        elements.messageForm.querySelector('button[type="submit"]').disabled = true;
+        ListopicApp.services.sendChatMessage(state.activeChatId, state.currentUser.uid, messageText)
+            .then(() => {
+                if (elements.messageInput) {
+                    elements.messageInput.value = '';
+                }
+            })
+            .catch(error => {
+                console.error('[page-chats] Error sending message:', error);
+                ListopicApp.services.showNotification('No se pudo enviar el mensaje. Inténtalo de nuevo.', 'error');
+            })
+            .finally(() => {
+                updateMessageFormState(Boolean(state.activeChatId));
+            });
+    }
+
+    function updateMessageFormState(isEnabled) {
+        if (!elements.messageForm || !elements.messageInput) {
+            return;
+        }
+        elements.messageInput.disabled = !isEnabled;
+        const submitButton = elements.messageForm.querySelector('button[type="submit"]');
+        if (submitButton) {
+            submitButton.disabled = !isEnabled;
+        }
+    }
+
+    function openNewChatModal() {
+        if (!elements.newChatModal) {
+            return;
+        }
+        elements.newChatModal.classList.add('active');
+        updateNewChatTypeVisibility();
+    }
+
+    function closeNewChatModal() {
+        if (!elements.newChatModal) {
+            return;
+        }
+        elements.newChatModal.classList.remove('active');
+        elements.newChatForm?.reset();
+        updateNewChatTypeVisibility();
+    }
+
+    function updateNewChatTypeVisibility() {
+        if (!elements.groupNameField) {
+            return;
+        }
+        const selectedType = elements.newChatTypeInputs.find(input => input.checked)?.value;
+        const shouldShowGroupName = selectedType === 'group';
+        elements.groupNameField.hidden = !shouldShowGroupName;
+    }
+
+    async function handleNewChatSubmit(event) {
+        event.preventDefault();
+        if (!state.currentUser) {
+            return;
+        }
+        const selectedType = elements.newChatTypeInputs.find(input => input.checked)?.value || 'private';
+        const identifiersRaw = elements.participantsInput?.value || '';
+        const identifiers = identifiersRaw
+            .split(',')
+            .map(value => value.trim())
+            .filter(Boolean);
+
+        if (identifiers.length === 0) {
+            ListopicApp.services.showNotification('Introduce al menos un usuario.', 'warning');
+            return;
+        }
+
+        try {
+            const resolvedUsers = await resolveIdentifiersToUsers(identifiers);
+            if (selectedType === 'private') {
+                await createPrivateChatFromModal(resolvedUsers);
+            } else {
+                await createGroupChatFromModal(resolvedUsers);
+            }
+            closeNewChatModal();
+        } catch (error) {
+            console.error('[page-chats] Error creating chat:', error);
+            ListopicApp.services.showNotification(error.message || 'No se pudo crear el chat.', 'error');
+        }
+    }
+
+    async function resolveIdentifiersToUsers(identifiers) {
+        const results = [];
+        for (const identifier of identifiers) {
+            if (!identifier) {
+                continue;
+            }
+            let userProfile = await ListopicApp.services.getUserProfileById(identifier);
+            if (!userProfile) {
+                userProfile = await ListopicApp.services.findUserByIdentifier(identifier);
+            }
+            if (userProfile) {
+                results.push(userProfile);
+            }
+        }
+        const unique = [];
+        const seen = new Set();
+        results.forEach(user => {
+            if (user && !seen.has(user.id)) {
+                seen.add(user.id);
+                unique.push(user);
+            }
+        });
+        if (!unique.length) {
+            throw new Error('No se encontraron usuarios con los datos proporcionados.');
+        }
+        return unique;
+    }
+
+    async function createPrivateChatFromModal(users) {
+        if (!users.length) {
+            throw new Error('Selecciona un usuario válido para iniciar el chat privado.');
+        }
+        const targetUser = users[0];
+        if (targetUser.id === state.currentUser.uid) {
+            throw new Error('No puedes iniciar un chat contigo mismo.');
+        }
+        const chat = await ListopicApp.services.getOrCreatePrivateChat(state.currentUser.uid, targetUser.id);
+        state.pendingChatSelection = chat.id;
+        ListopicApp.services.showNotification('Chat privado listo para conversar.', 'success');
+    }
+
+    async function createGroupChatFromModal(users) {
+        const memberIds = users
+            .filter(user => user.id !== state.currentUser.uid)
+            .map(user => user.id);
+        if (memberIds.length < 2) {
+            throw new Error('Un grupo necesita al menos dos participantes adicionales.');
+        }
+        const groupName = elements.groupNameInput?.value.trim();
+        const chat = await ListopicApp.services.createGroupChat(groupName, memberIds, state.currentUser.uid);
+        state.pendingChatSelection = chat.id;
+        ListopicApp.services.showNotification('Grupo creado con éxito.', 'success');
+    }
+
+    function handleInitialQueryParams() {
+        const params = new URLSearchParams(window.location.search);
+        const chatIdParam = params.get('chatId');
+        const userIdParam = params.get('userId');
+        if (chatIdParam) {
+            state.pendingChatSelection = chatIdParam;
+        } else if (userIdParam) {
+            ensurePrivateChatWithUser(userIdParam);
+        }
+    }
+
+    async function ensurePrivateChatWithUser(userId) {
+        if (!userId || !state.currentUser) {
+            return;
+        }
+        try {
+            const chat = await ListopicApp.services.getOrCreatePrivateChat(state.currentUser.uid, userId);
+            state.pendingChatSelection = chat.id;
+        } catch (error) {
+            console.error('[page-chats] Error ensuring private chat from query:', error);
+            ListopicApp.services.showNotification('No se pudo preparar el chat con esa persona.', 'error');
+        }
+    }
+
+    function autoSelectChat() {
+        if (state.pendingChatSelection) {
+            const exists = state.chats.some(chat => chat.id === state.pendingChatSelection);
+            if (exists) {
+                setActiveChat(state.pendingChatSelection);
+                state.pendingChatSelection = null;
+                return;
+            }
+        }
+        if (!state.activeChatId && state.chats.length) {
+            setActiveChat(state.chats[0].id);
+        } else if (!state.chats.length) {
+            state.activeChatId = null;
+            renderActiveChatHeader(null);
+        }
+    }
+
+    function cleanup() {
+        cleanupChatsListener();
+        cleanupMessagesListener();
+    }
+
+    return {
+        init
+    };
+})();

--- a/public/js/page-profile.js
+++ b/public/js/page-profile.js
@@ -19,6 +19,7 @@ ListopicApp.pageProfile = {
         myReviewsContainer: null,
         openEditModalBtn: null,
         followUnfollowBtn: null, // NUEVO
+        openChatButton: null,
         profileMessageArea: null,
         
         // --- Elementos del Modal ---
@@ -95,6 +96,7 @@ ListopicApp.pageProfile = {
         this.elements.myReviewsContainer = document.getElementById('my-reviews-container'); // MODIFICADO
         this.elements.openEditModalBtn = document.getElementById('open-edit-profile-modal-btn');
         this.elements.followUnfollowBtn = document.getElementById('follow-unfollow-btn'); // NUEVO
+        this.elements.openChatButton = document.getElementById('open-chat-button');
         this.elements.profileMessageArea = document.getElementById('profile-message-area');
         
         // --- CACHE DE LOS NUEVOS ELEMENTOS DE ESTADÍSTICAS ---
@@ -154,6 +156,10 @@ ListopicApp.pageProfile = {
         if (this.elements.followUnfollowBtn) {
             this.elements.followUnfollowBtn.style.display = isOwnProfile ? 'none' : 'inline-block';
         }
+        if (this.elements.openChatButton) {
+            this.elements.openChatButton.style.display = 'inline-block';
+            this.elements.openChatButton.textContent = isOwnProfile ? 'Ir a mis chats' : 'Enviar mensaje';
+        }
         // Cuando confirmemos que aparecen, volveremos a la lógica original.
     },
 
@@ -198,6 +204,7 @@ ListopicApp.pageProfile = {
         });
         // Dentro de attachEventListeners en ListopicApp.pageProfile
         this.elements.profilePhotoDisplay?.addEventListener('click', () => this.openPhotoModal());
+        this.elements.openChatButton?.addEventListener('click', () => this.handleOpenChat());
         this.elements.closePhotoModalBtn?.addEventListener('click', () => this.closePhotoModal());
         this.elements.photoModal?.addEventListener('click', (event) => {
             if (event.target === this.elements.photoModal) {
@@ -230,7 +237,7 @@ ListopicApp.pageProfile = {
         this.elements.profileTabs?.addEventListener('click', (event) => {
             const tabButton = event.target.closest('.profile-tab-button');
             if (!tabButton) return;
-        
+
             const tabName = tabButton.dataset.tab;
         
             // Quitar 'active' de todos los botones y contenidos
@@ -244,6 +251,20 @@ ListopicApp.pageProfile = {
                 activeContent.classList.add('active');
             }
         });
+    },
+
+    handleOpenChat: function() {
+        if (!this.currentUser) {
+            return;
+        }
+        const isOwnProfile = this.currentUser.uid === this.profileOwnerUserId;
+        if (isOwnProfile) {
+            window.location.href = 'chats.html';
+            return;
+        }
+        if (this.profileOwnerUserId) {
+            window.location.href = `chats.html?userId=${encodeURIComponent(this.profileOwnerUserId)}`;
+        }
     },
 
     checkFollowStatus: async function() {

--- a/public/list-form.html
+++ b/public/list-form.html
@@ -105,6 +105,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/list-view.html
+++ b/public/list-view.html
@@ -76,6 +76,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/place-detail.html
+++ b/public/place-detail.html
@@ -26,6 +26,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/profile.html
+++ b/public/profile.html
@@ -51,6 +51,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/profile.html
+++ b/public/profile.html
@@ -57,6 +57,7 @@
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
                     <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
                     <hr class="user-menu-divider">
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
@@ -89,6 +90,9 @@
                         </button>
                         <button id="follow-unfollow-btn" class="button primary-button" style="display: none;">
                             Seguir
+                        </button>
+                        <button id="open-chat-button" class="button tertiary-button" style="display: none;">
+                            Enviar mensaje
                         </button>
                     </div>
                 </div>

--- a/public/review-form.html
+++ b/public/review-form.html
@@ -44,6 +44,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/search.html
+++ b/public/search.html
@@ -24,6 +24,12 @@
             <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
                 <i class="fas fa-search"></i>
             </a>
+            <button type="button" id="notificationsButton" class="notifications-button header-action-button" aria-label="Notificaciones" aria-haspopup="dialog" aria-controls="notificationsModal" aria-expanded="false">
+                <i class="fas fa-bell"></i>
+            </button>
+            <a href="chats.html" class="chat-button header-action-button" aria-label="Abrir chats">
+                <i class="fas fa-comments"></i>
+            </a>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/style.css
+++ b/public/style.css
@@ -363,6 +363,20 @@ main > .table-container {
 .secondary-button { background-color: var(--accent-color-quaternary); color: white; }
 .secondary-button:hover { background-color: #1a75cf; box-shadow: 0 4px 15px rgba(var(--accent-color-quaternary-rgb), 0.3); }
 
+.tertiary-button {
+    background-color: transparent;
+    color: var(--accent-color-secondary);
+    border: 1px solid rgba(var(--accent-color-secondary-rgb), 0.6);
+    box-shadow: none;
+    transition: background-color 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tertiary-button:hover {
+    background-color: rgba(var(--accent-color-secondary-rgb), 0.15);
+    color: var(--accent-color-secondary);
+    box-shadow: 0 4px 12px rgba(var(--accent-color-secondary-rgb), 0.25);
+}
+
 .edit-button { background-color: var(--accent-color-tertiary); color: var(--main-button-text); }
 .edit-button:hover { background-color: #00cf6b; box-shadow: 0 4px 15px rgba(var(--accent-color-tertiary-rgb), 0.3); }
 .delete-button.danger, .delete-list-button.danger, .remove-button.danger { background-color: var(--danger-color); color: white; }
@@ -6381,3 +6395,386 @@ body.light-theme .leaflet-popup-tip {
 
 /* Toggle active state */
 #lists-toggle-main .button.active{background-color: var(--accent-color-tertiary); color: var(--main-button-text)}
+
+/* ================================================= */
+/* === Estilos para la página de chats (Listopic) === */
+/* ================================================= */
+
+.chat-main {
+    padding: 120px 20px 60px;
+    min-height: 100vh;
+    background: var(--primary-bg);
+}
+
+.chat-page {
+    display: grid;
+    grid-template-columns: minmax(280px, 340px) 1fr;
+    gap: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.chat-sidebar {
+    background: var(--container-bg);
+    border-radius: var(--border-radius-large);
+    padding: 24px;
+    box-shadow: var(--shadow-elevation-medium);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-height: calc(100vh - 200px);
+}
+
+.chat-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.chat-sidebar-title {
+    margin: 0;
+    font-size: 1.3rem;
+    color: var(--title-color);
+}
+
+.chat-list {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    padding-right: 6px;
+}
+
+.chat-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.chat-list::-webkit-scrollbar-thumb {
+    background: rgba(var(--accent-color-quaternary-rgb), 0.3);
+    border-radius: 999px;
+}
+
+.chat-list-item {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-medium);
+    padding: 14px 16px;
+    color: var(--text-color);
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.25s ease, background-color 0.25s ease, transform 0.18s ease;
+}
+
+.chat-list-item:hover {
+    border-color: rgba(var(--accent-color-primary-rgb), 0.55);
+    transform: translateY(-1px);
+}
+
+.chat-list-item.active {
+    border-color: var(--accent-color-primary);
+    background-color: rgba(var(--accent-color-primary-rgb), 0.15);
+}
+
+.chat-list-item-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.chat-list-item-title {
+    font-weight: 600;
+    color: var(--title-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.chat-list-item-time {
+    font-size: 0.75rem;
+    color: var(--secondary-text-color);
+    margin-left: 12px;
+}
+
+.chat-list-item-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.chat-list-item-subtitle,
+.chat-list-item-preview {
+    font-size: 0.85rem;
+    color: var(--secondary-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.chat-content {
+    background: var(--container-bg);
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--shadow-elevation-high);
+    display: flex;
+    flex-direction: column;
+    min-height: 620px;
+}
+
+.chat-content-header {
+    padding: 24px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.chat-content-header h2 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: var(--title-color);
+}
+
+.chat-content-header p {
+    margin: 6px 0 0;
+    color: var(--secondary-text-color);
+}
+
+.chat-members {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.chat-member-badge {
+    background: rgba(var(--accent-color-quaternary-rgb), 0.18);
+    color: var(--accent-color-quaternary);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+}
+
+.chat-messages {
+    flex: 1;
+    padding: 24px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.chat-messages::-webkit-scrollbar {
+    width: 10px;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+    background: rgba(var(--accent-color-primary-rgb), 0.25);
+    border-radius: 999px;
+}
+
+.chat-message-row {
+    display: flex;
+    width: 100%;
+}
+
+.chat-message-row.own {
+    justify-content: flex-end;
+}
+
+.chat-message-row.other {
+    justify-content: flex-start;
+}
+
+.chat-message-bubble {
+    max-width: clamp(220px, 70%, 520px);
+    background: var(--container-bg-secondary);
+    padding: 14px 16px;
+    border-radius: 20px;
+    box-shadow: var(--shadow-elevation-low);
+}
+
+.chat-message-row.own .chat-message-bubble {
+    background: rgba(var(--accent-color-primary-rgb), 0.2);
+    border-bottom-right-radius: 8px;
+    border-bottom-left-radius: 20px;
+}
+
+.chat-message-row.other .chat-message-bubble {
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 20px;
+}
+
+.chat-message-text {
+    margin: 0 0 8px;
+    color: var(--text-color);
+    line-height: 1.45;
+}
+
+.chat-message-meta {
+    font-size: 0.7rem;
+    color: var(--secondary-text-color);
+    display: block;
+    text-align: right;
+}
+
+.chat-message-row.own .chat-message-meta {
+    color: rgba(var(--accent-color-primary-rgb), 0.85);
+}
+
+.chat-message-form {
+    padding: 20px 24px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: rgba(var(--primary-bg-rgb-values), 0.35);
+    border-bottom-left-radius: var(--border-radius-large);
+    border-bottom-right-radius: var(--border-radius-large);
+}
+
+.chat-message-form input[type="text"] {
+    flex: 1;
+    padding: 12px 16px;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius-medium);
+    color: var(--text-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-message-form input[type="text"]:focus {
+    border-color: var(--accent-color-primary);
+    box-shadow: 0 0 0 2px rgba(var(--accent-color-primary-rgb), 0.25);
+    outline: none;
+}
+
+.chat-message-form button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.chat-empty-state {
+    text-align: center;
+    border: 1px dashed var(--border-color);
+    border-radius: var(--border-radius-medium);
+    padding: 40px 20px;
+    color: var(--secondary-text-color);
+    background: rgba(var(--primary-bg-rgb-values), 0.4);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+.chat-empty-state i {
+    font-size: 2rem;
+    color: var(--accent-color-quinary);
+}
+
+.chat-empty-state .hint {
+    font-size: 0.85rem;
+    margin: 0;
+    color: var(--secondary-text-color);
+}
+
+.chat-modal-content {
+    max-width: 520px;
+    width: 100%;
+    padding: 32px;
+    background: var(--container-bg);
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--shadow-elevation-high);
+    position: relative;
+}
+
+#new-chat-modal .close-button {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+}
+
+.chat-type-options {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.chat-type-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: var(--border-radius-medium);
+    border: 1px solid rgba(var(--accent-color-primary-rgb), 0.25);
+    background: rgba(255, 209, 102, 0.1);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.chat-type-option input[type="radio"] {
+    margin: 0;
+    accent-color: var(--accent-color-primary);
+}
+
+.chat-type-option input[type="radio"]:checked + span {
+    font-weight: 600;
+    color: var(--accent-color-primary);
+}
+
+.chat-type-option:hover {
+    border-color: rgba(var(--accent-color-primary-rgb), 0.5);
+    background: rgba(var(--accent-color-primary-rgb), 0.12);
+}
+
+.form-hint {
+    font-size: 0.8rem;
+    color: var(--secondary-text-color);
+    margin-top: 6px;
+}
+
+@media (max-width: 1100px) {
+    .chat-page {
+        grid-template-columns: minmax(260px, 300px) 1fr;
+    }
+}
+
+@media (max-width: 900px) {
+    .chat-page {
+        grid-template-columns: 1fr;
+    }
+
+    .chat-sidebar {
+        max-height: none;
+        order: 2;
+    }
+
+    .chat-content {
+        order: 1;
+    }
+}
+
+@media (max-width: 640px) {
+    .chat-sidebar-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .chat-message-bubble {
+        max-width: 100%;
+    }
+
+    .chat-message-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .chat-message-form button {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1498,6 +1498,26 @@ body.light-theme .user-menu-divider {
     gap: 9px; /* Espacio entre los botones de acción */
 }
 
+.header-action-button.notifications-button,
+.header-action-button.chat-button {
+    position: relative;
+}
+
+.notifications-button[data-loading="true"] {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+.notifications-button .fa-bell,
+.chat-button .fa-comments {
+    transition: transform 0.2s ease;
+}
+
+.notifications-button:hover .fa-bell,
+.chat-button:hover .fa-comments {
+    transform: scale(1.05);
+}
+
 /* En style.css */
 
 /* Estilo general para los botones de acción del header, incluyendo los que son enlaces */
@@ -1808,6 +1828,9 @@ a.header-action-button:hover {
 .modal.active {
     display: flex; /* Use flex to center content */
 }
+body.modal-open {
+    overflow: hidden;
+}
 .modal-content {
     background-color: var(--container-bg);
     margin: auto;
@@ -1835,6 +1858,101 @@ a.header-action-button:hover {
 }
 .close-button:hover, .close-button:focus {
     color: var(--text-color);
+}
+
+.notifications-modal-content {
+    max-width: 460px;
+    padding: 24px 28px 28px;
+}
+
+.notifications-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-height: 70vh;
+}
+
+.notifications-loading-state,
+.notifications-empty-state {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--secondary-text-color);
+}
+
+.notifications-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 52vh;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.notifications-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 14px;
+    align-items: flex-start;
+    padding: 12px 14px;
+    border-radius: var(--border-radius-medium);
+    background-color: var(--container-bg-secondary);
+    border: 1px solid var(--border-color-light);
+    box-shadow: var(--shadow-elevation-low);
+}
+
+.notification-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background-color: rgba(var(--accent-color-secondary-rgb), 0.18);
+    color: var(--accent-color-secondary);
+    font-size: 1.1rem;
+}
+
+.notification-main {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.notification-title {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--title-color);
+}
+
+.notification-message {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text-color);
+    line-height: 1.4;
+}
+
+.notification-link {
+    align-self: flex-start;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--accent-color-secondary);
+    text-decoration: none;
+}
+
+.notification-link:hover,
+.notification-link:focus {
+    text-decoration: underline;
+}
+
+.notification-time {
+    font-size: 0.8rem;
+    color: var(--secondary-text-color);
+}
+
+body.dark-theme .notifications-item {
+    background-color: rgba(255, 255, 255, 0.02);
 }
 
 /* Save button specific to modals, if different from global .button or .submit-button */


### PR DESCRIPTION
## Summary
- add a dedicated chats page and client logic to list conversations, send messages, and create private or group chats
- extend Firebase service helpers plus profile navigation to open conversations and surface the chat entry point
- update global styles and Firestore indexes for the new messaging interface and queries

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68db92ca76bc83268728f43522faf9ab