### PR TITLE
Add direct message shortcut from profile pages

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "chats",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -53,6 +53,12 @@ service cloud.firestore {
         allow read, list: if request.auth != null && request.auth.uid == userId;
         allow write: if false;
       }
+
+      match /notifications/{notificationId} {
+        allow read, list, update: if request.auth != null && request.auth.uid == userId;
+        allow create: if request.auth != null && request.auth.uid == userId;
+        allow delete: if false;
+      }
     }
 
     // ===============================================
@@ -138,6 +144,30 @@ service cloud.firestore {
       match /messages/{messageId} {
         allow read, list, create: if canAccessList();
         allow update, delete: if request.auth != null && (resource.data.userId == request.auth.uid || isJefe(request.auth.uid));
+      }
+    }
+
+    match /chats/{chatId} {
+      allow read, list: if request.auth != null
+                        && resource.data.participants != null
+                        && resource.data.participants.hasAny([request.auth.uid]);
+      allow create: if request.auth != null
+                     && request.resource.data.participants is list
+                     && request.resource.data.participants.hasAny([request.auth.uid]);
+      allow update: if request.auth != null
+                     && resource.data.participants != null
+                     && resource.data.participants.hasAny([request.auth.uid]);
+      allow delete: if false;
+
+      match /messages/{messageId} {
+        allow read, list: if request.auth != null
+                           && get(/databases/$(database)/documents/chats/$(chatId)).data.participants.hasAny([request.auth.uid]);
+        allow create: if request.auth != null
+                       && get(/databases/$(database)/documents/chats/$(chatId)).data.participants.hasAny([request.auth.uid])
+                       && request.resource.data.senderId == request.auth.uid;
+        allow update: if request.auth != null
+                       && get(/databases/$(database)/documents/chats/$(chatId)).data.participants.hasAny([request.auth.uid]);
+        allow delete: if false;
       }
     }
   }

