### PR TITLE
Enhance review cards with author info and view shortcut

### DIFF
--- a/public/chats.html
+++ b/public/chats.html
@@ -94,20 +94,21 @@
             <section class="chats-page" aria-label="Mensajes directos">
                 <aside class="chat-panel chat-list-panel" id="chat-list-panel">
                     <header class="chat-list-header">
-                        <h3>Conversaciones</h3>
-                        <button type="button" class="chat-list-close" id="chat-list-close" aria-label="Cerrar listado de chats">
-                            <i class="fas fa-times"></i>
-                        </button>
+                        <div class="chat-list-header-text">
+                            <h3>Conversaciones</h3>
+                        </div>
+                        <div class="chat-list-header-actions">
+                            <button type="button" class="chat-action-button" id="open-group-modal">
+                                <i class="fas fa-user-group" aria-hidden="true"></i>
+                                <span>Crear grupo</span>
+                            </button>
+                            <button type="button" class="chat-list-close" id="chat-list-close" aria-label="Cerrar listado de chats">
+                                <i class="fas fa-times"></i>
+                            </button>
+                        </div>
                     </header>
                     <p id="chat-list-status" class="chat-list-status">Cargando conversaciones...</p>
                     <div class="chat-list" id="chat-list"></div>
-                    <form id="new-chat-form" class="new-chat-form" autocomplete="off">
-                        <label for="new-chat-identifiers">Iniciar chat (usuario o email)</label>
-                        <input type="text" id="new-chat-identifiers" name="new-chat-identifiers" placeholder="usuario1, usuario2" required>
-                        <small>Separa varios destinatarios con comas. Solo podras chatear con usuarios existentes.</small>
-                        <button type="submit" class="button primary">Crear chat</button>
-                        <p class="form-error-inline" id="new-chat-error" style="display:none;"></p>
-                    </form>
                 </aside>
                 <div class="chat-list-backdrop" id="chat-list-backdrop" hidden></div>
 
@@ -124,6 +125,12 @@
                                 <p id="chat-detail-subtitle">Elige una conversacion para empezar.</p>
                             </div>
                         </div>
+                        <div class="chat-header-actions">
+                            <button type="button" class="chat-info-button" id="chat-info-button" aria-label="Ver informacion del chat" disabled>
+                                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                                <span>Info</span>
+                            </button>
+                        </div>
                     </header>
                     <div class="chat-messages" id="chat-messages">
                         <div class="chat-empty-state" id="chat-empty-state">
@@ -132,12 +139,64 @@
                     </div>
                     <form id="message-form" class="message-composer" autocomplete="off" hidden>
                         <textarea id="message-input" name="message" placeholder="Escribe un mensaje" required maxlength="2000"></textarea>
-                        <button type="submit" class="button primary">Enviar</button>
+                        <button type="submit" class="button primary message-send-button" aria-label="Enviar mensaje">
+                            <i class="fas fa-paper-plane" aria-hidden="true"></i>
+                            <span>Enviar</span>
+                        </button>
                     </form>
                 </section>
             </section>
         </div>
     </main>
