### PR TITLE
Add interactive shared review cards to chat messages

### DIFF
--- a/public/js/firebaseService.js
+++ b/public/js/firebaseService.js
@@ -701,13 +701,15 @@ ListopicApp.services = (() => {
         return updatedSummary;
     };
 
-    const sendChatMessage = async (chatId, senderId, text) => {
-        if (!chatId || !senderId || !text) {
+    const sendChatMessage = async (chatId, senderId, text, payload = null) => {
+        if (!chatId || !senderId) {
             throw new Error('Datos incompletos para enviar el mensaje.');
         }
 
-        const trimmed = text.trim();
-        if (!trimmed) {
+        const trimmed = typeof text === 'string' ? text.trim() : '';
+        const hasPayload = payload && typeof payload === 'object' && Object.keys(payload).length > 0;
+
+        if (!trimmed && !hasPayload) {
             throw new Error('El mensaje está vacío.');
         }
 
@@ -730,7 +732,7 @@ ListopicApp.services = (() => {
             const messageRef = chatRef.collection('messages').doc();
             const timestamp = FieldValue.serverTimestamp();
 
-            transaction.set(messageRef, {
+            const messageData = {
                 text: trimmed,
                 senderId,
                 createdAt: timestamp,
@@ -739,12 +741,51 @@ ListopicApp.services = (() => {
                     username: senderProfile.username || senderProfile.displayName || senderProfile.email || (currentAuthUser ? (currentAuthUser.displayName || currentAuthUser.email || '') : ''),
                     displayName: senderProfile.displayName || senderProfile.username || (currentAuthUser ? (currentAuthUser.displayName || '') : ''),
                     photoUrl: senderProfile.photoUrl || (currentAuthUser ? currentAuthUser.photoURL || '' : '')
+                },
+                messageType: 'text'
+            };
+
+            if (hasPayload) {
+                const payloadType = typeof payload.type === 'string' ? payload.type : 'custom';
+                messageData.messageType = payloadType;
+                const sanitizePayload = (value) => {
+                    const clean = {};
+                    Object.entries(value).forEach(([key, val]) => {
+                        if (val === undefined || val === null) {
+                            return;
+                        }
+                        if (typeof val === 'string') {
+                            const trimmed = val.trim();
+                            if (trimmed) {
+                                clean[key] = trimmed;
+                            }
+                            return;
+                        }
+                        if (typeof val === 'number' || typeof val === 'boolean') {
+                            clean[key] = val;
+                        }
+                    });
+                    return clean;
+                };
+                const sanitizedPayload = sanitizePayload(payload);
+                const hasSanitized = Object.keys(sanitizedPayload).length > 0;
+                if (hasSanitized) {
+                    if (payloadType === 'review-share') {
+                        messageData.sharePayload = sanitizedPayload;
+                    } else {
+                        messageData.payload = sanitizedPayload;
+                    }
+                } else {
+                    messageData.messageType = 'text';
                 }
-            });
+            }
+
+            transaction.set(messageRef, messageData);
 
             const updatePayload = {
-                lastMessage: trimmed,
+                lastMessage: trimmed || (messageData.messageType === 'review-share' ? 'Reseña compartida' : ''),
                 lastMessageSenderId: senderId,
+                lastMessageType: messageData.messageType,
                 updatedAt: timestamp
             };
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -43,21 +43,38 @@ ListopicApp.reviewActions = (() => {
         }
     };
 
+    const decodeDatasetValue = (() => {
+        let textarea = null;
+        return (value) => {
+            if (typeof value !== 'string') {
+                return '';
+            }
+            if (!textarea) {
+                textarea = document.createElement('textarea');
+            }
+            textarea.innerHTML = value;
+            return textarea.value;
+        };
+    })();
+
     const getReviewData = (card) => {
         if (!card) {
             return null;
         }
         const dataset = card.dataset || {};
         return {
-            reviewId: dataset.reviewId || '',
-            listId: dataset.listId || '',
-            authorId: dataset.authorId || '',
-            authorName: dataset.authorName || '',
-            listName: dataset.listName || '',
-            itemName: dataset.itemName || '',
-            placeId: dataset.placeId || '',
-            detailUrl: dataset.detailUrl || '',
-            overallRating: dataset.overallRating || '',
+            reviewId: decodeDatasetValue(dataset.reviewId || ''),
+            listId: decodeDatasetValue(dataset.listId || ''),
+            authorId: decodeDatasetValue(dataset.authorId || ''),
+            authorName: decodeDatasetValue(dataset.authorName || ''),
+            listName: decodeDatasetValue(dataset.listName || ''),
+            itemName: decodeDatasetValue(dataset.itemName || ''),
+            placeId: decodeDatasetValue(dataset.placeId || ''),
+            placeName: decodeDatasetValue(dataset.placeName || ''),
+            detailUrl: decodeDatasetValue(dataset.detailUrl || ''),
+            overallRating: decodeDatasetValue(dataset.overallRating || ''),
+            photoUrl: decodeDatasetValue(dataset.photoUrl || ''),
+            comment: decodeDatasetValue(dataset.comment || ''),
             isOwner: dataset.isOwner === '1',
             element: card
         };
@@ -565,8 +582,28 @@ ListopicApp.reviewShare = (() => {
         if (data?.overallRating) {
             parts.push(`Puntuacion: ${data.overallRating}/10.`);
         }
-        parts.push(link);
-        return parts.join(' ');
+
+        const messageText = parts.join(' ').trim();
+        const defaultText = 'Te comparto una rese\u00f1a.';
+        const textToSend = messageText || defaultText;
+
+        if (!data) {
+            return { text: textToSend, payload: null };
+        }
+
+        const payload = {
+            type: 'review-share',
+            detailUrl: (link || data.detailUrl || '').trim(),
+            photoUrl: (data.photoUrl || '').trim(),
+            comment: (data.comment || '').trim(),
+            rating: (data.overallRating || '').trim(),
+            listName: (data.listName || '').trim(),
+            itemName: (data.itemName || '').trim(),
+            placeName: (data.placeName || '').trim(),
+            authorName: (data.authorName || '').trim()
+        };
+
+        return { text: textToSend, payload };
     };
 
     const handleChatShare = async (chat, button, currentUserId) => {
@@ -586,8 +623,8 @@ ListopicApp.reviewShare = (() => {
         button.disabled = true;
         button.classList.add('is-loading');
         try {
-            const message = composeChatMessage(currentData, currentLink);
-            await services.sendChatMessage(chat.id, currentUserId, message);
+            const { text, payload } = composeChatMessage(currentData, currentLink);
+            await services.sendChatMessage(chat.id, currentUserId, text, payload);
             setFeedbackMessage(chatFeedbackElement, 'rese\u00f1a compartida en el chat.', 'success');
         } catch (error) {
             console.error('[reviewShare] Error compartiendo en chat:', error);

--- a/public/js/page-chats.js
+++ b/public/js/page-chats.js
@@ -63,6 +63,97 @@ ListopicApp.pageChats = (() => {
 
     const isMobileLayout = () => window.matchMedia('(max-width: 900px)').matches;
 
+    const sanitizeText = (value) => (typeof value === 'string' ? value : '');
+
+    const createSharedReviewCard = (payload, isOwnMessage) => {
+        if (!payload || typeof payload !== 'object') {
+            return null;
+        }
+
+        const detailUrl = sanitizeText(payload.detailUrl);
+        const cardElement = detailUrl ? document.createElement('a') : document.createElement('div');
+        cardElement.className = 'shared-review-card';
+        if (detailUrl) {
+            cardElement.href = detailUrl;
+            cardElement.target = '_blank';
+            cardElement.rel = 'noopener noreferrer';
+        }
+
+        if (isOwnMessage) {
+            cardElement.classList.add('shared-review-card--sent');
+        }
+
+        const media = document.createElement('div');
+        media.className = 'shared-review-card__media';
+        const photoUrl = sanitizeText(payload.photoUrl);
+        if (photoUrl) {
+            const image = document.createElement('img');
+            image.src = photoUrl;
+            image.alt = payload.itemName ? `Foto de ${sanitizeText(payload.itemName)}` : 'Foto de la reseña';
+            image.className = 'shared-review-card__image';
+            media.appendChild(image);
+        } else {
+            media.classList.add('shared-review-card__media--placeholder');
+            const icon = document.createElement('i');
+            icon.className = 'fas fa-camera';
+            media.appendChild(icon);
+        }
+
+        const body = document.createElement('div');
+        body.className = 'shared-review-card__body';
+
+        const titleRow = document.createElement('div');
+        titleRow.className = 'shared-review-card__title-row';
+
+        const title = document.createElement('span');
+        title.className = 'shared-review-card__title';
+        title.textContent = sanitizeText(payload.itemName) || 'Reseña compartida';
+        titleRow.appendChild(title);
+
+        const ratingValue = sanitizeText(payload.rating);
+        if (ratingValue) {
+            const rating = document.createElement('span');
+            rating.className = 'shared-review-card__rating';
+            const numericRating = Number.parseFloat(ratingValue);
+            rating.textContent = Number.isFinite(numericRating) ? numericRating.toFixed(1) : ratingValue;
+            const ratingColor = window.ListopicApp?.uiUtils?.getRatingColor;
+            if (typeof ratingColor === 'function') {
+                const computedColor = ratingColor(Number.isFinite(numericRating) ? numericRating : ratingValue);
+                if (computedColor) {
+                    rating.style.backgroundColor = computedColor;
+                }
+            }
+            titleRow.appendChild(rating);
+        }
+
+        body.appendChild(titleRow);
+
+        const subtitleParts = [];
+        const listName = sanitizeText(payload.listName);
+        const placeName = sanitizeText(payload.placeName);
+        if (listName) subtitleParts.push(listName);
+        if (placeName) subtitleParts.push(placeName);
+        if (subtitleParts.length) {
+            const subtitle = document.createElement('span');
+            subtitle.className = 'shared-review-card__subtitle';
+            subtitle.textContent = subtitleParts.join(' · ');
+            body.appendChild(subtitle);
+        }
+
+        const commentText = sanitizeText(payload.comment);
+        if (commentText) {
+            const comment = document.createElement('p');
+            comment.className = 'shared-review-card__comment';
+            comment.textContent = commentText;
+            body.appendChild(comment);
+        }
+
+        cardElement.appendChild(media);
+        cardElement.appendChild(body);
+
+        return cardElement;
+    };
+
     const openChatListModal = () => {
         if (!chatListPanel || !isMobileLayout()) return;
         chatListPanel.classList.add('is-open');
@@ -644,7 +735,8 @@ ListopicApp.pageChats = (() => {
                 bottomRow.className = 'chat-list-row';
                 const lastMessage = document.createElement('span');
                 lastMessage.className = 'chat-last-message';
-                lastMessage.textContent = chat.lastMessage || 'Sin mensajes todavia.';
+                const previewText = chat.lastMessage || (chat.lastMessageType === 'review-share' ? 'Reseña compartida' : 'Sin mensajes todavia.');
+                lastMessage.textContent = previewText;
                 bottomRow.appendChild(lastMessage);
 
                 const actionsContainer = document.createElement('div');
@@ -694,16 +786,44 @@ ListopicApp.pageChats = (() => {
         messages.forEach(msg => {
             const bubble = document.createElement('div');
             bubble.className = 'message-bubble';
-            if (msg.senderId === currentUser.uid) {
+            const isOwnMessage = msg.senderId === currentUser.uid;
+            if (isOwnMessage) {
                 bubble.classList.add('sent');
             } else {
                 bubble.classList.add('received');
             }
-            bubble.textContent = msg.text;
+
+            if (msg.messageType) {
+                bubble.dataset.messageType = msg.messageType;
+            }
+
+            const content = document.createElement('div');
+            content.className = 'message-content';
+
+            const rawText = typeof msg.text === 'string' ? msg.text : '';
+            const textValue = rawText.trim();
+            if (textValue) {
+                const textParagraph = document.createElement('p');
+                textParagraph.className = 'message-text';
+                textParagraph.textContent = rawText;
+                content.appendChild(textParagraph);
+            }
+
+            const sharePayload = msg.sharePayload || (msg.messageType === 'review-share' ? msg.payload : null);
+            if (msg.messageType === 'review-share' && sharePayload) {
+                const shareCard = createSharedReviewCard(sharePayload, isOwnMessage);
+                if (shareCard) {
+                    content.appendChild(shareCard);
+                    bubble.classList.add('has-shared-card');
+                }
+            }
+
+            if (content.children.length) {
+                bubble.appendChild(content);
+            }
 
             const meta = document.createElement('span');
             meta.className = 'message-meta';
-            const isOwnMessage = msg.senderId === currentUser.uid;
             const senderLabel = isOwnMessage ? 'Tu' : (msg.senderProfile?.displayName || msg.senderProfile?.username || 'Usuario');
             const timeLabel = msg.createdAt ? formatRelativeTime(msg.createdAt) : '';
             meta.textContent = timeLabel ? `${senderLabel} - ${timeLabel}` : senderLabel;

--- a/public/style.css
+++ b/public/style.css
@@ -7074,6 +7074,20 @@ body.light-theme .message-bubble.received {
     border: none;
 }
 
+.message-bubble .message-content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+}
+
+.message-bubble .message-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: inherit;
+}
+
 .message-bubble .message-meta {
     display: block;
     margin-top: 6px;
@@ -7083,6 +7097,136 @@ body.light-theme .message-bubble.received {
 
 .message-bubble:not(.sent) .message-meta {
     color: var(--muted-text-color, #6c757d);
+}
+
+.shared-review-card {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.08);
+    padding: 12px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    width: 100%;
+}
+
+.shared-review-card--sent,
+.message-bubble.sent .shared-review-card {
+    border-color: rgba(255, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.15);
+}
+
+body.light-theme .shared-review-card {
+    background: #ffffff;
+    border-color: rgba(0, 0, 0, 0.08);
+    color: var(--text-color, #1b1b1f);
+}
+
+body.light-theme .shared-review-card--sent,
+body.light-theme .message-bubble.sent .shared-review-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+.shared-review-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
+.shared-review-card:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+    outline: 2px solid var(--accent-color-secondary);
+    outline-offset: 2px;
+}
+
+.shared-review-card__media {
+    width: 64px;
+    height: 64px;
+    border-radius: 10px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(0, 0, 0, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+body.light-theme .shared-review-card__media {
+    background: rgba(0, 0, 0, 0.08);
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.shared-review-card__media--placeholder i {
+    font-size: 1.4rem;
+}
+
+.shared-review-card__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.shared-review-card__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.shared-review-card__title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.shared-review-card__title {
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.shared-review-card__rating {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #ffffff;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--accent-color-primary);
+    align-self: flex-start;
+    white-space: nowrap;
+}
+
+.shared-review-card__subtitle {
+    font-size: 0.85rem;
+    color: var(--muted-text-color, rgba(255, 255, 255, 0.7));
+    word-break: break-word;
+}
+
+body.light-theme .shared-review-card__subtitle {
+    color: var(--muted-text-color, #6c757d);
+}
+
+.shared-review-card__comment {
+    margin: 0;
+    font-size: 0.9rem;
+    color: inherit;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+}
+
+body.light-theme .shared-review-card__comment {
+    color: var(--text-color, #1b1b1f);
 }
 
 .message-composer {


### PR DESCRIPTION
## Summary
- capture review metadata when sharing so chat messages include a structured payload
- allow chat messages to persist optional review-share payloads and render interactive cards in the conversation view
- style the new shared review cards for both themes and update share messaging copy

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e12cd9b2bc8326bc6a3add2735fef0