--- a/functions/modules/core.js
+++ b/functions/modules/core.js
@@ -949,7 +949,7 @@ const toggleFollowUser = onCall(async (request) => {
             batch.delete(followerRef);
             batch.update(currentUserRef, { followingCount: FieldValue.increment(-1) });
             batch.update(userToFollowRef, { followersCount: FieldValue.increment(-1) });
-            
+
             await batch.commit();
             logger.info(`Usuario ${currentUserId} ha dejado de seguir a ${userIdToFollow}.`);
             return { status: 'unfollowed', message: 'Has dejado de seguir a este usuario.' };
@@ -962,12 +962,121 @@ const toggleFollowUser = onCall(async (request) => {
 
             await batch.commit();
             logger.info(`Usuario ${currentUserId} ahora sigue a ${userIdToFollow}.`);
+
+            try {
+                const followerProfileSnap = await currentUserRef.get();
+                const followerProfile = followerProfileSnap.exists ? followerProfileSnap.data() : {};
+                await userToFollowRef.collection('notifications').add({
+                    type: 'new_follower',
+                    followerId: currentUserId,
+                    followerUsername: followerProfile.username || followerProfile.displayName || followerProfile.email || '',
+                    followerPhotoUrl: followerProfile.photoUrl || '',
+                    createdAt: FieldValue.serverTimestamp(),
+                    read: false
+                });
+            } catch (notificationError) {
+                logger.error(`toggleFollowUser: Error creando notificaciÃ³n de nuevo seguidor para ${userIdToFollow}`, notificationError);
+            }
+
             return { status: 'followed', message: 'Ahora sigues a este usuario.' };
         }
     } catch (error) {
         logger.error(`Error en toggleFollowUser para ${currentUserId} -> ${userIdToFollow}:`, error);
         throw new HttpsError('internal', 'OcurriÃ³ un error al procesar la solicitud.');
     }
+});
+
+const resolveChatParticipants = onCall(async (request) => {
+    const contextAuth = request.auth;
+    if (!contextAuth) {
+        throw new HttpsError('unauthenticated', 'Debes estar autenticado.');
+    }
+
+    const rawIdentifiers = request.data && request.data.identifiers;
+    if (!Array.isArray(rawIdentifiers) || rawIdentifiers.length === 0) {
+        throw new HttpsError('invalid-argument', 'Debes proporcionar los identificadores de los usuarios.');
+    }
+
+    const normalizeIdentifier = (value) => {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        let cleaned = value.trim();
+        cleaned = cleaned.replace(/^[@#]+/, '');
+        cleaned = cleaned.replace(/[\s,;]+$/, '');
+        return cleaned.trim();
+    };
+
+    const identifiers = rawIdentifiers
+        .map(normalizeIdentifier)
+        .filter(identifier => identifier.length > 0);
+
+    if (!identifiers.length) {
+        throw new HttpsError('invalid-argument', 'Debes proporcionar identificadores válidos.');
+    }
+
+    const results = [];
+    const seen = new Set();
+
+    for (const identifier of identifiers) {
+        const dedupeKey = identifier.toLowerCase();
+        if (seen.has(dedupeKey)) {
+            continue;
+        }
+        seen.add(dedupeKey);
+
+        let userDoc = null;
+
+        try {
+            if (identifier.includes('@') && identifier.includes('.')) {
+                const lowered = identifier.toLowerCase();
+                const emailSnapshot = await db.collection('users').where('email', '==', lowered).limit(1).get();
+                if (!emailSnapshot.empty) {
+                    userDoc = emailSnapshot.docs[0];
+                } else if (lowered !== identifier) {
+                    const originalSnapshot = await db.collection('users').where('email', '==', identifier).limit(1).get();
+                    if (!originalSnapshot.empty) {
+                        userDoc = originalSnapshot.docs[0];
+                    }
+                }
+            }
+
+            if (!userDoc) {
+                const usernameSnapshot = await db.collection('users').where('username', '==', identifier).limit(1).get();
+                if (!usernameSnapshot.empty) {
+                    userDoc = usernameSnapshot.docs[0];
+                }
+            }
+
+            if (!userDoc) {
+                const possibleDoc = await db.collection('users').doc(identifier).get();
+                if (possibleDoc.exists) {
+                    userDoc = possibleDoc;
+                }
+            }
+
+            if (userDoc && userDoc.exists) {
+                if (userDoc.id === contextAuth.uid) {
+                    continue; // No incluimos al propio usuario
+                }
+                if (results.some(existing => existing.uid === userDoc.id)) {
+                    continue;
+                }
+                const data = userDoc.data();
+                results.push({
+                    uid: userDoc.id,
+                    username: data.username || '',
+                    displayName: data.displayName || '',
+                    email: data.email || '',
+                    photoUrl: data.photoUrl || ''
+                });
+            }
+        } catch (error) {
+            logger.error(`resolveChatParticipants: error buscando identificador ${identifier}`, error);
+        }
+    }
+
+    return { users: results };
 });
 
 // En functions/index.js, reemplaza la funciÃ³n getPlacesForList entera por esta:
@@ -2016,6 +2125,7 @@ module.exports = {
     updateUserStatsOnListChange,
     updateAggregatesOnCommentChange,
     toggleFollowUser,
+    resolveChatParticipants,
     getPlacesForList,
     getPlaceDetails,
     getGroupsForPlace,

--- a/public/chats.html
+++ b/public/chats.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chats - Listopic</title>
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <link rel="icon" href="img/favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
+
+    <meta property="og:title" content="Listopic - Tus conversaciones">
+    <meta property="og:description" content="Chatea con tu comunidad de Listopic.">
+    <meta property="og:image" content="https://listopic.web.app/public/img/listopic-logo400.png">
+    <meta property="og:url" content="https://listopic.web.app/chats.html">
+    <meta property="og:type" content="website">
+
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <script src="js/config.js" defer></script>
+    <script src="js/firebaseService.js" defer></script>
+    <script src="js/uiUtils.js" defer></script>
+    <script src="js/themeManager.js" defer></script>
+    <script src="js/authService.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <script src="js/page-chats.js" defer></script>
+</head>
+<body>
+    <div class="header-actions-container">
+        <div class="header-left-content">
+            <div class="app-logo-container">
+                <a href="Index.html" title="Ir a la página de inicio">
+                    <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
+                </a>
+            </div>
+        </div>
+        <div class="header-right-actions">
+            <a href="search.html" id="search-link-button" class="header-action-button icon-with-badge" aria-label="Buscar">
+                <i class="fas fa-search"></i>
+            </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats" aria-current="page">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
+            <div class="user-profile-menu-container">
+                <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+                    <i class="fas fa-user-circle"></i>
+                </button>
+                <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+                    <a href="profile.html" role="menuitem">Perfil</a>
+                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
+                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
+                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <hr class="user-menu-divider">
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+                    <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+                </div>
+            </div>
+            <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+                <i class="fas fa-moon"></i>
+            </button>
+        </div>
+    </div>
+
+    <main>
+        <div class="container">
+            <section class="chats-page" aria-label="Mensajes directos">
+                <aside class="chat-panel" id="chat-list-panel">
+                    <header>
+                        <h2>Tus chats</h2>
+                        <p id="chat-list-status" class="notifications-empty-state" style="text-align:left; margin-top:6px;">Cargando conversaciones...</p>
+                    </header>
+                    <div class="chat-list" id="chat-list"></div>
+                    <form id="new-chat-form" class="new-chat-form" autocomplete="off">
+                        <label for="new-chat-identifiers">Iniciar chat (usuario o email)</label>
+                        <input type="text" id="new-chat-identifiers" name="new-chat-identifiers" placeholder="usuario1, usuario2" required>
+                        <small>Separa varios destinatarios con comas. Solo podrás chatear con usuarios existentes.</small>
+                        <button type="submit" class="button primary">Crear chat</button>
+                        <p class="notifications-empty-state" id="new-chat-error" style="display:none;"></p>
+                    </form>
+                </aside>
+
+                <section class="chat-panel" id="chat-messages-panel" aria-live="polite">
+                    <header>
+                        <h2 id="chat-detail-title">Selecciona un chat</h2>
+                    </header>
+                    <div class="chat-messages" id="chat-messages">
+                        <div class="chat-empty-state" id="chat-empty-state">
+                            <p>Elige una conversación para ver los mensajes.</p>
+                        </div>
+                    </div>
+                    <form id="message-form" class="message-composer" autocomplete="off" hidden>
+                        <textarea id="message-input" name="message" placeholder="Escribe un mensaje" required maxlength="2000"></textarea>
+                        <button type="submit" class="button primary">Enviar</button>
+                    </form>
+                </section>
+            </section>
+        </div>
+    </main>
+</body>
+</html>

--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -61,9 +61,24 @@
         </div>
 
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/developer.html
+++ b/public/developer.html
@@ -24,7 +24,40 @@
 <body>
     <div class="header-actions-container">
         <div class="header-left-content"> <div class="app-logo-container"><a href="Index.html" title="Ir a la página de inicio"><img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo"></a></div> </div>
-        <div class="header-right-actions"> <a href="search.html" class="search-button header-action-button" aria-label="Search"><i class="fas fa-search"></i></a> <div class="user-profile-menu-container"> <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario"><i class="fas fa-user-circle"></i></button> <div class="user-menu" id="userMenuDropdown"><a href="profile.html">Perfil</a><a href="profile.html#profile-my-lists">Mis Listas</a><hr class="user-menu-divider"><button type="button" id="logoutBtnUserMenu">Cerrar sesión</button></div> </div> <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema"><i class="fas fa-moon"></i></button> </div>
+        <div class="header-right-actions">
+            <a href="search.html" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
+                <i class="fas fa-search"></i>
+            </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
+            <div class="user-profile-menu-container">
+                <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
+                    <i class="fas fa-user-circle"></i>
+                </button>
+                <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
+                    <a href="profile.html" role="menuitem">Perfil</a>
+                    <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
+                    <hr class="user-menu-divider">
+                    <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
+                </div>
+            </div>
+            <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
+                <i class="fas fa-moon"></i>
+            </button>
+        </div>
     </div>
     <main class="dev-container">
         <h1><i class="fas fa-tools"></i> Panel de Desarrollador</h1>

--- a/public/grouped-detail-view.html
+++ b/public/grouped-detail-view.html
@@ -60,9 +60,24 @@
         </div>
 
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -37,9 +37,24 @@
             </div>
         </div>
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>
@@ -50,7 +65,7 @@
                     <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
                     <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
                     <hr class="user-menu-divider">
-                    
+
                     <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
                         <i class="fas fa-download"></i> Instalar Aplicación
                     </button>

--- a/public/js/firebaseService.js
+++ b/public/js/firebaseService.js
@@ -11,6 +11,7 @@ ListopicApp.services = (() => {
     const auth = firebase.auth();
     const storage = firebase.storage();
     const db = firebase.firestore();
+    const FieldValue = firebase.firestore.FieldValue;
 
     // Función para mostrar notificaciones
     function showNotification(message, type = 'info') {
@@ -208,6 +209,276 @@ ListopicApp.services = (() => {
         }
     };
 
+    const listenToUserChats = (userId, onUpdate, onError) => {
+        if (!userId) return () => {};
+        try {
+            const query = db.collection('chats')
+                .where('participants', 'array-contains', userId)
+                .orderBy('updatedAt', 'desc');
+            const unsubscribe = query.onSnapshot(snapshot => {
+                const chats = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                onUpdate && onUpdate(chats);
+            }, error => {
+                console.error('[firebaseService] Error escuchando chats del usuario:', error);
+                onError && onError(error);
+            });
+            return unsubscribe;
+        } catch (error) {
+            console.error('[firebaseService] Error creando listener de chats:', error);
+            onError && onError(error);
+            return () => {};
+        }
+    };
+
+    const listenToChatMessages = (chatId, onUpdate, onError) => {
+        if (!chatId) return () => {};
+        try {
+            const query = db.collection('chats').doc(chatId).collection('messages').orderBy('createdAt', 'asc');
+            const unsubscribe = query.onSnapshot(snapshot => {
+                const messages = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                onUpdate && onUpdate(messages);
+            }, error => {
+                console.error('[firebaseService] Error escuchando mensajes del chat:', error);
+                onError && onError(error);
+            });
+            return unsubscribe;
+        } catch (error) {
+            console.error('[firebaseService] Error creando listener de mensajes:', error);
+            onError && onError(error);
+            return () => {};
+        }
+    };
+
+    const createChatWithParticipants = async (currentUser, identifiers) => {
+        if (!currentUser || !currentUser.uid) {
+            throw new Error('Usuario no autenticado.');
+        }
+
+        const normalizeIdentifier = (value) => {
+            if (typeof value !== 'string') {
+                return '';
+            }
+            let cleaned = value.trim();
+            cleaned = cleaned.replace(/^[@#]+/, '');
+            cleaned = cleaned.replace(/[\s,;]+$/, '');
+            return cleaned.trim();
+        };
+
+        const sanitized = Array.isArray(identifiers)
+            ? identifiers.map(normalizeIdentifier).filter(Boolean)
+            : [];
+
+        if (!sanitized.length) {
+            throw new Error('Debes indicar al menos un usuario.');
+        }
+
+        try {
+            const functions = firebase.app().functions('europe-west1');
+            const resolver = functions.httpsCallable('resolveChatParticipants');
+            const response = await resolver({ identifiers: sanitized });
+            const responseData = response && response.data ? response.data : {};
+            const resolvedUsersRaw = Array.isArray(responseData.users) ? responseData.users : [];
+            const resolvedUsers = resolvedUsersRaw.filter(user => user.uid !== currentUser.uid);
+
+            if (!resolvedUsers.length) {
+                throw new Error('No se encontraron usuarios con los datos proporcionados.');
+            }
+
+            const participantIds = new Set([currentUser.uid]);
+            const participantProfiles = {};
+
+            const currentProfileSnap = await db.collection('users').doc(currentUser.uid).get();
+            const currentProfile = currentProfileSnap.exists ? currentProfileSnap.data() : {};
+            participantProfiles[currentUser.uid] = {
+                username: currentProfile.username || currentUser.displayName || currentUser.email || '',
+                displayName: currentProfile.displayName || currentProfile.username || currentUser.displayName || '',
+                photoUrl: currentProfile.photoUrl || currentUser.photoURL || '',
+                email: currentProfile.email || currentUser.email || ''
+            };
+
+            resolvedUsers.forEach(user => {
+                participantIds.add(user.uid);
+                participantProfiles[user.uid] = {
+                    username: user.username || user.displayName || user.email || '',
+                    displayName: user.displayName || user.username || '',
+                    photoUrl: user.photoUrl || '',
+                    email: user.email || ''
+                };
+            });
+
+            if (participantIds.size < 2) {
+                throw new Error('Debes seleccionar al menos otro usuario.');
+            }
+
+            const participantsArray = Array.from(participantIds).sort();
+            const participantsHash = participantsArray.join('_');
+
+            const existingChatSnapshot = await db.collection('chats')
+                .where('participantsHash', '==', participantsHash)
+                .limit(1)
+                .get();
+
+            if (!existingChatSnapshot.empty) {
+                const existingChat = existingChatSnapshot.docs[0];
+                return { chatId: existingChat.id, alreadyExists: true };
+            }
+
+            const unreadCounts = {};
+            participantsArray.forEach(uid => {
+                unreadCounts[uid] = 0;
+            });
+
+            const chatData = {
+                participants: participantsArray,
+                participantsHash,
+                participantProfiles,
+                createdAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+                lastMessage: '',
+                lastMessageSenderId: null,
+                unreadCounts
+            };
+
+            const newChatRef = await db.collection('chats').add(chatData);
+            return { chatId: newChatRef.id, alreadyExists: false };
+        } catch (error) {
+            console.error('[firebaseService] Error creando chat:', error);
+            throw error;
+        }
+    };
+
+    const sendChatMessage = async (chatId, senderId, text) => {
+        if (!chatId || !senderId || !text) {
+            throw new Error('Datos incompletos para enviar el mensaje.');
+        }
+
+        const trimmed = text.trim();
+        if (!trimmed) {
+            throw new Error('El mensaje está vacío.');
+        }
+
+        const chatRef = db.collection('chats').doc(chatId);
+        const senderProfileSnap = await db.collection('users').doc(senderId).get();
+        const senderProfile = senderProfileSnap.exists ? senderProfileSnap.data() : {};
+        const currentAuthUser = auth.currentUser;
+
+        await db.runTransaction(async (transaction) => {
+            const chatSnap = await transaction.get(chatRef);
+            if (!chatSnap.exists) {
+                throw new Error('El chat ya no existe.');
+            }
+
+            const chatData = chatSnap.data();
+            if (!Array.isArray(chatData.participants) || !chatData.participants.includes(senderId)) {
+                throw new Error('No puedes enviar mensajes en este chat.');
+            }
+
+            const messageRef = chatRef.collection('messages').doc();
+            const timestamp = FieldValue.serverTimestamp();
+
+            transaction.set(messageRef, {
+                text: trimmed,
+                senderId,
+                createdAt: timestamp,
+                readBy: [senderId],
+                senderProfile: {
+                    username: senderProfile.username || senderProfile.displayName || senderProfile.email || (currentAuthUser ? (currentAuthUser.displayName || currentAuthUser.email || '') : ''),
+                    displayName: senderProfile.displayName || senderProfile.username || (currentAuthUser ? (currentAuthUser.displayName || '') : ''),
+                    photoUrl: senderProfile.photoUrl || (currentAuthUser ? currentAuthUser.photoURL || '' : '')
+                }
+            });
+
+            const updatePayload = {
+                lastMessage: trimmed,
+                lastMessageSenderId: senderId,
+                updatedAt: timestamp
+            };
+
+            const currentUnread = chatData.unreadCounts || {};
+            (chatData.participants || []).forEach(participantId => {
+                if (participantId === senderId) {
+                    updatePayload[`unreadCounts.${participantId}`] = 0;
+                } else {
+                    const previous = currentUnread[participantId] || 0;
+                    updatePayload[`unreadCounts.${participantId}`] = previous + 1;
+                }
+            });
+
+            transaction.update(chatRef, updatePayload);
+        });
+    };
+
+    const markChatMessagesAsRead = async (chatId, userId, messageIds = []) => {
+        if (!chatId || !userId) return;
+        try {
+            const chatRef = db.collection('chats').doc(chatId);
+            const unreadUpdate = {};
+            unreadUpdate[`unreadCounts.${userId}`] = 0;
+            await chatRef.set(unreadUpdate, { merge: true });
+
+            const idsToUpdate = Array.isArray(messageIds) ? messageIds.filter(Boolean) : [];
+            if (idsToUpdate.length > 0) {
+                const batch = db.batch();
+                idsToUpdate.forEach(messageId => {
+                    const messageRef = chatRef.collection('messages').doc(messageId);
+                    batch.set(messageRef, { readBy: FieldValue.arrayUnion(userId) }, { merge: true });
+                });
+                await batch.commit();
+            }
+        } catch (error) {
+            console.error('[firebaseService] Error marcando mensajes como leídos:', error);
+        }
+    };
+
+    const listenToNotifications = (userId, onUpdate, onError) => {
+        if (!userId) return () => {};
+        try {
+            const query = db.collection('users')
+                .doc(userId)
+                .collection('notifications')
+                .orderBy('createdAt', 'desc')
+                .limit(30);
+
+            const unsubscribe = query.onSnapshot(snapshot => {
+                const notifications = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                onUpdate && onUpdate(notifications);
+            }, error => {
+                console.error('[firebaseService] Error escuchando notificaciones:', error);
+                onError && onError(error);
+            });
+
+            return unsubscribe;
+        } catch (error) {
+            console.error('[firebaseService] Error creando listener de notificaciones:', error);
+            onError && onError(error);
+            return () => {};
+        }
+    };
+
+    const markNotificationsAsRead = async (userId, notificationIds = []) => {
+        if (!userId) return;
+        try {
+            const notificationsRef = db.collection('users').doc(userId).collection('notifications');
+            let targets = Array.isArray(notificationIds) ? notificationIds.filter(Boolean) : [];
+
+            if (!targets.length) {
+                const snapshot = await notificationsRef.where('read', '==', false).get();
+                targets = snapshot.docs.map(doc => doc.id);
+            }
+
+            if (!targets.length) return;
+
+            const batch = db.batch();
+            targets.forEach(notificationId => {
+                const ref = notificationsRef.doc(notificationId);
+                batch.set(ref, { read: true, readAt: FieldValue.serverTimestamp() }, { merge: true });
+            });
+            await batch.commit();
+        } catch (error) {
+            console.error('[firebaseService] Error marcando notificaciones como leídas:', error);
+        }
+    };
+
     return {
         auth: auth,
         storage: storage,
@@ -216,6 +487,13 @@ ListopicApp.services = (() => {
         getReviewsByUserId: getReviewsByUserId,
         createUserInAuthAndFirestore: createUserInAuthAndFirestore,
         showNotification: showNotification,
-        ensureUserProfileExists: ensureUserProfileExists // Exportar la nueva función
+        ensureUserProfileExists: ensureUserProfileExists,
+        listenToUserChats,
+        listenToChatMessages,
+        createChatWithParticipants,
+        sendChatMessage,
+        markChatMessagesAsRead,
+        listenToNotifications,
+        markNotificationsAsRead
     };
 })();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -17,6 +17,165 @@ ListopicApp.state = {
     lightboxImageUrls: [],
     currentLightboxImageIndex: 0,
     // Firebase services no deberían estar en state, se acceden desde ListopicApp.services
+    globalRealtimeInitialized: false,
+    globalRealtimeCleanup: [],
+    notificationsCache: []
+};
+
+const setBadgeVisibility = (badgeElement, visible) => {
+    if (!badgeElement) return;
+    if (visible) {
+        badgeElement.hidden = false;
+        badgeElement.setAttribute('data-visible', 'true');
+    } else {
+        badgeElement.hidden = true;
+        badgeElement.setAttribute('data-visible', 'false');
+    }
+};
+
+const formatTimestampForUi = (timestamp) => {
+    if (!timestamp) return '';
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMinutes = Math.round(diffMs / 60000);
+    if (diffMinutes < 1) return 'Justo ahora';
+    if (diffMinutes < 60) return `Hace ${diffMinutes} min`;
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) return `Hace ${diffHours} h`;
+    return date.toLocaleDateString();
+};
+
+const renderNotificationsList = (notifications, container, emptyStateElement) => {
+    if (!container) return;
+    container.innerHTML = '';
+
+    if (!notifications || notifications.length === 0) {
+        container.setAttribute('hidden', 'true');
+        if (emptyStateElement) {
+            emptyStateElement.textContent = 'Sin notificaciones nuevas.';
+        }
+        return;
+    }
+
+    container.removeAttribute('hidden');
+    if (emptyStateElement) {
+        const unread = notifications.filter(n => !n.read).length;
+        emptyStateElement.textContent = unread > 0 ? 'Tienes nuevas notificaciones.' : 'Esto es lo último que ha pasado.';
+    }
+
+    notifications.forEach(notification => {
+        const item = document.createElement('div');
+        item.className = 'notification-item';
+        if (!notification.read) {
+            item.classList.add('unread');
+        }
+
+        const avatar = document.createElement('img');
+        if (notification.type === 'new_follower') {
+            avatar.src = notification.followerPhotoUrl || 'img/default-avatar.png';
+            avatar.alt = `Avatar de ${notification.followerUsername || 'nuevo seguidor'}`;
+        } else {
+            avatar.src = 'img/default-avatar.png';
+            avatar.alt = 'Avatar de notificación';
+        }
+
+        const content = document.createElement('div');
+        content.className = 'notification-content';
+
+        const title = document.createElement('span');
+        title.className = 'notification-title';
+        if (notification.type === 'new_follower') {
+            title.textContent = `${notification.followerUsername || 'Un usuario'} empezó a seguirte.`;
+        } else {
+            title.textContent = notification.title || 'Nueva notificación';
+        }
+
+        const meta = document.createElement('span');
+        meta.className = 'notification-meta';
+        meta.textContent = formatTimestampForUi(notification.createdAt);
+
+        content.appendChild(title);
+        content.appendChild(meta);
+
+        item.appendChild(avatar);
+        item.appendChild(content);
+        container.appendChild(item);
+    });
+};
+
+const initializeGlobalRealtimeFeatures = (user) => {
+    if (!user || ListopicApp.state.globalRealtimeInitialized || !ListopicApp.services) return;
+
+    const chatsBadge = document.getElementById('chats-badge');
+    const notificationsBadge = document.getElementById('notifications-badge');
+    const notificationsButton = document.getElementById('notifications-button');
+    const notificationsDropdown = document.getElementById('notifications-dropdown');
+    const notificationsList = document.getElementById('notifications-list');
+    const emptyStateElement = notificationsDropdown ? notificationsDropdown.querySelector('.notifications-empty-state') : null;
+
+    const cleanupFunctions = [];
+
+    if (ListopicApp.services.listenToUserChats && chatsBadge) {
+        const unsubscribeChats = ListopicApp.services.listenToUserChats(user.uid, chats => {
+            const hasUnread = Array.isArray(chats) && chats.some(chat => (chat.unreadCounts && chat.unreadCounts[user.uid] > 0));
+            setBadgeVisibility(chatsBadge, hasUnread);
+        }, error => {
+            console.error('[main] Error monitorizando chats para badge:', error);
+        });
+        cleanupFunctions.push(unsubscribeChats);
+    }
+
+    if (ListopicApp.services.listenToNotifications && notificationsList) {
+        const unsubscribeNotifications = ListopicApp.services.listenToNotifications(user.uid, notifications => {
+            ListopicApp.state.notificationsCache = notifications;
+            const unreadCount = notifications.filter(n => !n.read).length;
+            setBadgeVisibility(notificationsBadge, unreadCount > 0);
+            renderNotificationsList(notifications, notificationsList, emptyStateElement);
+        }, error => {
+            console.error('[main] Error monitorizando notificaciones:', error);
+        });
+        cleanupFunctions.push(unsubscribeNotifications);
+    }
+
+    if (notificationsButton && notificationsDropdown) {
+        const toggleDropdown = (event) => {
+            event.stopPropagation();
+            const willOpen = !notificationsDropdown.classList.contains('active');
+            notificationsDropdown.classList.toggle('active', willOpen);
+            notificationsDropdown.setAttribute('aria-hidden', (!willOpen).toString());
+            notificationsButton.setAttribute('aria-expanded', willOpen.toString());
+            if (willOpen) {
+                const unreadIds = (ListopicApp.state.notificationsCache || []).filter(n => !n.read).map(n => n.id);
+                if (unreadIds.length > 0 && ListopicApp.services.markNotificationsAsRead) {
+                    ListopicApp.services.markNotificationsAsRead(user.uid, unreadIds);
+                }
+                setBadgeVisibility(notificationsBadge, false);
+            }
+        };
+
+        notificationsButton.addEventListener('click', toggleDropdown);
+
+        document.addEventListener('click', (event) => {
+            if (!notificationsDropdown.classList.contains('active')) return;
+            if (!notificationsDropdown.contains(event.target) && !notificationsButton.contains(event.target)) {
+                notificationsDropdown.classList.remove('active');
+                notificationsDropdown.setAttribute('aria-hidden', 'true');
+                notificationsButton.setAttribute('aria-expanded', 'false');
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && notificationsDropdown.classList.contains('active')) {
+                notificationsDropdown.classList.remove('active');
+                notificationsDropdown.setAttribute('aria-hidden', 'true');
+                notificationsButton.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+
+    ListopicApp.state.globalRealtimeCleanup = cleanupFunctions;
+    ListopicApp.state.globalRealtimeInitialized = true;
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -79,6 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             // Usuario autenticado, o página pública que no requiere autenticación (como index, si se decide)
             console.log("MAIN.JS: Usuario autenticado o página pública. Procediendo a inicializar lógica de página específica."); // <--- LOG 14
+            initializeGlobalRealtimeFeatures(user);
             if (isIndexPage) {
                 console.log("MAIN.JS: Es Index page, intentando inicializar pageIndex..."); // <--- LOG 15
                  if(ListopicApp.pageIndex && ListopicApp.pageIndex.init) {
@@ -126,6 +286,10 @@ document.addEventListener('DOMContentLoaded', () => {
             } else if (pageName === 'developer.html') { // PÁGINA DE LUGAR
             if (ListopicApp.pagePlace && ListopicApp.pageDeveloper.init) {
                 ListopicApp.pagePlace.init();
+                }
+            } else if (pageName === 'chats.html') {
+                if (ListopicApp.pageChats && ListopicApp.pageChats.init) {
+                    ListopicApp.pageChats.init();
                 }
             } else {
                 // Esta es la línea 95 en la estructura original del if/else if

--- a/public/js/page-chats.js
+++ b/public/js/page-chats.js
@@ -1,0 +1,349 @@
+window.ListopicApp = window.ListopicApp || {};
+
+ListopicApp.pageChats = (() => {
+    let chatListElement;
+    let chatMessagesElement;
+    let newChatForm;
+    let newChatInput;
+    let messageForm;
+    let messageInput;
+    let chatListStatusElement;
+    let newChatErrorElement;
+    let chatTitleElement;
+    let emptyStateElement;
+
+    let unsubscribeChats = null;
+    let unsubscribeMessages = null;
+    let currentChatId = null;
+    let chatsCache = [];
+    let currentUser = null;
+    let pendingChatId = null;
+
+    const formatRelativeTime = (timestamp) => {
+        if (!timestamp) return '';
+        const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+        const now = new Date();
+        const diffMs = now - date;
+        const diffMinutes = Math.round(diffMs / 60000);
+        if (diffMinutes < 1) return 'Justo ahora';
+        if (diffMinutes < 60) return `Hace ${diffMinutes} min`;
+        const diffHours = Math.round(diffMinutes / 60);
+        if (diffHours < 24) return `Hace ${diffHours} h`;
+        return date.toLocaleDateString();
+    };
+
+    const getChatDisplayName = (chat) => {
+        if (!chat) return 'Chat';
+        const participants = chat.participants || [];
+        const otherParticipants = participants.filter(uid => uid !== currentUser.uid);
+        if (otherParticipants.length === 0) return 'Conversación personal';
+
+        const profiles = chat.participantProfiles || {};
+        const names = otherParticipants.map(uid => {
+            const profile = profiles[uid] || {};
+            return profile.username || profile.displayName || profile.email || 'Usuario';
+        });
+        return names.join(', ');
+    };
+
+    const renderChatList = (chats) => {
+        chatsCache = chats;
+        chatListElement.innerHTML = '';
+
+        if (!chats.length) {
+            if (chatListStatusElement) {
+                chatListStatusElement.textContent = 'No tienes chats activos todavía.';
+            }
+            return;
+        }
+
+        if (chatListStatusElement) {
+            chatListStatusElement.textContent = '';
+        }
+
+        chats.forEach(chat => {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'chat-list-item';
+            item.dataset.chatId = chat.id;
+            if (chat.id === currentChatId) {
+                item.classList.add('active');
+            }
+
+            const avatar = document.createElement('div');
+            avatar.className = 'avatar';
+            const name = getChatDisplayName(chat);
+            avatar.textContent = name.substring(0, 1).toUpperCase();
+
+            const info = document.createElement('div');
+            info.className = 'chat-info';
+
+            const nameElement = document.createElement('span');
+            nameElement.className = 'chat-name';
+            nameElement.textContent = name;
+
+            const lastMessageElement = document.createElement('span');
+            lastMessageElement.className = 'chat-last-message';
+            lastMessageElement.textContent = chat.lastMessage || 'Sin mensajes todavía.';
+
+            const updatedAtElement = document.createElement('span');
+            updatedAtElement.className = 'chat-updated-at';
+            updatedAtElement.textContent = formatRelativeTime(chat.updatedAt);
+
+            info.appendChild(nameElement);
+            info.appendChild(lastMessageElement);
+            info.appendChild(updatedAtElement);
+
+            item.appendChild(avatar);
+            item.appendChild(info);
+
+            const unreadCount = chat.unreadCounts && chat.unreadCounts[currentUser.uid];
+            if (unreadCount && unreadCount > 0) {
+                const indicator = document.createElement('span');
+                indicator.className = 'chat-unread-indicator';
+                indicator.title = `${unreadCount} mensaje(s) sin leer`;
+                item.appendChild(indicator);
+            }
+
+            item.addEventListener('click', () => selectChat(chat.id));
+            chatListElement.appendChild(item);
+        });
+    };
+
+    const renderMessages = (messages) => {
+        chatMessagesElement.innerHTML = '';
+
+        if (!messages.length) {
+            const empty = document.createElement('div');
+            empty.className = 'chat-empty-state';
+            empty.innerHTML = '<p>Empieza la conversación enviando el primer mensaje.</p>';
+            chatMessagesElement.appendChild(empty);
+            return;
+        }
+
+        messages.forEach(msg => {
+            const bubble = document.createElement('div');
+            bubble.className = 'message-bubble';
+            if (msg.senderId === currentUser.uid) {
+                bubble.classList.add('sent');
+            }
+            bubble.textContent = msg.text;
+
+            const meta = document.createElement('span');
+            meta.className = 'message-meta';
+            const senderProfile = msg.senderId === currentUser.uid ? 'Tú' : (msg.senderProfile?.username || msg.senderProfile?.displayName || 'Usuario');
+            const time = msg.createdAt ? formatRelativeTime(msg.createdAt) : '';
+            meta.textContent = `${senderProfile} · ${time}`;
+            bubble.appendChild(meta);
+
+            chatMessagesElement.appendChild(bubble);
+        });
+
+        chatMessagesElement.scrollTop = chatMessagesElement.scrollHeight;
+    };
+
+    const handleNewChatSubmit = async (event) => {
+        event.preventDefault();
+        if (!currentUser) return;
+
+        const rawIdentifiers = newChatInput.value;
+        const identifiers = rawIdentifiers.split(',').map(id => id.trim()).filter(Boolean);
+        if (!identifiers.length) {
+            showNewChatError('Introduce al menos un usuario.');
+            return;
+        }
+
+        try {
+            setNewChatBusy(true);
+            if (!ListopicApp.services.createChatWithParticipants) {
+                throw new Error('El servicio de chats no está disponible en este momento.');
+            }
+            const result = await ListopicApp.services.createChatWithParticipants(currentUser, identifiers);
+            newChatInput.value = '';
+            hideNewChatError();
+            if (result && result.chatId) {
+                selectChat(result.chatId);
+                if (ListopicApp.services.showNotification) {
+                    if (result.alreadyExists) {
+                        ListopicApp.services.showNotification('Ya tienes una conversación con estos usuarios.', 'info');
+                    } else {
+                        ListopicApp.services.showNotification('Chat creado correctamente.', 'success');
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('[page-chats] Error creating chat:', error);
+            const message = error && error.message ? error.message : 'No se pudo crear el chat.';
+            showNewChatError(message);
+        } finally {
+            setNewChatBusy(false);
+        }
+    };
+
+    const handleMessageSubmit = async (event) => {
+        event.preventDefault();
+        if (!currentChatId) return;
+        const text = messageInput.value.trim();
+        if (!text) return;
+
+        messageForm.querySelector('button[type="submit"]').disabled = true;
+
+        try {
+            if (!ListopicApp.services.sendChatMessage) {
+                throw new Error('El servicio de mensajería no está disponible en este momento.');
+            }
+            await ListopicApp.services.sendChatMessage(currentChatId, currentUser.uid, text);
+            messageInput.value = '';
+        } catch (error) {
+            console.error('[page-chats] Error sending message:', error);
+            ListopicApp.services.showNotification('No se pudo enviar el mensaje.', 'error');
+        } finally {
+            messageForm.querySelector('button[type="submit"]').disabled = false;
+        }
+    };
+
+    const selectChat = (chatId) => {
+        if (currentChatId === chatId) return;
+        currentChatId = chatId;
+
+        if (unsubscribeMessages) {
+            unsubscribeMessages();
+            unsubscribeMessages = null;
+        }
+
+        if (!ListopicApp.services.listenToChatMessages) {
+            console.error('[page-chats] El servicio de mensajes no está disponible.');
+            return;
+        }
+
+        Array.from(chatListElement.querySelectorAll('.chat-list-item')).forEach(item => {
+            item.classList.toggle('active', item.dataset.chatId === chatId);
+        });
+
+        const chat = chatsCache.find(c => c.id === chatId);
+        chatTitleElement.textContent = getChatDisplayName(chat);
+        messageForm.hidden = false;
+        emptyStateElement && (emptyStateElement.style.display = 'none');
+
+        unsubscribeMessages = ListopicApp.services.listenToChatMessages(chatId, async messages => {
+            renderMessages(messages);
+            const unreadMessageIds = messages
+                .filter(msg => Array.isArray(msg.readBy) ? !msg.readBy.includes(currentUser.uid) : true)
+                .map(msg => msg.id);
+            if (ListopicApp.services.markChatMessagesAsRead) {
+                if (unreadMessageIds.length > 0) {
+                    await ListopicApp.services.markChatMessagesAsRead(chatId, currentUser.uid, unreadMessageIds);
+                } else {
+                    await ListopicApp.services.markChatMessagesAsRead(chatId, currentUser.uid, []);
+                }
+            }
+        }, error => {
+            console.error('[page-chats] Error listening messages:', error);
+        });
+    };
+
+    const showNewChatError = (message) => {
+        newChatErrorElement.textContent = message;
+        newChatErrorElement.style.display = 'block';
+    };
+
+    const hideNewChatError = () => {
+        newChatErrorElement.textContent = '';
+        newChatErrorElement.style.display = 'none';
+    };
+
+    const setNewChatBusy = (isBusy) => {
+        if (!newChatForm) return;
+        Array.from(newChatForm.elements).forEach(el => el.disabled = isBusy);
+    };
+
+    const subscribeToChats = () => {
+        if (!currentUser) return;
+        if (!ListopicApp.services.listenToUserChats) {
+            chatListStatusElement.textContent = 'El servicio de chats no está disponible.';
+            return;
+        }
+        if (unsubscribeChats) {
+            unsubscribeChats();
+            unsubscribeChats = null;
+        }
+
+        unsubscribeChats = ListopicApp.services.listenToUserChats(currentUser.uid, chats => {
+            renderChatList(chats);
+            if (pendingChatId) {
+                const pendingExists = chats.some(chat => chat.id === pendingChatId);
+                if (pendingExists) {
+                    selectChat(pendingChatId);
+                    pendingChatId = null;
+                }
+            }
+            if (currentChatId) {
+                const stillExists = chats.some(chat => chat.id === currentChatId);
+                if (!stillExists && unsubscribeMessages) {
+                    unsubscribeMessages();
+                    unsubscribeMessages = null;
+                    currentChatId = null;
+                    chatTitleElement.textContent = 'Selecciona un chat';
+                    chatMessagesElement.innerHTML = '';
+                    messageForm.hidden = true;
+                }
+            }
+        }, error => {
+            console.error('[page-chats] Error listening user chats:', error);
+            if (chatListStatusElement) {
+                chatListStatusElement.textContent = 'No se pudieron cargar tus chats.';
+            }
+        });
+    };
+
+    const cacheDomElements = () => {
+        chatListElement = document.getElementById('chat-list');
+        chatMessagesElement = document.getElementById('chat-messages');
+        newChatForm = document.getElementById('new-chat-form');
+        newChatInput = document.getElementById('new-chat-identifiers');
+        messageForm = document.getElementById('message-form');
+        messageInput = document.getElementById('message-input');
+        chatListStatusElement = document.getElementById('chat-list-status');
+        newChatErrorElement = document.getElementById('new-chat-error');
+        chatTitleElement = document.getElementById('chat-detail-title');
+        emptyStateElement = document.getElementById('chat-empty-state');
+    };
+
+    const attachEventListeners = () => {
+        if (newChatForm) {
+            newChatForm.addEventListener('submit', handleNewChatSubmit);
+        }
+        if (messageForm) {
+            messageForm.addEventListener('submit', handleMessageSubmit);
+        }
+        window.addEventListener('beforeunload', () => {
+            unsubscribeChats && unsubscribeChats();
+            unsubscribeMessages && unsubscribeMessages();
+        });
+    };
+
+    const init = () => {
+        if (!ListopicApp.services || !ListopicApp.services.auth) {
+            console.error('[page-chats] Firebase services no disponibles.');
+            return;
+        }
+
+        currentUser = ListopicApp.services.auth.currentUser;
+        if (!currentUser) {
+            console.error('[page-chats] Usuario no autenticado.');
+            return;
+        }
+
+        cacheDomElements();
+        attachEventListeners();
+
+        const params = new URLSearchParams(window.location.search);
+        pendingChatId = params.get('chatId');
+
+        subscribeToChats();
+    };
+
+    return {
+        init
+    };
+})();

--- a/public/js/page-profile.js
+++ b/public/js/page-profile.js
@@ -19,6 +19,7 @@ ListopicApp.pageProfile = {
         myReviewsContainer: null,
         openEditModalBtn: null,
         followUnfollowBtn: null, // NUEVO
+        directMessageBtn: null,
         profileMessageArea: null,
         
         // --- Elementos del Modal ---
@@ -95,6 +96,7 @@ ListopicApp.pageProfile = {
         this.elements.myReviewsContainer = document.getElementById('my-reviews-container'); // MODIFICADO
         this.elements.openEditModalBtn = document.getElementById('open-edit-profile-modal-btn');
         this.elements.followUnfollowBtn = document.getElementById('follow-unfollow-btn'); // NUEVO
+        this.elements.directMessageBtn = document.getElementById('direct-message-btn');
         this.elements.profileMessageArea = document.getElementById('profile-message-area');
         
         // --- CACHE DE LOS NUEVOS ELEMENTOS DE ESTADÍSTICAS ---
@@ -143,18 +145,19 @@ ListopicApp.pageProfile = {
     },
 
     updateProfileButtons: function() {
-        // --- LÓGICA DE DEPURACIÓN ---
-        // Forzamos ambos botones a ser visibles para ver si el problema es de la lógica o del renderizado.
-        console.log("[DEBUG] Forzando botones a ser visibles para depuración.");
         const isOwnProfile = this.currentUser && this.currentUser.uid === this.profileOwnerUserId;
-        
+
         if (this.elements.openEditModalBtn) {
             this.elements.openEditModalBtn.style.display = isOwnProfile ? 'inline-block' : 'none';
         }
+
         if (this.elements.followUnfollowBtn) {
             this.elements.followUnfollowBtn.style.display = isOwnProfile ? 'none' : 'inline-block';
         }
-        // Cuando confirmemos que aparecen, volveremos a la lógica original.
+
+        if (this.elements.directMessageBtn) {
+            this.elements.directMessageBtn.style.display = isOwnProfile ? 'none' : 'inline-flex';
+        }
     },
 
     // Dentro del objeto ListopicApp.pageProfile
@@ -174,6 +177,7 @@ ListopicApp.pageProfile = {
     attachEventListeners: function() {
         this.elements.openEditModalBtn?.addEventListener('click', () => this.openEditModal());
         this.elements.followUnfollowBtn?.addEventListener('click', () => this.handleFollowToggle()); // NUEVO
+        this.elements.directMessageBtn?.addEventListener('click', () => this.handleDirectMessage());
         this.elements.closeEditModalBtn?.addEventListener('click', () => this.closeEditModal());
         this.elements.editProfileModal?.addEventListener('click', (event) => {
             if (event.target === this.elements.editProfileModal) {
@@ -278,7 +282,7 @@ ListopicApp.pageProfile = {
         const btn = this.elements.followUnfollowBtn;
         if (!btn) return;
         btn.disabled = true;
-        
+
         try {
             const functions = firebase.app().functions('europe-west1');
             const toggleFollow = functions.httpsCallable('toggleFollowUser');
@@ -300,6 +304,40 @@ ListopicApp.pageProfile = {
             ListopicApp.services.showNotification(`Error: ${error.message}`, 'error');
         } finally {
             btn.disabled = false;
+        }
+    },
+
+    handleDirectMessage: async function() {
+        const btn = this.elements.directMessageBtn;
+        if (!btn || !this.currentUser || this.currentUser.uid === this.profileOwnerUserId) {
+            return;
+        }
+
+        btn.disabled = true;
+        let redirecting = false;
+
+        try {
+            if (!ListopicApp.services.createChatWithParticipants) {
+                throw new Error('El servicio de chats no está disponible en este momento.');
+            }
+
+            const result = await ListopicApp.services.createChatWithParticipants(this.currentUser, [this.profileOwnerUserId]);
+            if (result && result.chatId) {
+                const chatUrl = new URL('chats.html', window.location.origin);
+                chatUrl.searchParams.set('chatId', result.chatId);
+                redirecting = true;
+                window.location.href = chatUrl.toString();
+            } else {
+                throw new Error('No se pudo crear la conversación.');
+            }
+        } catch (error) {
+            console.error('[page-profile] Error al iniciar mensaje directo:', error);
+            const message = error && error.message ? error.message : 'No se pudo abrir el chat.';
+            ListopicApp.services.showNotification?.(message, 'error');
+        } finally {
+            if (!redirecting) {
+                btn.disabled = false;
+            }
         }
     },
 

--- a/public/list-form.html
+++ b/public/list-form.html
@@ -102,9 +102,24 @@
             <button id="forum-button" class="forum-button header-action-button" aria-label="Foro de la lista" title="Foro de la lista">
                 <i class="fas fa-comments"></i>
             </button>
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/list-view.html
+++ b/public/list-view.html
@@ -73,9 +73,24 @@
             <button id="forum-button" class="forum-button header-action-button" aria-label="Foro de la lista" title="Foro de la lista">
                 <i class="fas fa-comments"></i>
             </button>
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/place-detail.html
+++ b/public/place-detail.html
@@ -23,9 +23,24 @@
             </div>
         </div>
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/profile.html
+++ b/public/profile.html
@@ -48,9 +48,24 @@
             </div>
         </div>
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>
@@ -89,6 +104,9 @@
                         </button>
                         <button id="follow-unfollow-btn" class="button primary-button" style="display: none;">
                             Seguir
+                        </button>
+                        <button id="direct-message-btn" class="button secondary-button" style="display: none;">
+                            <i class="fas fa-paper-plane"></i> Mensaje directo
                         </button>
                     </div>
                 </div>

--- a/public/review-form.html
+++ b/public/review-form.html
@@ -41,9 +41,24 @@
         </div>
 
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>

--- a/public/search.html
+++ b/public/search.html
@@ -21,9 +21,24 @@
             </div>
         </div>
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="search-button header-action-button" aria-label="Search">
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
                 <i class="fas fa-search"></i>
             </a>
+            <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
+                <i class="fas fa-comments"></i>
+                <span class="badge-indicator" id="chats-badge" hidden></span>
+            </a>
+            <div class="header-icon-group">
+                <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
+                    <i class="fas fa-bell"></i>
+                    <span class="badge-indicator" id="notifications-badge" hidden></span>
+                </button>
+                <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
+                    <h4>Notificaciones</h4>
+                    <p class="notifications-empty-state">Sin notificaciones nuevas.</p>
+                    <div class="notifications-list" id="notifications-list" hidden></div>
+                </div>
+            </div>
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
                     <i class="fas fa-user-circle"></i>
@@ -34,7 +49,7 @@
                     <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
                     <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
                     <hr class="user-menu-divider">
-                    
+
                     <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
                         <i class="fas fa-download"></i> Instalar Aplicación
                     </button>

--- a/public/style.css
+++ b/public/style.css
@@ -1487,7 +1487,7 @@ body.light-theme .user-menu-divider {
 /* En style.css */
 
 /* Estilo general para los botones de acción del header, incluyendo los que son enlaces */
-.header-action-button, 
+.header-action-button,
 a.header-action-button { /* Importante añadir 'a.header-action-button' */
     background-color: var(--container-bg);
     color: var(--text-color); /* Para el color del icono */
@@ -1507,6 +1507,113 @@ a.header-action-button { /* Importante añadir 'a.header-action-button' */
     flex-shrink: 0;
     
     text-decoration: none; /* CLAVE: Quita el subrayado de los enlaces */
+}
+
+
+.icon-with-badge {
+    position: relative;
+}
+
+.badge-indicator {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: var(--danger-color, #e63946);
+    display: none;
+}
+
+.badge-indicator[data-visible="true"] {
+    display: block;
+}
+
+.header-icon-group {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.notifications-dropdown {
+    position: absolute;
+    top: 48px;
+    right: 0;
+    width: min(320px, 90vw);
+    background: var(--container-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 12px;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+    padding: 12px;
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 999;
+}
+
+.notifications-dropdown.active {
+    display: flex;
+}
+
+.notifications-dropdown h4 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--title-color);
+}
+
+.notifications-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 280px;
+    overflow-y: auto;
+}
+
+.notification-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: var(--card-bg, rgba(255,255,255,0.04));
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.notification-item.unread {
+    border-color: var(--accent-color-secondary);
+    background: rgba(17, 138, 178, 0.08);
+}
+
+.notification-item img {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.notification-item .notification-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+}
+
+.notification-item .notification-title {
+    font-weight: 600;
+    color: var(--title-color);
+}
+
+.notification-item .notification-meta {
+    font-size: 0.8rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.notifications-empty-state {
+    margin: 0;
+    color: var(--muted-text-color, #6c757d);
+    font-size: 0.95rem;
+    text-align: center;
 }
 
 
@@ -6381,3 +6488,160 @@ body.light-theme .leaflet-popup-tip {
 
 /* Toggle active state */
 #lists-toggle-main .button.active{background-color: var(--accent-color-tertiary); color: var(--main-button-text)}
+
+/* === Chats Page === */
+.chats-page {
+    display: grid;
+    grid-template-columns: minmax(260px, 340px) 1fr;
+    gap: 20px;
+    height: calc(100vh - 160px);
+    margin-top: 20px;
+}
+
+.chat-panel {
+    background: var(--container-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.chat-panel header {
+    padding: 16px;
+    border-bottom: 1px solid var(--input-border);
+}
+
+.chat-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.chat-list-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--card-separator, rgba(0,0,0,0.05));
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.chat-list-item:last-child {
+    border-bottom: none;
+}
+
+.chat-list-item:hover,
+.chat-list-item.active {
+    background: rgba(17, 138, 178, 0.12);
+}
+
+.chat-list-item .avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--accent-color-secondary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.chat-list-item .chat-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.chat-list-item .chat-name {
+    font-weight: 600;
+    color: var(--title-color);
+}
+
+.chat-list-item .chat-last-message {
+    font-size: 0.9rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-list-item .chat-updated-at {
+    font-size: 0.75rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-unread-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent-color-secondary);
+}
+
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.message-bubble {
+    max-width: 70%;
+    padding: 12px 16px;
+    border-radius: 16px;
+    line-height: 1.4;
+    position: relative;
+    background: var(--card-bg, rgba(255,255,255,0.06));
+}
+
+.message-bubble.sent {
+    margin-left: auto;
+    background: var(--accent-color-primary);
+    color: var(--main-button-text);
+}
+
+.message-bubble .message-meta {
+    display: block;
+    margin-top: 6px;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.message-composer {
+    border-top: 1px solid var(--input-border);
+    padding: 16px;
+    display: flex;
+    gap: 12px;
+}
+
+.message-composer textarea {
+    flex: 1;
+    resize: none;
+    min-height: 60px;
+}
+
+.new-chat-form {
+    padding: 16px;
+    border-top: 1px solid var(--input-border);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.chat-empty-state {
+    margin: auto;
+    text-align: center;
+    color: var(--muted-text-color, #6c757d);
+}
+
+@media (max-width: 900px) {
+    .chats-page {
+        grid-template-columns: 1fr;
+        height: auto;
+    }
+
+    .chat-panel {
+        min-height: 300px;
+    }
+}


### PR DESCRIPTION
## Summary
- show a direct message action on other users' profiles beside the follow control
- wire the button to create or reuse a private chat and redirect to the conversation view
- allow the chats page to auto-open a conversation when a chatId query parameter is present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de4f4e876c8326a9cf36276c4a5307