+
+    <div class="chat-modal" id="chat-group-modal" role="dialog" aria-hidden="true" aria-labelledby="chat-group-modal-title">
+        <div class="chat-modal-dialog">
+            <button type="button" class="chat-modal-close" id="chat-group-modal-close" aria-label="Cerrar">
+                <i class="fas fa-times"></i>
+            </button>
+            <form id="chat-group-form" class="chat-group-form">
+                <header class="chat-modal-header">
+                    <h2 id="chat-group-modal-title">Crear grupo</h2>
+                    <p id="chat-group-modal-subtitle">Selecciona usuarios de entre las personas a las que sigues.</p>
+                </header>
+                <div class="chat-modal-body">
+                    <div class="chat-group-field" id="group-name-field">
+                        <label for="group-name-input">Nombre del grupo</label>
+                        <input type="text" id="group-name-input" name="group-name" placeholder="Viaje a Barcelona" maxlength="80" required>
+                    </div>
+                    <div class="chat-group-field">
+                        <label for="group-search-input">Añadir participantes</label>
+                        <input type="text" id="group-search-input" name="group-search" placeholder="Busca entre tus seguidos" autocomplete="off">
+                        <p class="chat-modal-empty-state" id="group-modal-empty-state">Empieza a escribir para buscar entre tus seguidos.</p>
+                        <div class="chat-search-results" id="group-search-results" role="listbox"></div>
+                    </div>
+                    <div class="chat-selected-users" id="group-selected-users" aria-live="polite"></div>
+                </div>
+                <footer class="chat-modal-footer">
+                    <button type="button" class="button ghost" id="chat-group-cancel">Cancelar</button>
+                    <button type="submit" class="button primary" id="chat-group-submit" disabled>Crear grupo</button>
+                </footer>
+            </form>
+        </div>
+    </div>
+
+    <div class="chat-modal" id="chat-info-modal" role="dialog" aria-hidden="true" aria-labelledby="chat-info-title">
+        <div class="chat-modal-dialog">
+            <button type="button" class="chat-modal-close" id="chat-info-modal-close" aria-label="Cerrar">
+                <i class="fas fa-times"></i>
+            </button>
+            <div class="chat-modal-header">
+                <h2 id="chat-info-title">Informacion del chat</h2>
+                <p id="chat-info-subtitle"></p>
+            </div>
+            <div class="chat-modal-body">
+                <div class="chat-info-participants" id="chat-info-participants"></div>
+            </div>
+            <footer class="chat-modal-footer">
+                <button type="button" class="button secondary" id="chat-info-add">Añadir participantes</button>
+            </footer>
+        </div>
+    </div>
 </body>
 </html>
 

--- a/public/js/page-chats.js
+++ b/public/js/page-chats.js
@@ -322,6 +322,9 @@ ListopicApp.pageChats = (() => {
         if (groupNameField) {
             groupNameField.hidden = mode !== 'create';
         }
+        if (groupNameInput) {
+            groupNameInput.required = mode === 'create';
+        }
         if (groupModalSubmitButton) {
             groupModalSubmitButton.textContent = mode === 'create' ? 'Crear grupo' : 'Agregar';
         }
@@ -719,6 +722,16 @@ ListopicApp.pageChats = (() => {
         currentChatId = chatId;
         const chat = chatsCache.find(c => c.id === chatId);
         currentChatData = chat || null;
+
+        if (chat && currentUser?.uid && chat.unreadCounts && typeof chat.unreadCounts === 'object') {
+            const unreadCount = chat.unreadCounts[currentUser.uid] || 0;
+            if (unreadCount > 0) {
+                const updatedCounts = { ...chat.unreadCounts, [currentUser.uid]: 0 };
+                updateLocalChatData(chat.id, { unreadCounts: updatedCounts });
+                renderChatList(chatsCache);
+            }
+        }
+
         renderChatHeader(currentChatData);
 
         if (unsubscribeMessages) {
@@ -872,6 +885,19 @@ ListopicApp.pageChats = (() => {
     const attachEventListeners = () => {
         if (messageForm) {
             messageForm.addEventListener('submit', handleMessageSubmit);
+        }
+        if (messageInput) {
+            messageInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' && !event.shiftKey && !isMobileLayout()) {
+                    event.preventDefault();
+                    if (typeof messageForm?.requestSubmit === 'function') {
+                        messageForm.requestSubmit();
+                    } else if (messageForm) {
+                        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+                        messageForm.dispatchEvent(submitEvent);
+                    }
+                }
+            });
         }
         if (mobileListOpenButton) {
             mobileListOpenButton.addEventListener('click', () => openChatListModal());

--- a/public/js/page-profile.js
+++ b/public/js/page-profile.js
@@ -631,6 +631,7 @@ ListopicApp.pageProfile = {
                     menu.innerHTML = `
                         <button class="review-menu__btn" title="Opciones"><i class="fas fa-ellipsis-h"></i></button>
                         <div class="review-menu__dropdown">
+                            <button class="review-action" data-action="view">Ver rese�a</button>
                             <button class="review-action" data-action="edit">Editar rese�a</button>
                             <button class="review-action" data-action="share">Compartir</button>
                             <button class="review-action danger" data-action="delete">Eliminar</button>
@@ -644,7 +645,9 @@ ListopicApp.pageProfile = {
                         actBtn.addEventListener('click', async (e) => {
                             e.stopPropagation();
                             const action = actBtn.dataset.action;
-                            if (action === 'edit') {
+                            if (action === 'view') {
+                                window.location.href = `detail-view.html?id=${r.id}&listId=${r.listId}`;
+                            } else if (action === 'edit') {
                                 window.location.href = `review-form.html?listId=${r.listId}&editId=${r.id}`;
                             } else if (action === 'share') {
                                 const url = `${location.origin}${location.pathname.replace(/[^/]+$/, '')}detail-view.html?id=${r.id}&listId=${r.listId}`;

--- a/public/js/uiUtils.js
+++ b/public/js/uiUtils.js
@@ -186,6 +186,8 @@ ListopicApp.uiUtils = {
         const authorId = author.id || review.userId;
         const authorName = uiUtils.escapeHtml(author.name || 'Usuario Anónimo');
         const authorPhoto = uiUtils.escapeHtml(author.photoUrl || 'img/placeholder-avatar.png');
+        const rawAuthorUsername = author.username || review.authorUsername || review.username || '';
+        const authorUsername = rawAuthorUsername ? uiUtils.escapeHtml(rawAuthorUsername.replace(/^@+/, '')) : '';
 
         const place = review.place || {};
         const placeId = place.id || review.placeId;
@@ -229,16 +231,28 @@ ListopicApp.uiUtils = {
         const imageHtml = review.photoUrl
             ? `<img src="${uiUtils.escapeHtml(review.photoUrl)}" alt="Foto de ${uiUtils.escapeHtml(review.itemName)}" class="review-super-card__image">`
             : `<div class="review-super-card__icon-placeholder"><i class="fas fa-camera"></i></div>`;
+
+        const authorMetaHtml = authorUsername
+            ? `<div class="author-meta"><span class="author-meta__label">Autor</span><span class="meta-separator">•</span><span class="author-meta__username">@${authorUsername}</span></div>`
+            : `<div class="author-meta"><span class="author-meta__label">Autor</span></div>`;
+
+        const imageLinkHtml = `
+            <a href="${detailUrl}" class="review-super-card__image-link" onclick="event.stopPropagation()">
+                ${imageHtml}
+            </a>`;
         
         // --- 3. Ensamblado Final ---
         return `
             <article class="review-super-card" onclick="window.location.href='${detailUrl}';">
                 <header class="review-super-card__header">
                     <div class="header-main-info">
-                        <a href="profile.html?viewUserId=${authorId}" class="author-link" onclick="event.stopPropagation()">
-                            <img src="${authorPhoto}" alt="Avatar de ${authorName}" class="author-avatar">
-                            <span class="author-name">${authorName}</span>
-                        </a>
+                        <div class="author-stack">
+                            <a href="profile.html?viewUserId=${authorId}" class="author-link" onclick="event.stopPropagation()">
+                                <img src="${authorPhoto}" alt="Avatar de ${authorName}" class="author-avatar">
+                                <span class="author-name">${authorName}</span>
+                            </a>
+                            ${authorMetaHtml}
+                        </div>
                         <div class="list-highlight">
                             <span class="meta-separator">•</span> en <a href="list-view.html?listId=${list.id}" onclick="event.stopPropagation()">${list.name}</a>
                         </div>
@@ -249,7 +263,7 @@ ListopicApp.uiUtils = {
                 </header>
                 <div class="review-super-card__body">
                     <div class="review-super-card__image-container">
-                        ${imageHtml}
+                        ${imageLinkHtml}
                     </div>
                     <div class="review-super-card__main-content">
                         <div class="review-super-card__title-group">
@@ -459,7 +473,8 @@ createListViewGroupCard: function(group, listData, listIcon) {
                     author: {
                         id: review.userId,
                         name: authorData?.displayName || authorData?.username || 'Usuario Anónimo',
-                        photoUrl: authorData?.photoUrl || 'img/placeholder-avatar.png'
+                        photoUrl: authorData?.photoUrl || 'img/placeholder-avatar.png',
+                        username: authorData?.username || ''
                     },
                     place: {
                         id: review.placeId,

--- a/public/style.css
+++ b/public/style.css
@@ -5031,9 +5031,15 @@ body.light-theme .info-tag:hover {
 }
 .header-main-info { /* Contenedor para autor y lista */
     display: flex;
-    align-items: center; /* Alinear en la misma línea */
+    align-items: flex-start; /* Alinear en columna cuando sea necesario */
     flex-wrap: wrap; /* Por si no cabe en pantallas muy pequeñas */
-    gap: 8px;
+    gap: 12px;
+}
+.author-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
 }
 .author-link {
     display: inline-flex;
@@ -5044,6 +5050,24 @@ body.light-theme .info-tag:hover {
     font-weight: 600;
 }
 .author-link:hover { color: var(--accent-color-primary); }
+.author-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--secondary-text-color);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.author-meta__label {
+    font-weight: 600;
+}
+.author-meta__username {
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 600;
+    color: var(--accent-color-secondary);
+}
 .author-avatar {
     width: 28px;
     height: 28px;
@@ -5074,7 +5098,24 @@ body.light-theme .info-tag:hover {
 /* --- Cuerpo --- */
 .review-super-card__body { display: flex; gap: 20px; padding: 12px; }
 .review-super-card__image-container { flex: 0 0 150px; width: 150px; height: 150px; }
-.review-super-card__image, .review-super-card__icon-placeholder { width: 100%; height: 100%; object-fit: cover; border-radius: var(--border-radius-medium); }
+.review-super-card__image-link {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--border-radius-medium);
+    overflow: hidden;
+}
+.review-super-card__image-link:focus-visible {
+    outline: 2px solid var(--accent-color-primary);
+    outline-offset: 2px;
+}
+.review-super-card__image,
+.review-super-card__icon-placeholder {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--border-radius-medium);
+}
 .review-super-card__icon-placeholder { display: flex; align-items: center; justify-content: center; background-color: var(--icon-placeholder-bg); font-size: 3rem; color: var(--icon-placeholder-color); }
 .review-super-card__main-content { flex: 1 1 auto; min-width: 0; }
 .review-super-card__title-group { margin-bottom: 8px; /* Reducimos el espacio inferior */ }
@@ -6663,7 +6704,14 @@ body.light-theme .leaflet-popup-tip {
     align-items: center;
     justify-content: space-between;
     padding: 16px;
+    gap: 12px;
     border-bottom: 1px solid var(--input-border);
+}
+
+.chat-list-header-text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 .chat-list-header h3 {
@@ -6671,6 +6719,38 @@ body.light-theme .leaflet-popup-tip {
     font-size: 1rem;
     color: var(--title-color);
     font-weight: 600;
+}
+
+.chat-list-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.chat-action-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: rgba(17, 138, 178, 0.12);
+    color: var(--accent-color-secondary);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.chat-action-button i {
+    font-size: 0.95rem;
+}
+
+.chat-action-button:hover,
+.chat-action-button:focus-visible {
+    background: rgba(17, 138, 178, 0.22);
+    border-color: rgba(17, 138, 178, 0.35);
+    outline: none;
+    transform: translateY(-1px);
 }
 
 .chat-list-close {
@@ -6932,6 +7012,44 @@ body.light-theme .leaflet-popup-tip {
     min-width: 0;
 }
 
+.chat-header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
+.chat-info-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: rgba(0, 0, 0, 0.04);
+    color: var(--muted-text-color, #6c757d);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.chat-info-button span {
+    display: inline;
+}
+
+.chat-info-button:hover,
+.chat-info-button:focus-visible {
+    background: rgba(17, 138, 178, 0.12);
+    border-color: rgba(17, 138, 178, 0.35);
+    color: var(--accent-color-secondary);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.chat-info-button:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .chat-header-text h3 {
     margin: 0;
     font-size: 1.05rem;
@@ -7001,20 +7119,37 @@ body.light-theme .message-bubble.received {
     padding: 16px;
     display: flex;
     gap: 12px;
+    align-items: flex-end;
 }
 
 .message-composer textarea {
     flex: 1;
     resize: none;
-    min-height: 60px;
+    min-height: 64px;
+    max-height: 220px;
+    padding: 12px 14px;
+    border-radius: 14px;
 }
 
-.new-chat-form {
-    padding: 16px;
-    border-top: 1px solid var(--input-border);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+.message-composer textarea:focus-visible {
+    outline: 2px solid var(--accent-color-secondary);
+}
+
+.message-send-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border-radius: 14px;
+}
+
+.message-send-button i {
+    font-size: 1rem;
+}
+
+.message-send-button span {
+    font-weight: 600;
 }
 
 .chat-empty-state {
@@ -7035,6 +7170,367 @@ body.light-theme .message-bubble.received {
     display: block;
 }
 
+
+.chat-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 2200;
+    padding: 24px;
+}
+
+.chat-modal.is-open {
+    display: flex;
+}
+
+.chat-modal-dialog {
+    position: relative;
+    width: min(540px, 100%);
+    max-height: 90vh;
+    background: var(--container-bg);
+    border-radius: 20px;
+    border: 1px solid var(--input-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.22);
+}
+
+.chat-modal-close {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--muted-text-color, #6c757d);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.chat-modal-close:hover,
+.chat-modal-close:focus-visible {
+    background: rgba(17, 138, 178, 0.12);
+    border-color: rgba(17, 138, 178, 0.35);
+    color: var(--accent-color-secondary);
+    outline: none;
+}
+
+.chat-modal-header {
+    padding: 24px 24px 12px 24px;
+    border-bottom: 1px solid var(--input-border);
+}
+
+.chat-modal-header h2 {
+    margin: 0 0 6px 0;
+    font-size: 1.25rem;
+    color: var(--title-color);
+}
+
+.chat-modal-header p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-modal-body {
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    overflow-y: auto;
+}
+
+.chat-group-form {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.chat-group-field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.chat-group-field input {
+    width: 100%;
+}
+
+.chat-modal-empty-state {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-search-results {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+    margin-top: 4px;
+}
+
+.chat-search-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    background: rgba(0, 0, 0, 0.04);
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.chat-search-item:hover,
+.chat-search-item:focus-visible {
+    background: rgba(17, 138, 178, 0.12);
+    border-color: rgba(17, 138, 178, 0.35);
+    outline: none;
+}
+
+.chat-search-avatar {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: var(--accent-color-secondary);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.chat-search-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.chat-search-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: left;
+}
+
+.chat-search-info strong {
+    font-size: 0.95rem;
+    color: var(--title-color);
+}
+
+.chat-search-info span {
+    font-size: 0.82rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-selected-users {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px dashed var(--input-border);
+    min-height: 56px;
+    background: rgba(0, 0, 0, 0.03);
+}
+
+.chat-selected-users.is-empty::before {
+    content: 'Aun no has seleccionado participantes.';
+    font-size: 0.85rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(17, 138, 178, 0.35);
+    background: rgba(17, 138, 178, 0.12);
+    color: var(--accent-color-secondary);
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.chat-chip:hover,
+.chat-chip:focus-visible {
+    background: rgba(17, 138, 178, 0.22);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.chat-chip-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(17, 138, 178, 0.8);
+    color: #fff;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.chat-chip-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.chat-chip-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.chat-chip i {
+    font-size: 0.75rem;
+}
+
+.chat-modal-footer {
+    margin-top: auto;
+    padding: 16px 24px 24px 24px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    border-top: 1px solid var(--input-border);
+}
+
+.chat-info-participants {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.chat-info-participant {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    background: rgba(0, 0, 0, 0.03);
+}
+
+.chat-info-participant-avatar {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: rgba(17, 138, 178, 0.85);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.chat-info-participant-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.chat-info-participant-data {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+}
+
+.chat-info-participant-name {
+    font-weight: 600;
+    color: var(--title-color);
+}
+
+.chat-info-participant-username {
+    font-size: 0.85rem;
+    color: var(--muted-text-color, #6c757d);
+}
+
+.chat-info-participant-badge {
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(17, 138, 178, 0.18);
+    color: var(--accent-color-secondary);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.chat-info-remove {
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(230, 57, 70, 0.35);
+    background: rgba(230, 57, 70, 0.12);
+    color: var(--danger-color, #e63946);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.chat-info-remove:hover,
+.chat-info-remove:focus-visible {
+    background: rgba(230, 57, 70, 0.2);
+    border-color: rgba(230, 57, 70, 0.6);
+    outline: none;
+}
+
+.chat-info-add {
+    margin-left: auto;
+}
+
+.chat-info-add[hidden] {
+    display: none !important;
+}
+
+.notification-item {
+    position: relative;
+    padding-left: 28px;
+}
+
+.notification-item::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 10px;
+    transform: translateY(-50%);
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--danger-color, #e63946);
+    opacity: 0;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.notification-item.unread::before {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.05);
+}
+
+.notification-item.unread {
+    border-color: var(--accent-color-secondary);
+    background: rgba(17, 138, 178, 0.08);
+}
+
+body.chat-modal-open {
+    overflow: hidden;
+}
 
 .form-error-inline {
     color: var(--danger-color, #e63946);
@@ -7067,6 +7563,24 @@ body.chat-list-modal-open {
         transform: translateX(0);
     }
 
+    .chat-list-header {
+        padding: 16px 20px;
+    }
+
+    .chat-list-header-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .chat-action-button {
+        padding: 10px;
+        border-radius: 14px;
+    }
+
+    .chat-action-button span {
+        display: none;
+    }
+
     .chat-list-close {
         display: inline-flex;
     }
@@ -7089,9 +7603,66 @@ body.chat-list-modal-open {
         width: 100%;
     }
 
+    .chat-header-actions {
+        width: 100%;
+        justify-content: flex-end;
+    }
+
     .chat-header-avatars .chat-avatar {
         width: 40px;
         height: 40px;
+    }
+
+    .chat-modal {
+        padding: 16px;
+    }
+
+    .chat-modal-dialog {
+        max-height: 92vh;
+    }
+}
+
+@media (max-width: 720px) {
+    .message-composer {
+        align-items: center;
+    }
+
+    .message-composer textarea {
+        min-height: 48px;
+        padding: 10px 12px;
+    }
+
+    .message-send-button {
+        width: 46px;
+        height: 46px;
+        padding: 0;
+        border-radius: 12px;
+    }
+
+    .message-send-button span {
+        display: none;
+    }
+
+    .chat-info-button span {
+        display: none;
+    }
+
+    .chat-info-button {
+        padding: 8px;
+        border-radius: 12px;
+    }
+}
+
+@media (max-width: 540px) {
+    .chat-modal-dialog {
+        border-radius: 16px;
+    }
+
+    .chat-modal-header,
+    .chat-modal-body,
+    .chat-modal-footer {
+        padding-left: 18px;
+        padding-right: 18px;
     }
 }
 


### PR DESCRIPTION
## Summary
- show author metadata with username in review cards and link the cover image to the review detail
- propagate author usernames through the review enrichment helper and restyle the card header for the new layout
- add a "Ver reseña" option to the owner dropdown so the detail view is available from the three-dot menu

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dee6a19a848326a4e10dca36dcaeac