### PR TITLE
Add Instagram story sharing experience and guard Firebase Functions

### DIFF
--- a/public/js/config.js
+++ b/public/js/config.js
@@ -21,7 +21,16 @@ const app = firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
 const auth = firebase.auth();
 const storage = firebase.storage();
-const functions = firebase.functions();
+let functions = null;
+try {
+    if (typeof firebase.functions === 'function') {
+        functions = firebase.functions();
+    } else if (firebase.app && typeof firebase.app().functions === 'function') {
+        functions = firebase.app().functions('europe-west1');
+    }
+} catch (error) {
+    console.warn('Firebase Functions no disponible en este momento.', error);
+}
 
 // 3. LÓGICA PARA CONECTAR A LOS EMULADORES EN LOCAL (sin cambios)
 /*

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -242,6 +242,15 @@ ListopicApp.reviewShare = (() => {
     let chatsListElement;
     let chatsLoadingElement;
     let chatsEmptyElement;
+    let storySection;
+    let storyButton;
+    let storyButtonDefaultHTML = '';
+    let storyDownloadLink;
+    let storyFeedbackElement;
+    let storyColorSelect;
+    let storyStyleSelect;
+    let storyCustomization = null;
+    let storyContextCache = null;
     let isInitialized = false;
     let currentData = null;
     let currentLink = '';
@@ -257,6 +266,193 @@ ListopicApp.reviewShare = (() => {
         isInitialized = true;
     };
 
+    const getStoryModule = () => window.ListopicApp?.storyShare || null;
+
+    const getStoryDefaults = () => getStoryModule()?.getDefaultCustomization?.() || { colorScheme: 'midnight', graphicStyle: 'bars' };
+
+    const populateStoryOptions = () => {
+        if (!storyColorSelect || !storyStyleSelect) {
+            return;
+        }
+        const module = getStoryModule();
+        const colorOptions = module?.getColorSchemeOptions?.() || [
+            { value: 'midnight', label: 'Aurora nocturna' },
+            { value: 'sunset', label: 'Atardecer brillante' },
+            { value: 'ocean', label: 'Olas frías' },
+            { value: 'forest', label: 'Bosque vivo' }
+        ];
+        storyColorSelect.innerHTML = colorOptions
+            .map(option => `<option value="${option.value}">${option.label}</option>`)
+            .join('');
+        const styleOptions = module?.getGraphicStyleOptions?.() || [
+            { value: 'bars', label: 'Barras' },
+            { value: 'radar', label: 'Gráfico radar' }
+        ];
+        storyStyleSelect.innerHTML = styleOptions
+            .map(option => `<option value="${option.value}">${option.label}</option>`)
+            .join('');
+    };
+
+    const setStoryFeedback = (message, type = 'info') => {
+        if (!storyFeedbackElement) {
+            return;
+        }
+        if (!message) {
+            storyFeedbackElement.hidden = true;
+            storyFeedbackElement.textContent = '';
+            storyFeedbackElement.dataset.type = '';
+            return;
+        }
+        storyFeedbackElement.textContent = message;
+        storyFeedbackElement.dataset.type = type;
+        storyFeedbackElement.hidden = false;
+    };
+
+    const setStoryButtonLoading = (isLoading) => {
+        if (!storyButton) {
+            return;
+        }
+        if (isLoading) {
+            storyButton.dataset.loading = 'true';
+            storyButton.disabled = true;
+            storyButton.innerHTML = '<i class="fas fa-spinner"></i> Generando...';
+        } else {
+            storyButton.dataset.loading = 'false';
+            const defaultLabel = storyButtonDefaultHTML || '<i class="fab fa-instagram"></i> Generar tarjeta';
+            storyButton.disabled = false;
+            storyButton.innerHTML = defaultLabel;
+        }
+    };
+
+    const resetStorySection = () => {
+        populateStoryOptions();
+        const defaults = getStoryDefaults();
+        storyCustomization = { ...defaults };
+        if (storyColorSelect) {
+            storyColorSelect.value = defaults.colorScheme;
+        }
+        if (storyStyleSelect) {
+            storyStyleSelect.value = defaults.graphicStyle;
+        }
+        if (storyDownloadLink) {
+            storyDownloadLink.hidden = true;
+            storyDownloadLink.removeAttribute('href');
+        }
+        const module = getStoryModule();
+        if (!module) {
+            setStoryFeedback('La generación de tarjetas no está disponible por ahora.', 'warning');
+            if (storyButton) {
+                storyButton.disabled = true;
+            }
+        } else {
+            setStoryFeedback('', 'info');
+            if (storyButton) {
+                storyButton.disabled = false;
+                storyButton.innerHTML = storyButtonDefaultHTML || '<i class="fab fa-instagram"></i> Generar tarjeta';
+            }
+        }
+        storyContextCache = null;
+    };
+
+    const handleStoryOptionChange = () => {
+        if (!storyCustomization) {
+            storyCustomization = { ...getStoryDefaults() };
+        }
+        if (storyColorSelect?.value) {
+            storyCustomization.colorScheme = storyColorSelect.value;
+        }
+        if (storyStyleSelect?.value) {
+            storyCustomization.graphicStyle = storyStyleSelect.value;
+        }
+        if (storyFeedbackElement && !storyFeedbackElement.hidden && storyFeedbackElement.dataset.type !== 'error') {
+            setStoryFeedback('Aplicaremos el nuevo estilo en la próxima tarjeta.', 'info');
+        }
+    };
+
+    const prepareStoryContext = async () => {
+        const module = getStoryModule();
+        if (!module) {
+            throw new Error('Servicio de tarjetas no disponible.');
+        }
+        if (!currentData?.listId || !currentData?.reviewId) {
+            throw new Error('Faltan datos para generar la tarjeta.');
+        }
+        if (storyContextCache && storyContextCache.key === `${currentData.listId}/${currentData.reviewId}`) {
+            return storyContextCache;
+        }
+        const result = await module.loadShareContext(currentData.listId, currentData.reviewId);
+        storyContextCache = { key: `${currentData.listId}/${currentData.reviewId}`, ...result };
+        return storyContextCache;
+    };
+
+    const handleStoryShareClick = async () => {
+        const module = getStoryModule();
+        if (!module) {
+            setStoryFeedback('No podemos generar la tarjeta en este momento.', 'error');
+            return;
+        }
+        if (storyButton?.dataset.loading === 'true') {
+            return;
+        }
+        if (!storyCustomization) {
+            storyCustomization = { ...getStoryDefaults() };
+        }
+        if (storyColorSelect?.value) {
+            storyCustomization.colorScheme = storyColorSelect.value;
+        }
+        if (storyStyleSelect?.value) {
+            storyCustomization.graphicStyle = storyStyleSelect.value;
+        }
+        setStoryButtonLoading(true);
+        setStoryFeedback('Generando la tarjeta...', 'info');
+        let blobUrl = null;
+        try {
+            const { context, criteriaDefinitions } = await prepareStoryContext();
+            const { blob } = await module.createInstagramStoryCard(context, criteriaDefinitions, storyCustomization);
+            const fileName = `listopic-story-${context.review?.id || 'reseña'}.png`;
+            const file = new File([blob], fileName, { type: 'image/png' });
+            let shared = false;
+            if (navigator.canShare) {
+                try {
+                    if (navigator.canShare({ files: [file] })) {
+                        await navigator.share({
+                            files: [file],
+                            title: `Mi reseña en ${context.place?.name || context.review?.establishmentName || 'Listopic'}`,
+                            text: context.review?.itemName ? `${context.review.itemName} en Listopic` : 'Mi reseña en Listopic'
+                        });
+                        shared = true;
+                        setStoryFeedback('¡Tarjeta lista! Completa la publicación en Instagram.', 'success');
+                    }
+                } catch (error) {
+                    if (error?.name === 'AbortError') {
+                        setStoryFeedback('Compartir cancelado. Puedes descargar la tarjeta para subirla manualmente.', 'info');
+                    } else {
+                        console.warn('[reviewShare] Error compartiendo tarjeta:', error);
+                        setStoryFeedback('No pudimos compartir automáticamente. Descarga la tarjeta para subirla tú.', 'info');
+                    }
+                }
+            }
+            if (!shared) {
+                blobUrl = URL.createObjectURL(blob);
+                if (storyDownloadLink) {
+                    storyDownloadLink.href = blobUrl;
+                    storyDownloadLink.download = fileName;
+                    storyDownloadLink.hidden = false;
+                    storyDownloadLink.click();
+                }
+                setStoryFeedback('Descargamos la tarjeta. Busca la imagen en tu galería.', 'info');
+            }
+        } catch (error) {
+            console.error('[reviewShare] Error generando la tarjeta:', error);
+            setStoryFeedback('No pudimos generar la tarjeta. Inténtalo nuevamente.', 'error');
+        } finally {
+            setStoryButtonLoading(false);
+            if (blobUrl) {
+                setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+            }
+        }
+    };
+
     const createModal = () => {
         modal = document.createElement('div');
         modal.id = 'review-share-modal';
@@ -264,7 +460,7 @@ ListopicApp.reviewShare = (() => {
         modal.innerHTML = `
             <div class="modal-content review-share-modal__content" role="dialog" aria-modal="true" aria-labelledby="review-share-title">
                 <button type="button" class="close-button review-share-modal__close" aria-label="Cerrar">&times;</button>
-                <h2 id="review-share-title" class="review-share-modal__title">Compartir rese&#241;a</h2>
+                <h2 id="review-share-title" class="review-share-modal__title">Compartir reseña</h2>
                 <p class="review-share-modal__subtitle"></p>
                 <section class="review-share-modal__section">
                     <h3 class="review-share-modal__section-title">Compartir enlace</h3>
@@ -279,10 +475,27 @@ ListopicApp.reviewShare = (() => {
                     <h3 class="review-share-modal__section-title">Enviar a un chat</h3>
                     <div class="review-share-modal__chats">
                         <p class="review-share-modal__chats-loading">Cargando chats...</p>
-                        <p class="review-share-modal__chats-empty" hidden>No hay chats activos todav&iacute;a.</p>
+                        <p class="review-share-modal__chats-empty" hidden>No hay chats activos todavía.</p>
                         <div class="review-share-modal__chats-list"></div>
                     </div>
                     <p class="review-share-modal__chat-feedback" hidden></p>
+                </section>
+                <section class="review-share-modal__section review-share-modal__section--story">
+                    <h3 class="review-share-modal__section-title">Tarjeta para Instagram</h3>
+                    <p class="review-share-modal__story-description">Genera una tarjeta lista para compartirla en tus historias con el estilo que prefieras.</p>
+                    <div class="review-share-modal__story-grid">
+                        <label class="review-share-modal__story-label" for="review-share-story-color">Colores</label>
+                        <select id="review-share-story-color" class="review-share-modal__story-select"></select>
+                        <label class="review-share-modal__story-label" for="review-share-story-style">Gráfico</label>
+                        <select id="review-share-story-style" class="review-share-modal__story-select"></select>
+                    </div>
+                    <div class="review-share-modal__story-actions">
+                        <button type="button" class="button tertiary-button review-share-story-btn">
+                            <i class="fab fa-instagram"></i> Generar tarjeta
+                        </button>
+                        <a class="button secondary-button review-share-story-download" hidden download>Descargar</a>
+                    </div>
+                    <p class="review-share-modal__story-feedback" hidden></p>
                 </section>
             </div>
         `;
@@ -299,6 +512,23 @@ ListopicApp.reviewShare = (() => {
         chatsListElement = modal.querySelector('.review-share-modal__chats-list');
         chatsLoadingElement = modal.querySelector('.review-share-modal__chats-loading');
         chatsEmptyElement = modal.querySelector('.review-share-modal__chats-empty');
+        storySection = modal.querySelector('.review-share-modal__section--story');
+        storyButton = modal.querySelector('.review-share-story-btn');
+        storyDownloadLink = modal.querySelector('.review-share-story-download');
+        storyFeedbackElement = modal.querySelector('.review-share-modal__story-feedback');
+        storyColorSelect = modal.querySelector('#review-share-story-color');
+        storyStyleSelect = modal.querySelector('#review-share-story-style');
+        if (storyButton) {
+            storyButtonDefaultHTML = storyButton.innerHTML;
+            storyButton.addEventListener('click', handleStoryShareClick);
+        }
+        if (storyColorSelect) {
+            storyColorSelect.addEventListener('change', handleStoryOptionChange);
+        }
+        if (storyStyleSelect) {
+            storyStyleSelect.addEventListener('change', handleStoryOptionChange);
+        }
+        resetStorySection();
 
         closeButton.addEventListener('click', close);
         copyButton.addEventListener('click', handleCopyLink);
@@ -368,6 +598,7 @@ ListopicApp.reviewShare = (() => {
             nativeShareButton.hidden = !supported;
             nativeShareButton.disabled = !supported;
         }
+        resetStorySection();
         modal.classList.add('active');
         document.body.classList.add('modal-open');
         loadChats();

--- a/public/js/page-detail-view.js
+++ b/public/js/page-detail-view.js
@@ -1,5 +1,722 @@
 window.ListopicApp = window.ListopicApp || {};
 ListopicApp.pageDetailView = (() => {
+    const STORY_DEFAULT_CUSTOMIZATION = {
+        colorScheme: 'midnight',
+        graphicStyle: 'bars'
+    };
+
+    const STORY_GRAPHIC_STYLES = [
+        { value: 'bars', label: 'Barras' },
+        { value: 'radar', label: 'Tela de araña' }
+    ];
+
+    const STORY_COLOR_SCHEMES = {
+        midnight: {
+            label: 'Aurora nocturna',
+            background: ['#0f172a', '#1f2937'],
+            overlayShape: 'rgba(255,255,255,0.08)',
+            accentPrimary: '#f97316',
+            accentSecondary: '#facc15',
+            accentTertiary: '#06b6d4',
+            barTrack: 'rgba(255,255,255,0.14)',
+            metricFill: 'rgba(255,255,255,0.12)',
+            metricStroke: 'rgba(255,255,255,0.35)',
+            panelTint: 'rgba(15,23,42,0.55)',
+            textMuted: 'rgba(255,255,255,0.75)',
+            fallbackGradient: ['#f97316', '#fb7185'],
+            radarGrid: 'rgba(255,255,255,0.18)',
+            radarAxis: 'rgba(255,255,255,0.24)'
+        },
+        sunset: {
+            label: 'Atardecer brillante',
+            background: ['#37102d', '#ea5f6c'],
+            overlayShape: 'rgba(255,255,255,0.12)',
+            accentPrimary: '#ff8a5b',
+            accentSecondary: '#ffd166',
+            accentTertiary: '#ff6f91',
+            barTrack: 'rgba(255,255,255,0.18)',
+            metricFill: 'rgba(255,255,255,0.14)',
+            metricStroke: 'rgba(255,255,255,0.32)',
+            panelTint: 'rgba(58,18,41,0.55)',
+            textMuted: 'rgba(255,255,255,0.82)',
+            fallbackGradient: ['#ff9a8b', '#ff6a88'],
+            radarGrid: 'rgba(255,255,255,0.22)',
+            radarAxis: 'rgba(255,255,255,0.3)'
+        },
+        ocean: {
+            label: 'Olas frías',
+            background: ['#02203a', '#065a82'],
+            overlayShape: 'rgba(255,255,255,0.1)',
+            accentPrimary: '#3cd5ff',
+            accentSecondary: '#f4a259',
+            accentTertiary: '#00bcd4',
+            barTrack: 'rgba(255,255,255,0.16)',
+            metricFill: 'rgba(255,255,255,0.14)',
+            metricStroke: 'rgba(255,255,255,0.3)',
+            panelTint: 'rgba(3,24,45,0.6)',
+            textMuted: 'rgba(225,245,255,0.76)',
+            fallbackGradient: ['#00b4d8', '#0077b6'],
+            radarGrid: 'rgba(255,255,255,0.2)',
+            radarAxis: 'rgba(255,255,255,0.28)'
+        },
+        forest: {
+            label: 'Bosque vivo',
+            background: ['#0b1f1a', '#164b2f'],
+            overlayShape: 'rgba(255,255,255,0.1)',
+            accentPrimary: '#4ade80',
+            accentSecondary: '#facc15',
+            accentTertiary: '#34d399',
+            barTrack: 'rgba(255,255,255,0.14)',
+            metricFill: 'rgba(255,255,255,0.12)',
+            metricStroke: 'rgba(255,255,255,0.3)',
+            panelTint: 'rgba(9,34,23,0.6)',
+            textMuted: 'rgba(226,255,234,0.78)',
+            fallbackGradient: ['#10b981', '#22c55e'],
+            radarGrid: 'rgba(255,255,255,0.2)',
+            radarAxis: 'rgba(255,255,255,0.3)'
+        }
+    };
+
+    function getColorScheme(name) {
+        return STORY_COLOR_SCHEMES[name] || STORY_COLOR_SCHEMES.midnight;
+    }
+
+    function wrapText(ctx, text, x, y, maxWidth, lineHeight) {
+        if (!text) {
+            return y;
+        }
+        const words = text.toString().split(/\s+/);
+        let line = '';
+        for (let n = 0; n < words.length; n += 1) {
+            const testLine = line ? `${line} ${words[n]}` : words[n];
+            const metrics = ctx.measureText(testLine);
+            if (metrics.width > maxWidth && n > 0) {
+                ctx.fillText(line, x, y);
+                line = words[n];
+                y += lineHeight;
+            } else {
+                line = testLine;
+            }
+        }
+        ctx.fillText(line, x, y);
+        return y + lineHeight;
+    }
+
+    function drawRoundedRectPath(ctx, x, y, width, height, radius) {
+        const effectiveRadius = Math.min(radius, width / 2, height / 2);
+        ctx.beginPath();
+        ctx.moveTo(x + effectiveRadius, y);
+        ctx.lineTo(x + width - effectiveRadius, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + effectiveRadius);
+        ctx.lineTo(x + width, y + height - effectiveRadius);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - effectiveRadius, y + height);
+        ctx.lineTo(x + effectiveRadius, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - effectiveRadius);
+        ctx.lineTo(x, y + effectiveRadius);
+        ctx.quadraticCurveTo(x, y, x + effectiveRadius, y);
+        ctx.closePath();
+    }
+
+    function drawRoundedImage(ctx, img, x, y, width, height, radius) {
+        ctx.save();
+        ctx.clip();
+        drawRoundedRectPath(ctx, x, y, width, height, radius);
+        ctx.drawImage(img, x, y, width, height);
+        ctx.restore();
+    }
+
+    async function loadImageSafely(url) {
+        if (!url) throw new Error('URL no disponible');
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.referrerPolicy = 'no-referrer';
+        return await new Promise((resolve, reject) => {
+            img.onload = () => resolve(img);
+            img.onerror = () => reject(new Error('No se pudo cargar la imagen.'));
+            img.src = url;
+        });
+    }
+
+    let cachedListopicLogoImage = null;
+    let cachedDefaultAvatarImage = null;
+
+    async function loadListopicLogoImage() {
+        if (cachedListopicLogoImage) {
+            return cachedListopicLogoImage;
+        }
+        try {
+            cachedListopicLogoImage = await loadImageSafely('img/logo-listopic400.png');
+        } catch (error) {
+            console.warn('No se pudo cargar el logo de Listopic para la tarjeta.', error);
+            cachedListopicLogoImage = null;
+        }
+        return cachedListopicLogoImage;
+    }
+
+    async function loadDefaultAvatarImage() {
+        if (cachedDefaultAvatarImage) {
+            return cachedDefaultAvatarImage;
+        }
+        try {
+            cachedDefaultAvatarImage = await loadImageSafely('img/default-avatar.png');
+        } catch (error) {
+            console.warn('No se pudo cargar el avatar por defecto para la tarjeta.', error);
+            cachedDefaultAvatarImage = null;
+        }
+        return cachedDefaultAvatarImage;
+    }
+
+    async function resolveAuthorPhoto(author) {
+        if (author && author.photoUrl) {
+            try {
+                return await loadImageSafely(author.photoUrl);
+            } catch (error) {
+                console.warn('No se pudo cargar la foto del autor para la tarjeta.', error);
+            }
+        }
+        return await loadDefaultAvatarImage();
+    }
+
+    function getAuthorInitials(name) {
+        if (!name) {
+            return '';
+        }
+        const parts = String(name).trim().split(/\s+/).filter(Boolean).slice(0, 2);
+        if (parts.length === 0) {
+            return '';
+        }
+        return parts.map(part => part.charAt(0).toUpperCase()).join('');
+    }
+
+    function hexToRgba(hex, alpha) {
+        if (!hex) {
+            return `rgba(255,255,255,${alpha ?? 1})`;
+        }
+        let normalized = String(hex).trim().replace('#', '');
+        if (normalized.length === 3) {
+            normalized = normalized.split('').map(char => char + char).join('');
+        }
+        if (normalized.length !== 6) {
+            return `rgba(255,255,255,${alpha ?? 1})`;
+        }
+        const intValue = Number.parseInt(normalized, 16);
+        if (Number.isNaN(intValue)) {
+            return `rgba(255,255,255,${alpha ?? 1})`;
+        }
+        const r = (intValue >> 16) & 255;
+        const g = (intValue >> 8) & 255;
+        const b = intValue & 255;
+        return `rgba(${r}, ${g}, ${b}, ${alpha ?? 1})`;
+    }
+
+    async function createInstagramStoryCard(context, criteriaDefinitions = {}, customization = {}) {
+        const { review, list, place, author } = context || {};
+        const { colorScheme = STORY_DEFAULT_CUSTOMIZATION.colorScheme, graphicStyle = STORY_DEFAULT_CUSTOMIZATION.graphicStyle } = customization || {};
+        const scheme = getColorScheme(colorScheme);
+        const canvas = document.createElement('canvas');
+        const width = 1080;
+        const height = 1920;
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+
+        const gradient = ctx.createLinearGradient(0, 0, width, height);
+        gradient.addColorStop(0, scheme.background[0]);
+        gradient.addColorStop(1, scheme.background[1]);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, width, height);
+
+        ctx.save();
+        ctx.fillStyle = scheme.overlayShape;
+        for (let i = -width; i < width * 2; i += 180) {
+            ctx.beginPath();
+            ctx.ellipse(i, height * 0.3, 220, 80, Math.PI / 6, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.restore();
+
+        const margin = 96;
+        const availableWidth = width - margin * 2;
+
+        const dishName = (review?.itemName || 'Mi reseña favorita').toString();
+        const placeName = (place?.name || review?.establishmentName || 'Lugar especial').toString();
+        const listName = (list?.name || 'Mi ranking personal').toString();
+        const authorName = (author?.name || review?.authorName || review?.userDisplayName || 'Autor anónimo').toString();
+        const overallRating = Number.parseFloat(review?.overallRating ?? review?.overallScore ?? 0) || 0;
+
+        const authorPhoto = await resolveAuthorPhoto(author);
+        const authorInitials = getAuthorInitials(authorName);
+        const logoImage = await loadListopicLogoImage();
+
+        ctx.fillStyle = 'rgba(255,255,255,0.6)';
+        ctx.font = '500 36px "Poppins", "Helvetica Neue", Arial';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        ctx.fillText(listName, margin, 120);
+
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '700 68px "Poppins", "Helvetica Neue", Arial';
+        let currentY = wrapText(ctx, dishName, margin, 180, availableWidth, 82);
+
+        ctx.fillStyle = 'rgba(255,255,255,0.85)';
+        ctx.font = '500 46px "Poppins", "Helvetica Neue", Arial';
+        currentY = wrapText(ctx, placeName, margin, currentY + 10, availableWidth, 60);
+
+        const imageHeight = 680;
+        const imageWidth = availableWidth;
+        const imageY = currentY + 20;
+        let imageDrawn = false;
+        if (review?.photoUrl) {
+            try {
+                const img = await loadImageSafely(review.photoUrl);
+                const scale = Math.min(imageWidth / img.width, imageHeight / img.height);
+                const drawWidth = img.width * scale;
+                const drawHeight = img.height * scale;
+                const offsetX = margin + (imageWidth - drawWidth) / 2;
+                const offsetY = imageY + (imageHeight - drawHeight) / 2;
+                drawRoundedImage(ctx, img, offsetX, offsetY, drawWidth, drawHeight, 42);
+                imageDrawn = true;
+            } catch (error) {
+                console.warn('No se pudo cargar la imagen de la reseña para la tarjeta.', error);
+            }
+        }
+
+        if (!imageDrawn) {
+            ctx.save();
+            drawRoundedRectPath(ctx, margin, imageY, imageWidth, imageHeight, 42);
+            ctx.clip();
+            const fallbackGradient = ctx.createLinearGradient(margin, imageY, margin + imageWidth, imageY + imageHeight);
+            fallbackGradient.addColorStop(0, scheme.fallbackGradient[0]);
+            fallbackGradient.addColorStop(1, scheme.fallbackGradient[1]);
+            ctx.fillStyle = fallbackGradient;
+            ctx.fillRect(margin, imageY, imageWidth, imageHeight);
+            ctx.restore();
+            ctx.save();
+            ctx.fillStyle = 'rgba(255,255,255,0.1)';
+            ctx.font = '600 48px "Poppins", "Helvetica Neue", Arial';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.translate(width / 2, imageY + imageHeight / 2);
+            ctx.rotate(-Math.PI / 9);
+            ctx.fillText('LISTOPIC', 0, 0);
+            ctx.restore();
+        }
+
+        ctx.save();
+        drawRoundedRectPath(ctx, margin, imageY, imageWidth, imageHeight, 42);
+        ctx.clip();
+        const overlayGradient = ctx.createLinearGradient(0, imageY, 0, imageY + imageHeight);
+        overlayGradient.addColorStop(0, 'rgba(0,0,0,0)');
+        overlayGradient.addColorStop(1, 'rgba(0,0,0,0.35)');
+        ctx.fillStyle = overlayGradient;
+        ctx.fillRect(margin, imageY, imageWidth, imageHeight);
+        ctx.restore();
+
+        const badgeRadius = 72;
+        const badgeCenterX = margin + badgeRadius + 24;
+        const badgeCenterY = imageY + imageHeight - badgeRadius - 32;
+
+        const drawAuthorBadge = () => {
+            if (!authorPhoto && !authorInitials) {
+                return;
+            }
+            ctx.save();
+            ctx.beginPath();
+            ctx.arc(badgeCenterX, badgeCenterY, badgeRadius + 10, 0, Math.PI * 2);
+            ctx.fillStyle = 'rgba(0,0,0,0.45)';
+            ctx.fill();
+            ctx.restore();
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.arc(badgeCenterX, badgeCenterY, badgeRadius, 0, Math.PI * 2);
+            ctx.fillStyle = '#ffffff';
+            ctx.fill();
+            ctx.clip();
+            if (authorPhoto) {
+                const scale = Math.max((badgeRadius * 2) / authorPhoto.width, (badgeRadius * 2) / authorPhoto.height);
+                const drawWidth = authorPhoto.width * scale;
+                const drawHeight = authorPhoto.height * scale;
+                ctx.drawImage(authorPhoto, badgeCenterX - drawWidth / 2, badgeCenterY - drawHeight / 2, drawWidth, drawHeight);
+            } else {
+                const avatarGradient = ctx.createLinearGradient(badgeCenterX - badgeRadius, badgeCenterY - badgeRadius, badgeCenterX + badgeRadius, badgeCenterY + badgeRadius);
+                avatarGradient.addColorStop(0, scheme.accentPrimary);
+                avatarGradient.addColorStop(1, scheme.accentTertiary);
+                ctx.fillStyle = avatarGradient;
+                ctx.fillRect(badgeCenterX - badgeRadius, badgeCenterY - badgeRadius, badgeRadius * 2, badgeRadius * 2);
+            }
+            ctx.restore();
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.arc(badgeCenterX, badgeCenterY, badgeRadius, 0, Math.PI * 2);
+            ctx.lineWidth = 4;
+            ctx.strokeStyle = scheme.accentSecondary;
+            ctx.stroke();
+            ctx.restore();
+
+            if (!authorPhoto && authorInitials) {
+                ctx.save();
+                ctx.fillStyle = '#ffffff';
+                ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(authorInitials, badgeCenterX, badgeCenterY);
+                ctx.restore();
+            }
+
+            const boxHeight = 72;
+            const textWidth = ctx.measureText(authorName).width;
+            let boxWidth = Math.min(420, Math.max(220, textWidth + 60));
+            let boxX = badgeCenterX + badgeRadius + 28;
+            const maxBoxX = margin + imageWidth - boxWidth - 24;
+            if (boxX > maxBoxX) {
+                boxX = maxBoxX;
+            }
+            if (boxX < margin + badgeRadius * 2 + 32) {
+                boxX = margin + badgeRadius * 2 + 32;
+            }
+            if (boxX + boxWidth > margin + imageWidth - 24) {
+                boxWidth = margin + imageWidth - 24 - boxX;
+            }
+            const boxY = badgeCenterY - boxHeight / 2;
+
+            ctx.save();
+            drawRoundedRectPath(ctx, boxX, boxY, boxWidth, boxHeight, 28);
+            ctx.fillStyle = scheme.panelTint;
+            ctx.fill();
+            ctx.restore();
+
+            ctx.save();
+            ctx.textAlign = 'left';
+            ctx.fillStyle = scheme.textMuted;
+            ctx.font = '600 20px "Poppins", "Helvetica Neue", Arial';
+            ctx.fillText('Autor', boxX + 22, boxY + 20);
+            ctx.fillStyle = '#ffffff';
+            ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
+            ctx.textBaseline = 'bottom';
+            ctx.fillText(authorName, boxX + 22, boxY + boxHeight - 16);
+            ctx.restore();
+        };
+
+        drawAuthorBadge();
+
+        if (logoImage) {
+            const logoSize = 140;
+            const logoPadding = 28;
+            const logoX = margin + imageWidth - logoSize - logoPadding;
+            const logoY = imageY + logoPadding;
+            ctx.save();
+            drawRoundedRectPath(ctx, logoX - 18, logoY - 18, logoSize + 36, logoSize + 36, 24);
+            ctx.fillStyle = hexToRgba(scheme.accentSecondary, 0.18);
+            ctx.fill();
+            ctx.restore();
+
+            ctx.save();
+            ctx.globalAlpha = 0.9;
+            ctx.drawImage(logoImage, logoX, logoY, logoSize, logoSize);
+            ctx.restore();
+        }
+
+        let currentMetricsY = imageY + imageHeight + 60;
+
+        const circleRadius = 150;
+        const circleCenterX = margin + circleRadius;
+        const circleCenterY = currentMetricsY + circleRadius;
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(circleCenterX, circleCenterY, circleRadius, 0, Math.PI * 2);
+        ctx.closePath();
+        ctx.fillStyle = scheme.metricFill;
+        ctx.fill();
+        ctx.lineWidth = 6;
+        ctx.strokeStyle = scheme.metricStroke;
+        ctx.stroke();
+        ctx.restore();
+
+        ctx.save();
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '700 120px "Poppins", "Helvetica Neue", Arial';
+        ctx.fillText(overallRating.toFixed(1), circleCenterX, circleCenterY - 10);
+        ctx.font = '500 36px "Poppins", "Helvetica Neue", Arial';
+        ctx.fillStyle = 'rgba(255,255,255,0.75)';
+        ctx.fillText('Valoración', circleCenterX, circleCenterY + 140);
+        ctx.restore();
+
+        const availableCriteria = [];
+        if (criteriaDefinitions && typeof criteriaDefinitions === 'object' && Object.keys(criteriaDefinitions).length > 0) {
+            for (const [key, definition] of Object.entries(criteriaDefinitions)) {
+                if (review?.scores?.[key] === undefined) {
+                    continue;
+                }
+                const value = Number.parseFloat(review.scores[key]);
+                if (!Number.isFinite(value)) {
+                    continue;
+                }
+                availableCriteria.push([key, definition]);
+            }
+        } else if (review?.scores) {
+            for (const key of Object.keys(review.scores)) {
+                const value = Number.parseFloat(review.scores[key]);
+                if (!Number.isFinite(value)) {
+                    continue;
+                }
+                availableCriteria.push([key, { label: key, min: 0, max: 10 }]);
+            }
+        }
+
+        const barsStartX = circleCenterX + circleRadius + 70;
+        const barsMaxWidth = width - barsStartX - margin;
+        const barHeight = 44;
+        const barGap = 88;
+
+        const drawBarsGraphic = (entries) => {
+            if (!entries.length) {
+                return circleCenterY + circleRadius;
+            }
+            let index = 0;
+            let lastBottom = circleCenterY - circleRadius;
+            for (const [key, definition] of entries) {
+                const raw = Number.parseFloat(review.scores[key]);
+                const min = Number.parseFloat(definition?.min ?? 0);
+                const max = Number.parseFloat(definition?.max ?? 10);
+                const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const barY = circleCenterY - circleRadius + index * barGap;
+                ctx.fillStyle = scheme.barTrack;
+                drawRoundedRectPath(ctx, barsStartX, barY, barsMaxWidth, barHeight, 20);
+                ctx.fill();
+                ctx.fillStyle = scheme.accentPrimary;
+                drawRoundedRectPath(ctx, barsStartX, barY, Math.max(0, barsMaxWidth * clamped), barHeight, 20);
+                ctx.fill();
+
+                ctx.fillStyle = '#ffffff';
+                ctx.font = '500 34px "Poppins", "Helvetica Neue", Arial';
+                ctx.textAlign = 'left';
+                ctx.textBaseline = 'middle';
+                const label = (definition?.label || key).toString();
+                ctx.fillText(label, barsStartX + 16, barY + barHeight / 2);
+
+                ctx.textAlign = 'right';
+                ctx.fillStyle = scheme.textMuted;
+                ctx.fillText(raw.toFixed(1), barsStartX + barsMaxWidth - 16, barY + barHeight / 2);
+
+                index += 1;
+                lastBottom = barY + barHeight;
+            }
+            return lastBottom + 40;
+        };
+
+        const drawRadarGraphic = (entries) => {
+            const metricsAreaX = circleCenterX + circleRadius + 70;
+            const metricsAreaWidth = width - metricsAreaX - margin;
+            const centerX = metricsAreaX + metricsAreaWidth / 2;
+            const centerY = circleCenterY;
+            const radius = Math.min(metricsAreaWidth / 2, circleRadius * 1.7, 260);
+            const levels = 5;
+
+            ctx.save();
+            ctx.lineWidth = 1.5;
+            ctx.strokeStyle = scheme.radarGrid;
+            for (let step = 1; step <= levels; step += 1) {
+                const ratio = step / levels;
+                ctx.beginPath();
+                entries.forEach(([key, definition], index) => {
+                    const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
+                    const x = centerX + Math.cos(angle) * radius * ratio;
+                    const y = centerY + Math.sin(angle) * radius * ratio;
+                    if (index === 0) {
+                        ctx.moveTo(x, y);
+                    } else {
+                        ctx.lineTo(x, y);
+                    }
+                });
+                ctx.closePath();
+                ctx.stroke();
+            }
+
+            ctx.strokeStyle = scheme.radarAxis;
+            entries.forEach((entry, index) => {
+                const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
+                ctx.beginPath();
+                ctx.moveTo(centerX, centerY);
+                ctx.lineTo(centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius);
+                ctx.stroke();
+            });
+
+            ctx.beginPath();
+            entries.forEach(([key, definition], index) => {
+                const raw = Number.parseFloat(review.scores[key]);
+                const min = Number.parseFloat(definition?.min ?? 0);
+                const max = Number.parseFloat(definition?.max ?? 10);
+                const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
+                const x = centerX + Math.cos(angle) * radius * clamped;
+                const y = centerY + Math.sin(angle) * radius * clamped;
+                if (index === 0) {
+                    ctx.moveTo(x, y);
+                } else {
+                    ctx.lineTo(x, y);
+                }
+            });
+            ctx.closePath();
+            ctx.fillStyle = hexToRgba(scheme.accentPrimary, 0.32);
+            ctx.fill();
+            ctx.lineWidth = 3;
+            ctx.strokeStyle = scheme.accentPrimary;
+            ctx.stroke();
+
+            entries.forEach(([key, definition], index) => {
+                const raw = Number.parseFloat(review.scores[key]);
+                const min = Number.parseFloat(definition?.min ?? 0);
+                const max = Number.parseFloat(definition?.max ?? 10);
+                const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
+                const x = centerX + Math.cos(angle) * radius * clamped;
+                const y = centerY + Math.sin(angle) * radius * clamped;
+                ctx.beginPath();
+                ctx.arc(x, y, 6, 0, Math.PI * 2);
+                ctx.fillStyle = '#ffffff';
+                ctx.fill();
+            });
+
+            entries.forEach(([key, definition], index) => {
+                const raw = Number.parseFloat(review.scores[key]);
+                const label = (definition?.label || key).toString();
+                const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
+                let textAlign = 'center';
+                if (Math.cos(angle) > 0.2) {
+                    textAlign = 'left';
+                } else if (Math.cos(angle) < -0.2) {
+                    textAlign = 'right';
+                }
+                const labelX = centerX + Math.cos(angle) * (radius + 36);
+                const labelY = centerY + Math.sin(angle) * (radius + 36);
+                ctx.textAlign = textAlign;
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = '#ffffff';
+                ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
+                ctx.fillText(label, labelX, labelY);
+                ctx.fillStyle = scheme.textMuted;
+                ctx.font = '400 24px "Poppins", "Helvetica Neue", Arial';
+                ctx.fillText(raw.toFixed(1), labelX, labelY + 26);
+            });
+
+            ctx.restore();
+            return centerY + radius + 40;
+        };
+
+        let metricsBottom = circleCenterY + circleRadius;
+        if (graphicStyle === 'radar' && availableCriteria.length >= 3) {
+            metricsBottom = Math.max(metricsBottom, drawRadarGraphic(availableCriteria.slice(0, 6)));
+        } else {
+            metricsBottom = Math.max(metricsBottom, drawBarsGraphic(availableCriteria.slice(0, 4)));
+        }
+
+        currentMetricsY = metricsBottom + 60;
+
+        let comment = (review?.comment || '').toString().trim();
+        if (comment.length > 280) comment = `${comment.slice(0, 277)}…`;
+        if (comment) {
+            ctx.fillStyle = '#ffffff';
+            ctx.textAlign = 'left';
+            ctx.textBaseline = 'top';
+            ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
+            ctx.fillText('Notas rápidas', margin, currentMetricsY);
+            ctx.font = '400 34px "Poppins", "Helvetica Neue", Arial';
+            currentMetricsY = wrapText(ctx, `“${comment}”`, margin, currentMetricsY + 56, availableWidth, 48);
+        }
+
+        ctx.fillStyle = scheme.textMuted;
+        ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('Comparte tu ranking en Listopic', width / 2, height - 200);
+        ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
+        ctx.fillStyle = '#ffffff';
+        ctx.fillText('listopic.app', width / 2, height - 140);
+
+        const blob = await new Promise((resolve, reject) => {
+            canvas.toBlob(result => {
+                if (result) resolve(result);
+                else reject(new Error('No se pudo generar la tarjeta.'));
+            }, 'image/png');
+        });
+
+        return { blob };
+    }
+
+    async function loadShareContext(listId, reviewId) {
+        const services = window.ListopicApp?.services;
+        if (!services?.db) {
+            throw new Error('Servicios de Firebase no disponibles.');
+        }
+        if (!listId || !reviewId) {
+            throw new Error('Faltan datos para preparar la tarjeta.');
+        }
+
+        const listRef = services.db.collection('lists').doc(listId);
+        const reviewRef = listRef.collection('reviews').doc(reviewId);
+        const reviewDoc = await reviewRef.get();
+        if (!reviewDoc.exists) {
+            throw new Error('No encontramos esa reseña.');
+        }
+        const reviewData = { id: reviewDoc.id, ...reviewDoc.data() };
+
+        let listDoc = null;
+        let listData = null;
+        try {
+            listDoc = await listRef.get();
+            if (listDoc.exists) {
+                listData = { id: listDoc.id, ...listDoc.data() };
+            }
+        } catch (error) {
+            console.warn('No se pudo cargar la lista asociada para la tarjeta.', error);
+        }
+
+        let placeData = null;
+        if (reviewData.placeId) {
+            try {
+                const placeDoc = await services.db.collection('places').doc(reviewData.placeId).get();
+                if (placeDoc.exists) {
+                    placeData = { id: placeDoc.id, ...placeDoc.data() };
+                }
+            } catch (error) {
+                console.warn('No se pudo cargar el lugar asociado para la tarjeta.', error);
+            }
+        }
+
+        const authorInfo = {
+            id: reviewData.userId || reviewData.authorId || null,
+            name: reviewData.authorName || reviewData.userDisplayName || reviewData.username || '',
+            photoUrl: reviewData.authorPhotoUrl || ''
+        };
+
+        const criteriaDefinitions = listData?.criteriaDefinitions || listData?.defaultCriteriaDefinitions || {};
+
+        return {
+            context: {
+                review: reviewData,
+                list: listData,
+                place: placeData,
+                author: authorInfo
+            },
+            criteriaDefinitions
+        };
+    }
+
+    ListopicApp.storyShare = Object.assign({}, ListopicApp.storyShare, {
+        createInstagramStoryCard,
+        getDefaultCustomization: () => ({ ...STORY_DEFAULT_CUSTOMIZATION }),
+        getColorSchemeOptions: () => Object.entries(STORY_COLOR_SCHEMES).map(([value, scheme]) => ({ value, label: scheme.label })),
+        getGraphicStyleOptions: () => STORY_GRAPHIC_STYLES.map(option => ({ ...option })),
+        loadShareContext
+    });
+
     function init() {
         console.log('Initializing Detail View page logic...');
 
@@ -15,8 +732,19 @@ ListopicApp.pageDetailView = (() => {
         // Elementos del DOM
         const detailEstablishmentNameEl = document.getElementById('detail-restaurant-name');
         const detailItemNameEl = document.getElementById('detail-dish-name');
-        const reviewAuthorNameEl = document.getElementById('review-author-name'); // <<--- ASEGÚRATE QUE ESTE ID ESTÉ EN TU HTML
-        const detailImageEl = document.getElementById('detail-image');
+        const defaultStoryCustomization = ListopicApp.storyShare?.getDefaultCustomization
+            ? ListopicApp.storyShare.getDefaultCustomization()
+            : { ...STORY_DEFAULT_CUSTOMIZATION };
+
+            colorScheme: (shareColorSchemeSelect && shareColorSchemeSelect.value) || defaultStoryCustomization.colorScheme,
+            graphicStyle: (shareGraphicStyleSelect && shareGraphicStyleSelect.value) || defaultStoryCustomization.graphicStyle
+        if (shareColorSchemeSelect && !shareColorSchemeSelect.value) {
+            shareColorSchemeSelect.value = shareCustomization.colorScheme;
+        }
+        if (shareGraphicStyleSelect && !shareGraphicStyleSelect.value) {
+            shareGraphicStyleSelect.value = shareCustomization.graphicStyle;
+        }
+
         const detailScoreValueEl = document.getElementById('detail-score-value');
         const detailRatingsListEl = document.getElementById('detail-ratings');
         const detailLocationLinkEl = document.getElementById('detail-location-link');
@@ -115,667 +843,35 @@ ListopicApp.pageDetailView = (() => {
             if (shareHelperEl) shareHelperEl.hidden = false;
             if (shareCustomizationContainer) shareCustomizationContainer.hidden = false;
             setCustomizationControlsDisabled(false);
-            setShareStatus('Personaliza la tarjeta y compartela en Instagram Stories.', 'info');
-        }
-
-        function wrapText(ctx, text, x, y, maxWidth, lineHeight) {
-            if (!text) return y;
-            const words = String(text).split(/\s+/).filter(Boolean);
-            let line = '';
-            let currentY = y;
-            for (const word of words) {
-                const testLine = line ? `${line} ${word}` : word;
-                if (ctx.measureText(testLine).width > maxWidth && line) {
-                    ctx.fillText(line, x, currentY);
-                    line = word;
-                    currentY += lineHeight;
-                } else {
-                    line = testLine;
-                }
-            }
-            if (line) {
-                ctx.fillText(line, x, currentY);
-                currentY += lineHeight;
-            }
-            return currentY;
-        }
-
-        function drawRoundedRectPath(ctx, x, y, width, height, radius) {
-            const cornerRadius = Math.min(radius, width / 2, height / 2);
-            ctx.beginPath();
-            ctx.moveTo(x + cornerRadius, y);
-            ctx.lineTo(x + width - cornerRadius, y);
-            ctx.quadraticCurveTo(x + width, y, x + width, y + cornerRadius);
-            ctx.lineTo(x + width, y + height - cornerRadius);
-            ctx.quadraticCurveTo(x + width, y + height, x + width - cornerRadius, y + height);
-            ctx.lineTo(x + cornerRadius, y + height);
-            ctx.quadraticCurveTo(x, y + height, x, y + height - cornerRadius);
-            ctx.lineTo(x, y + cornerRadius);
-            ctx.quadraticCurveTo(x, y, x + cornerRadius, y);
-            ctx.closePath();
-        }
-
-        function drawRoundedImage(ctx, img, x, y, width, height, radius) {
-            drawRoundedRectPath(ctx, x, y, width, height, radius);
-            ctx.save();
-            ctx.clip();
-            ctx.drawImage(img, x, y, width, height);
-            ctx.restore();
-        }
-
-        async function loadImageSafely(url) {
-            if (!url) throw new Error('URL no disponible');
-            const img = new Image();
-            img.crossOrigin = 'anonymous';
-            img.referrerPolicy = 'no-referrer';
-            return await new Promise((resolve, reject) => {
-                img.onload = () => resolve(img);
-                img.onerror = () => reject(new Error('No se pudo cargar la imagen.'));
-                img.src = url;
-            });
-        }
-        const COLOR_SCHEMES = {
-            midnight: {
-                background: ['#0f172a', '#1f2937'],
-                overlayShape: 'rgba(255,255,255,0.08)',
-                accentPrimary: '#f97316',
-                accentSecondary: '#facc15',
-                accentTertiary: '#06b6d4',
-                barTrack: 'rgba(255,255,255,0.14)',
-                metricFill: 'rgba(255,255,255,0.12)',
-                metricStroke: 'rgba(255,255,255,0.35)',
-                panelTint: 'rgba(15,23,42,0.55)',
-                textMuted: 'rgba(255,255,255,0.75)',
-                fallbackGradient: ['#f97316', '#fb7185'],
-                radarGrid: 'rgba(255,255,255,0.18)',
-                radarAxis: 'rgba(255,255,255,0.24)'
-            },
-            sunset: {
-                background: ['#37102d', '#ea5f6c'],
-                overlayShape: 'rgba(255,255,255,0.12)',
-                accentPrimary: '#ff8a5b',
-                accentSecondary: '#ffd166',
-                accentTertiary: '#ff6f91',
-                barTrack: 'rgba(255,255,255,0.18)',
-                metricFill: 'rgba(255,255,255,0.14)',
-                metricStroke: 'rgba(255,255,255,0.32)',
-                panelTint: 'rgba(58,18,41,0.55)',
-                textMuted: 'rgba(255,255,255,0.82)',
-                fallbackGradient: ['#ff9a8b', '#ff6a88'],
-                radarGrid: 'rgba(255,255,255,0.22)',
-                radarAxis: 'rgba(255,255,255,0.3)'
-            },
-            ocean: {
-                background: ['#02203a', '#065a82'],
-                overlayShape: 'rgba(255,255,255,0.1)',
-                accentPrimary: '#3cd5ff',
-                accentSecondary: '#f4a259',
-                accentTertiary: '#00bcd4',
-                barTrack: 'rgba(255,255,255,0.16)',
-                metricFill: 'rgba(255,255,255,0.14)',
-                metricStroke: 'rgba(255,255,255,0.3)',
-                panelTint: 'rgba(3,24,45,0.6)',
-                textMuted: 'rgba(225,245,255,0.76)',
-                fallbackGradient: ['#00b4d8', '#0077b6'],
-                radarGrid: 'rgba(255,255,255,0.2)',
-                radarAxis: 'rgba(255,255,255,0.28)'
-            },
-            forest: {
-                background: ['#0b1f1a', '#164b2f'],
-                overlayShape: 'rgba(255,255,255,0.1)',
-                accentPrimary: '#4ade80',
-                accentSecondary: '#facc15',
-                accentTertiary: '#34d399',
-                barTrack: 'rgba(255,255,255,0.14)',
-                metricFill: 'rgba(255,255,255,0.12)',
-                metricStroke: 'rgba(255,255,255,0.3)',
-                panelTint: 'rgba(9,34,23,0.6)',
-                textMuted: 'rgba(226,255,234,0.78)',
-                fallbackGradient: ['#10b981', '#22c55e'],
-                radarGrid: 'rgba(255,255,255,0.2)',
-                radarAxis: 'rgba(255,255,255,0.3)'
-            }
-        };
-
-        function getColorScheme(name) {
-            return COLOR_SCHEMES[name] || COLOR_SCHEMES.midnight;
-        }
-
-        function hexToRgba(hex, alpha) {
-            if (!hex) {
-                return `rgba(255,255,255,${alpha ?? 1})`;
-            }
-            let normalized = String(hex).trim().replace('#', '');
-            if (normalized.length == 3) {
-                normalized = normalized.split('').map(char => char + char).join('');
-            }
-            if (normalized.length != 6) {
-                return `rgba(255,255,255,${alpha ?? 1})`;
-            }
-            const intValue = Number.parseInt(normalized, 16);
-            if (Number.isNaN(intValue)) {
-                return `rgba(255,255,255,${alpha ?? 1})`;
-            }
-            const r = (intValue >> 16) & 255;
-            const g = (intValue >> 8) & 255;
-            const b = intValue & 255;
-            return `rgba(${r}, ${g}, ${b}, ${alpha ?? 1})`;
-        }
-
-        let cachedListopicLogoImage = null;
-        let cachedDefaultAvatarImage = null;
-
-        async function loadListopicLogoImage() {
-            if (cachedListopicLogoImage) {
-                return cachedListopicLogoImage;
-            }
-            try {
-                cachedListopicLogoImage = await loadImageSafely('img/logo-listopic400.png');
-            } catch (error) {
-                console.warn('No se pudo cargar el logo de Listopic para la tarjeta.', error);
-                cachedListopicLogoImage = null;
-            }
-            return cachedListopicLogoImage;
-        }
-
-        async function loadDefaultAvatarImage() {
-            if (cachedDefaultAvatarImage) {
-                return cachedDefaultAvatarImage;
-            }
-            try {
-                cachedDefaultAvatarImage = await loadImageSafely('img/default-avatar.png');
-            } catch (error) {
-                console.warn('No se pudo cargar el avatar por defecto para la tarjeta.', error);
-                cachedDefaultAvatarImage = null;
-            }
-            return cachedDefaultAvatarImage;
-        }
-
-        async function resolveAuthorPhoto(author) {
-            if (author && author.photoUrl) {
-                try {
-                    return await loadImageSafely(author.photoUrl);
-                } catch (error) {
-                    console.warn('No se pudo cargar la foto del autor para la tarjeta.', error);
-                }
-            }
-            return await loadDefaultAvatarImage();
-        }
-
-        function getAuthorInitials(name) {
-            if (!name) {
-                return '';
-            }
-            const parts = String(name).trim().split(/\s+/).filter(Boolean).slice(0, 2);
-            if (parts.length === 0) {
-                return '';
-            }
-            return parts.map(part => part.charAt(0).toUpperCase()).join('');
-        }
-
-
-        async function createInstagramStoryCard(context, criteriaDefinitions = {}, customization = {}) {
-            const { review, list, place, author } = context || {};
-            const { colorScheme = 'midnight', graphicStyle = 'bars' } = customization || {};
-            const scheme = getColorScheme(colorScheme);
-            const canvas = document.createElement('canvas');
-            const width = 1080;
-            const height = 1920;
-            canvas.width = width;
-            canvas.height = height;
-            const ctx = canvas.getContext('2d');
-
-            const gradient = ctx.createLinearGradient(0, 0, width, height);
-            gradient.addColorStop(0, scheme.background[0]);
-            gradient.addColorStop(1, scheme.background[1]);
-            ctx.fillStyle = gradient;
-            ctx.fillRect(0, 0, width, height);
-
-            ctx.save();
-            ctx.fillStyle = scheme.overlayShape;
-            for (let i = -width; i < width * 2; i += 180) {
-                ctx.beginPath();
-                ctx.ellipse(i, height * 0.3, 220, 80, Math.PI / 6, 0, Math.PI * 2);
-                ctx.fill();
-            }
-            ctx.restore();
-
-            const margin = 96;
-            const availableWidth = width - margin * 2;
-
-            const dishName = (review?.itemName || 'Mi resena favorita').toString();
-            const placeName = (place?.name || review?.establishmentName || 'Lugar especial').toString();
-            const listName = (list?.name || 'Mi ranking personal').toString();
-            const overallRating = Number.parseFloat(review?.overallRating ?? review?.overallScore ?? 0) || 0;
-
-            ctx.fillStyle = 'rgba(255,255,255,0.6)';
-            ctx.font = '500 36px "Poppins", "Helvetica Neue", Arial';
-            ctx.textAlign = 'left';
-            ctx.textBaseline = 'top';
-            ctx.fillText(listName, margin, 120);
-
-            ctx.fillStyle = '#ffffff';
-            ctx.font = '700 68px "Poppins", "Helvetica Neue", Arial';
-            let currentY = wrapText(ctx, dishName, margin, 180, availableWidth, 82);
-
-            ctx.fillStyle = 'rgba(255,255,255,0.85)';
-            ctx.font = '500 46px "Poppins", "Helvetica Neue", Arial';
-            currentY = wrapText(ctx, placeName, margin, currentY + 10, availableWidth, 60);
-
-            const imageHeight = 680;
-            const imageWidth = availableWidth;
-            const imageY = currentY + 20;
-            let imageDrawn = false;
-            if (review?.photoUrl) {
-                try {
-                    const img = await loadImageSafely(review.photoUrl);
-                    const scale = Math.min(imageWidth / img.width, imageHeight / img.height);
-                    const drawWidth = img.width * scale;
-                    const drawHeight = img.height * scale;
-                    const offsetX = margin + (imageWidth - drawWidth) / 2;
-                    const offsetY = imageY + (imageHeight - drawHeight) / 2;
-                    drawRoundedImage(ctx, img, offsetX, offsetY, drawWidth, drawHeight, 42);
-                    imageDrawn = true;
-                } catch (error) {
-                    console.warn('No se pudo cargar la imagen de la resena para la tarjeta.', error);
-                }
-            }
-
-            if (!imageDrawn) {
-                ctx.save();
-                drawRoundedRectPath(ctx, margin, imageY, imageWidth, imageHeight, 42);
-                ctx.clip();
-                const fallbackGradient = ctx.createLinearGradient(margin, imageY, margin + imageWidth, imageY + imageHeight);
-                fallbackGradient.addColorStop(0, scheme.fallbackGradient[0]);
-                fallbackGradient.addColorStop(1, scheme.fallbackGradient[1]);
-                ctx.fillStyle = fallbackGradient;
-                ctx.fillRect(margin, imageY, imageWidth, imageHeight);
-                ctx.restore();
-                ctx.save();
-                ctx.fillStyle = 'rgba(255,255,255,0.1)';
-                ctx.font = '600 48px "Poppins", "Helvetica Neue", Arial';
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'middle';
-                ctx.translate(width / 2, imageY + imageHeight / 2);
-                ctx.rotate(-Math.PI / 9);
-                ctx.fillText('LISTOPIC', 0, 0);
-                ctx.restore();
-            }
-
-            ctx.save();
-            drawRoundedRectPath(ctx, margin, imageY, imageWidth, imageHeight, 42);
-            ctx.clip();
-            const overlayGradient = ctx.createLinearGradient(0, imageY, 0, imageY + imageHeight);
-            overlayGradient.addColorStop(0, 'rgba(0,0,0,0)');
-            overlayGradient.addColorStop(1, 'rgba(0,0,0,0.35)');
-            ctx.fillStyle = overlayGradient;
-            ctx.fillRect(margin, imageY, imageWidth, imageHeight);
-            ctx.restore();
-
-            const badgeRadius = 72;
-            const badgeCenterX = margin + badgeRadius + 24;
-            const badgeCenterY = imageY + imageHeight - badgeRadius - 32;
-
-            const drawAuthorBadge = () => {
-                if (!authorPhoto && !authorInitials) {
-                    return;
-                }
-                ctx.save();
-                ctx.beginPath();
-                ctx.arc(badgeCenterX, badgeCenterY, badgeRadius + 10, 0, Math.PI * 2);
-                ctx.fillStyle = 'rgba(0,0,0,0.45)';
-                ctx.fill();
-                ctx.restore();
-
-                ctx.save();
-                ctx.beginPath();
-                ctx.arc(badgeCenterX, badgeCenterY, badgeRadius, 0, Math.PI * 2);
-                ctx.fillStyle = '#ffffff';
-                ctx.fill();
-                ctx.clip();
-                if (authorPhoto) {
-                    const scale = Math.max((badgeRadius * 2) / authorPhoto.width, (badgeRadius * 2) / authorPhoto.height);
-                    const drawWidth = authorPhoto.width * scale;
-                    const drawHeight = authorPhoto.height * scale;
-                    ctx.drawImage(authorPhoto, badgeCenterX - drawWidth / 2, badgeCenterY - drawHeight / 2, drawWidth, drawHeight);
-                } else {
-                    const avatarGradient = ctx.createLinearGradient(badgeCenterX - badgeRadius, badgeCenterY - badgeRadius, badgeCenterX + badgeRadius, badgeCenterY + badgeRadius);
-                    avatarGradient.addColorStop(0, scheme.accentPrimary);
-                    avatarGradient.addColorStop(1, scheme.accentTertiary);
-                    ctx.fillStyle = avatarGradient;
-                    ctx.fillRect(badgeCenterX - badgeRadius, badgeCenterY - badgeRadius, badgeRadius * 2, badgeRadius * 2);
-                }
-                ctx.restore();
-
-                ctx.save();
-                ctx.beginPath();
-                ctx.arc(badgeCenterX, badgeCenterY, badgeRadius, 0, Math.PI * 2);
-                ctx.lineWidth = 4;
-                ctx.strokeStyle = scheme.accentSecondary;
-                ctx.stroke();
-                ctx.restore();
-
-                if (!authorPhoto && authorInitials) {
-                    ctx.save();
-                    ctx.fillStyle = '#ffffff';
-                    ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
-                    ctx.textAlign = 'center';
-                    ctx.textBaseline = 'middle';
-                    ctx.fillText(authorInitials, badgeCenterX, badgeCenterY);
-                    ctx.restore();
-                }
-
-                const boxHeight = 72;
-                const textWidth = ctx.measureText(authorName).width;
-                let boxWidth = Math.min(420, Math.max(220, textWidth + 60));
-                let boxX = badgeCenterX + badgeRadius + 28;
-                const maxBoxX = margin + imageWidth - boxWidth - 24;
-                if (boxX > maxBoxX) {
-                    boxX = maxBoxX;
-                }
-                if (boxX < margin + badgeRadius * 2 + 32) {
-                    boxX = margin + badgeRadius * 2 + 32;
-                }
-                if (boxX + boxWidth > margin + imageWidth - 24) {
-                    boxWidth = margin + imageWidth - 24 - boxX;
-                }
-                const boxY = badgeCenterY - boxHeight / 2;
-
-                ctx.save();
-                drawRoundedRectPath(ctx, boxX, boxY, boxWidth, boxHeight, 28);
-                ctx.fillStyle = scheme.panelTint;
-                ctx.fill();
-                ctx.restore();
-
-                ctx.save();
-                ctx.textAlign = 'left';
-                ctx.fillStyle = scheme.textMuted;
-                ctx.font = '600 20px "Poppins", "Helvetica Neue", Arial';
-                ctx.fillText('Autor', boxX + 22, boxY + 20);
-                ctx.fillStyle = '#ffffff';
-                ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
-                ctx.textBaseline = 'bottom';
-                ctx.fillText(authorName, boxX + 22, boxY + boxHeight - 16);
-                ctx.restore();
-            };
-
-            drawAuthorBadge();
-
-            if (logoImage) {
-                const logoSize = 140;
-                const logoPadding = 28;
-                const logoX = margin + imageWidth - logoSize - logoPadding;
-                const logoY = imageY + logoPadding;
-                ctx.save();
-                drawRoundedRectPath(ctx, logoX - 18, logoY - 18, logoSize + 36, logoSize + 36, 24);
-                ctx.fillStyle = hexToRgba(scheme.accentSecondary, 0.18);
-                ctx.fill();
-                ctx.restore();
-
-                ctx.save();
-                ctx.globalAlpha = 0.9;
-                ctx.drawImage(logoImage, logoX, logoY, logoSize, logoSize);
-                ctx.restore();
-            }
-
-            currentY = imageY + imageHeight + 60;
-
-            const circleRadius = 150;
-            const circleCenterX = margin + circleRadius;
-            const circleCenterY = currentY + circleRadius;
-            ctx.save();
-            ctx.beginPath();
-            ctx.arc(circleCenterX, circleCenterY, circleRadius, 0, Math.PI * 2);
-            ctx.closePath();
-            ctx.fillStyle = scheme.metricFill;
-            ctx.fill();
-            ctx.lineWidth = 6;
-            ctx.strokeStyle = scheme.metricStroke;
-            ctx.stroke();
-            ctx.restore();
-
-            ctx.save();
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillStyle = '#ffffff';
-            ctx.font = '700 120px "Poppins", "Helvetica Neue", Arial';
-            ctx.fillText(overallRating.toFixed(1), circleCenterX, circleCenterY - 10);
-            ctx.font = '500 36px "Poppins", "Helvetica Neue", Arial';
-            ctx.fillStyle = 'rgba(255,255,255,0.75)';
-            ctx.fillText('Valoracion', circleCenterX, circleCenterY + 140);
-            ctx.restore();
-
-            const availableCriteria = [];
-            if (criteriaDefinitions && typeof criteriaDefinitions === 'object' && Object.keys(criteriaDefinitions).length > 0) {
-                for (const [key, definition] of Object.entries(criteriaDefinitions)) {
-                    if (review?.scores?.[key] === undefined) {
-                        continue;
-                    }
-                    const value = Number.parseFloat(review.scores[key]);
-                    if (!Number.isFinite(value)) {
-                        continue;
-                    }
-                    availableCriteria.push([key, definition]);
-                }
-            } else if (review?.scores) {
-                for (const key of Object.keys(review.scores)) {
-                    const value = Number.parseFloat(review.scores[key]);
-                    if (!Number.isFinite(value)) {
-                        continue;
-                    }
-                    availableCriteria.push([key, { label: key, min: 0, max: 10 }]);
-                }
-            }
-
-            const barsStartX = circleCenterX + circleRadius + 70;
-            const barsMaxWidth = width - barsStartX - margin;
-            const barHeight = 44;
-            const barGap = 88;
-
-            const drawBarsGraphic = (entries) => {
-                if (!entries.length) {
-                    return circleCenterY + circleRadius;
-                }
-                let index = 0;
-                let lastBottom = circleCenterY - circleRadius;
-                for (const [key, definition] of entries) {
-                    const raw = Number.parseFloat(review.scores[key]);
-                    const min = Number.parseFloat(definition?.min ?? 0);
-                    const max = Number.parseFloat(definition?.max ?? 10);
-                    const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
-                    const clamped = Math.max(0, Math.min(1, normalized));
-                    const barY = circleCenterY - circleRadius + index * barGap;
-                    ctx.fillStyle = scheme.barTrack;
-                    drawRoundedRectPath(ctx, barsStartX, barY, barsMaxWidth, barHeight, 20);
-                    ctx.fill();
-                    ctx.fillStyle = scheme.accentPrimary;
-                    drawRoundedRectPath(ctx, barsStartX, barY, Math.max(0, barsMaxWidth * clamped), barHeight, 20);
-                    ctx.fill();
-
-                    ctx.fillStyle = '#ffffff';
-                    ctx.font = '500 34px "Poppins", "Helvetica Neue", Arial';
-                    ctx.textAlign = 'left';
-                    ctx.textBaseline = 'middle';
-                    const label = (definition?.label || key).toString();
-                    ctx.fillText(label, barsStartX + 16, barY + barHeight / 2);
-
-                    ctx.textAlign = 'right';
-                    ctx.fillStyle = scheme.textMuted;
-                    ctx.fillText(raw.toFixed(1), barsStartX + barsMaxWidth - 16, barY + barHeight / 2);
-
-                    index += 1;
-                    lastBottom = barY + barHeight;
-                }
-                return lastBottom + 40;
-            };
-
-            const drawRadarGraphic = (entries) => {
-                const metricsAreaX = circleCenterX + circleRadius + 70;
-                const metricsAreaWidth = width - metricsAreaX - margin;
-                const centerX = metricsAreaX + metricsAreaWidth / 2;
-                const centerY = circleCenterY;
-                const radius = Math.min(metricsAreaWidth / 2, circleRadius * 1.7, 260);
-                const levels = 5;
-
-                ctx.save();
-                ctx.lineWidth = 1.5;
-                ctx.strokeStyle = scheme.radarGrid;
-                for (let step = 1; step <= levels; step += 1) {
-                    const ratio = step / levels;
-                    ctx.beginPath();
-                    entries.forEach(([key, definition], index) => {
-                        const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
-                        const x = centerX + Math.cos(angle) * radius * ratio;
-                        const y = centerY + Math.sin(angle) * radius * ratio;
-                        if (index === 0) {
-                            ctx.moveTo(x, y);
-                        } else {
-                            ctx.lineTo(x, y);
-                        }
-                    });
-                    ctx.closePath();
-                    ctx.stroke();
-                }
-
-                ctx.strokeStyle = scheme.radarAxis;
-                entries.forEach((entry, index) => {
-                    const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
-                    ctx.beginPath();
-                    ctx.moveTo(centerX, centerY);
-                    ctx.lineTo(centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius);
-                    ctx.stroke();
-                });
-
-                ctx.beginPath();
-                entries.forEach(([key, definition], index) => {
-                    const raw = Number.parseFloat(review.scores[key]);
-                    const min = Number.parseFloat(definition?.min ?? 0);
-                    const max = Number.parseFloat(definition?.max ?? 10);
-                    const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
-                    const clamped = Math.max(0, Math.min(1, normalized));
-                    const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
-                    const x = centerX + Math.cos(angle) * radius * clamped;
-                    const y = centerY + Math.sin(angle) * radius * clamped;
-                    if (index === 0) {
-                        ctx.moveTo(x, y);
-                    } else {
-                        ctx.lineTo(x, y);
-                    }
-                });
-                ctx.closePath();
-                ctx.fillStyle = hexToRgba(scheme.accentPrimary, 0.32);
-                ctx.fill();
-                ctx.lineWidth = 3;
-                ctx.strokeStyle = scheme.accentPrimary;
-                ctx.stroke();
-
-                entries.forEach(([key, definition], index) => {
-                    const raw = Number.parseFloat(review.scores[key]);
-                    const min = Number.parseFloat(definition?.min ?? 0);
-                    const max = Number.parseFloat(definition?.max ?? 10);
-                    const normalized = max > min ? (raw - min) / (max - min) : raw / 10;
-                    const clamped = Math.max(0, Math.min(1, normalized));
-                    const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
-                    const x = centerX + Math.cos(angle) * radius * clamped;
-                    const y = centerY + Math.sin(angle) * radius * clamped;
-                    ctx.beginPath();
-                    ctx.arc(x, y, 6, 0, Math.PI * 2);
-                    ctx.fillStyle = '#ffffff';
-                    ctx.fill();
-                });
-
-                entries.forEach(([key, definition], index) => {
-                    const raw = Number.parseFloat(review.scores[key]);
-                    const label = (definition?.label || key).toString();
-                    const angle = (Math.PI * 2 * index) / entries.length - Math.PI / 2;
-                    let textAlign = 'center';
-                    if (Math.cos(angle) > 0.2) {
-                        textAlign = 'left';
-                    } else if (Math.cos(angle) < -0.2) {
-                        textAlign = 'right';
-                    }
-                    const labelX = centerX + Math.cos(angle) * (radius + 36);
-                    const labelY = centerY + Math.sin(angle) * (radius + 36);
-                    ctx.textAlign = textAlign;
-                    ctx.textBaseline = 'middle';
-                    ctx.fillStyle = '#ffffff';
-                    ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
-                    ctx.fillText(label, labelX, labelY);
-                    ctx.fillStyle = scheme.textMuted;
-                    ctx.font = '400 24px "Poppins", "Helvetica Neue", Arial';
-                    ctx.fillText(raw.toFixed(1), labelX, labelY + 26);
-                });
-
-                ctx.restore();
-                return centerY + radius + 40;
-            };
-
-            let metricsBottom = circleCenterY + circleRadius;
-            if (graphicStyle === 'radar' && availableCriteria.length >= 3) {
-                metricsBottom = Math.max(metricsBottom, drawRadarGraphic(availableCriteria.slice(0, 6)));
-            } else {
-                metricsBottom = Math.max(metricsBottom, drawBarsGraphic(availableCriteria.slice(0, 4)));
-            }
-
-            currentY = metricsBottom + 60;
-
-            let comment = (review?.comment || '').toString().trim();
-            if (comment.length > 280) comment = `${comment.slice(0, 277)}…`;
-            if (comment) {
-                ctx.fillStyle = '#ffffff';
-                ctx.textAlign = 'left';
-                ctx.textBaseline = 'top';
-                ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
-                ctx.fillText('Notas rapidas', margin, currentY);
-                ctx.font = '400 34px "Poppins", "Helvetica Neue", Arial';
-                currentY = wrapText(ctx, `“${comment}”`, margin, currentY + 56, availableWidth, 48);
-            }
-
-            ctx.fillStyle = scheme.textMuted;
-            ctx.font = '500 30px "Poppins", "Helvetica Neue", Arial';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText('Comparte tu ranking en Listopic', width / 2, height - 200);
-            ctx.font = '600 42px "Poppins", "Helvetica Neue", Arial';
-            ctx.fillStyle = '#ffffff';
-            ctx.fillText('listopic.app', width / 2, height - 140);
-
-            const blob = await new Promise((resolve, reject) => {
-                canvas.toBlob(result => {
-                    if (result) resolve(result);
-                    else reject(new Error('No se pudo generar la tarjeta.'));
-                }, 'image/png');
-            });
-
-            return { blob };
+            setShareStatus('Personaliza la tarjeta y compártela en Instagram Stories.', 'info');
         }
 
         async function handleShareClick() {
             if (!shareButton) return;
             if (!shareAssetsReady) {
-                setShareStatus('Estamos preparando los datos de tu resena…', 'info');
+                setShareStatus('Estamos preparando los datos de tu reseña…', 'info');
                 return;
             }
 
             toggleShareLoading(true);
-            setShareStatus('Generando tu tarjeta para Instagram…', 'info');
+                const fileName = `listopic-story-${shareContext.review?.id || 'reseña'}.png`;
+                const shareTitle = `Mi reseña en ${shareContext.place?.name || shareContext.review?.establishmentName || 'Listopic'}`;
+                    ? `${shareContext.review?.itemName || 'Mi reseña'} - ${ratingLabel} en Listopic`
+                    : `${shareContext.review?.itemName || 'Mi reseña'} en Listopic`;
+                        setShareStatus('¡Listo! Si Instagram no se abre automáticamente, revisa tu galería para encontrar la tarjeta.', 'success');
+                            console.warn('El uso de la API de compartir falló, se ofrecerá descarga manual.', shareError);
+                            setShareStatus('No pudimos abrir Instagram automáticamente. Descarga la tarjeta y súbela manualmente.', 'info');
+                    setShareStatus('Descargamos la tarjeta. Súbela como historia desde tu galería.', 'info');
+                    showNotification('Tarjeta preparada. Completa la publicación en Instagram.', 'success');
+                setShareStatus('No pudimos generar la tarjeta. Inténtalo nuevamente.', 'error');
+                return `${rating.toFixed(1)} ⭐`;
 
-            try {
-                const { blob } = await createInstagramStoryCard(shareContext, state.currentListCriteriaDefinitions || {}, shareCustomization);
-                const fileName = `listopic-story-${shareContext.review?.id || 'resena'}.png`;
-                const file = new File([blob], fileName, { type: 'image/png' });
-                const shareTitle = `Mi resena en ${shareContext.place?.name || shareContext.review?.establishmentName || 'Listopic'}`;
-                const ratingLabel = overallRatingLabel(shareContext.review);
-                const shareText = ratingLabel
-                    ? `${shareContext.review?.itemName || 'Mi resena'} - ${ratingLabel} en Listopic`
-                    : `${shareContext.review?.itemName || 'Mi resena'} en Listopic`;
-
-                let shared = false;
-                let canUseWebShare = false;
-                if (navigator.canShare) {
-                    try {
-                        canUseWebShare = navigator.canShare({ files: [file] });
-                    } catch (shareCapabilityError) {
+            setShareStatus('Preparando datos de tu reseña para compartir…', 'info');
+            const errorMsg = "Error: Falta ID de reseña o ID de lista en la URL.";
+        // 1. Obtener la reseña
+                if (!reviewDoc.exists) throw new Error(`Reseña no encontrada.`);
+                // Mostrar datos básicos de la reseña
+                        detailImageEl.alt = `Foto de ${uiUtils.escapeHtml(reviewDataGlobal.itemName || 'reseña')}`;
                         console.warn('El navegador no permite compartir archivos directamente.', shareCapabilityError);
                         canUseWebShare = false;
                     }
@@ -831,7 +927,7 @@ ListopicApp.pageDetailView = (() => {
             if (!review) return '';
             const rating = Number.parseFloat(review.overallRating ?? review.overallScore);
             if (Number.isFinite(rating)) {
-                return `${rating.toFixed(1)} ⭐️`;
+                return `${rating.toFixed(1)} â­ï¸`;
             }
             return '';
         }
@@ -853,7 +949,7 @@ ListopicApp.pageDetailView = (() => {
             shareButton.disabled = true;
             shareButton.setAttribute('aria-busy', 'true');
             shareButton.addEventListener('click', handleShareClick);
-            setShareStatus('Preparando datos de tu resena para compartir…', 'info');
+            setShareStatus('Preparando datos de tu resena para compartirâ€¦', 'info');
         }
 
         // Configurar boton de Volver
@@ -983,7 +1079,7 @@ ListopicApp.pageDetailView = (() => {
                      detailRatingsListEl.innerHTML = '<li>No hay valoraciones detalladas disponibles.</li>';
                 }
 
-                // 3. Obtener datos del autor de la resena
+                // 3. Obtener datos del autor de la reseña
                 if (reviewDataGlobal.userId && reviewAuthorNameEl) {
                     return db.collection('users').doc(reviewDataGlobal.userId).get(); // Esto devuelve una promesa
                 } else {
@@ -1006,10 +1102,10 @@ ListopicApp.pageDetailView = (() => {
                     }
                 } else if (reviewDataGlobal.userId && reviewAuthorNameEl) { 
                     reviewAuthorNameEl.textContent = 'Usuario Desconocido';
-                    console.warn(`Autor de resena con ID ${reviewDataGlobal.userId} no encontrado.`);
+                    console.warn(`Autor de reseña con ID ${reviewDataGlobal.userId} no encontrado.`);
                 }
                 
-                // 4. Si la resena tiene placeId, obtener datos del lugar
+                // 4. Si la reseña tiene placeId, obtener datos del lugar
                 if (reviewDataGlobal && reviewDataGlobal.placeId) {
                     return db.collection('places').doc(reviewDataGlobal.placeId).get(); // Esto devuelve una promesa
                 } else {
@@ -1028,7 +1124,7 @@ ListopicApp.pageDetailView = (() => {
                     placeData = placeDocOrNull.data();
                     if (detailEstablishmentNameEl) detailEstablishmentNameEl.textContent = placeData.name || "Nombre de lugar desconocido";
                     
-                    if (detailImageEl && detailImageEl.alt === `Foto de resena`) {
+                    if (detailImageEl && detailImageEl.alt === `Foto de reseña`) {
                          detailImageEl.alt = `Foto de ${uiUtils.escapeHtml(reviewDataGlobal.itemName || placeData.name)}`;
                     }
 
@@ -1056,7 +1152,7 @@ ListopicApp.pageDetailView = (() => {
                     }
                 } else if (reviewDataGlobal && reviewDataGlobal.placeId) {
                     if (detailEstablishmentNameEl) detailEstablishmentNameEl.textContent = "Lugar no encontrado en BD";
-                    console.warn(`Lugar con ID ${reviewDataGlobal.placeId} no encontrado para la resena ${reviewId}`);
+                    console.warn(`Lugar con ID ${reviewDataGlobal.placeId} no encontrado para la reseña ${reviewId}`);
                     if (detailLocationContainerEl) detailLocationContainerEl.style.display = 'none';
                     if (detailNoLocationDivEl) detailNoLocationDivEl.style.display = 'flex';
                 }
@@ -1083,13 +1179,13 @@ ListopicApp.pageDetailView = (() => {
         if (deleteButton) {
             deleteButton.addEventListener('click', async () => {
                 if (!reviewId || !listIdFromURL) {
-                    ListopicApp.services.showNotification("No se puede eliminar: falta informacion.", "error");
+                    ListopicApp.services.showNotification("No se puede eliminar: falta información.", "error");
                     return;
                 }
-                if (confirm('�?Estas seguro de que quieres eliminar esta resena?')) {
+                if (confirm('¿Estás seguro de que quieres eliminar esta reseña?')) {
                     try {
                         await db.collection('lists').doc(listIdFromURL).collection('reviews').doc(reviewId).delete();
-                        ListopicApp.services.showNotification('Resena eliminada.', 'success');
+                        ListopicApp.services.showNotification('Reseña eliminada.', 'success');
                         
                         // Redirigir
                         const fromPlaceIdParam = params.get('fromPlaceId');

--- a/public/style.css
+++ b/public/style.css
@@ -8401,6 +8401,75 @@ body.chat-list-modal-open {
     overflow-y: auto;
 }
 
+.review-share-modal__section--story {
+    margin-top: 24px;
+    padding: 18px 20px;
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--border-color);
+    background: var(--container-alt-bg, rgba(255, 255, 255, 0.02));
+}
+
+.review-share-modal__story-description {
+    margin: 0 0 14px;
+    font-size: 0.92rem;
+    color: var(--secondary-text-color);
+}
+
+.review-share-modal__story-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.review-share-modal__story-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    align-self: center;
+}
+
+.review-share-modal__story-select {
+    width: 100%;
+    padding: 10px 12px;
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--border-color);
+    background: var(--input-bg, var(--container-bg));
+    color: var(--text-color);
+}
+
+.review-share-modal__story-select:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 1px;
+}
+
+.review-share-modal__story-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.review-share-story-download {
+    text-decoration: none;
+}
+
+.review-share-modal__story-feedback {
+    margin-top: 10px;
+    font-size: 0.9rem;
+}
+
+.review-share-modal__story-feedback[data-type="success"] {
+    color: var(--accent-color-tertiary);
+}
+
+.review-share-modal__story-feedback[data-type="error"] {
+    color: var(--danger-color);
+}
+
+.review-share-modal__story-feedback[data-type="warning"] {
+    color: var(--accent-color-secondary);
+}
+
 .review-share-chat-btn {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- expose a reusable `ListopicApp.storyShare` module from the detail view that prepares Firestore context and renders Instagram story cards with multiple themes
- extend the global share modal to surface story customization controls, generator triggers, and download handling with polished feedback messaging
- style the new story-sharing block and harden Firebase Functions initialization so the compat bundle can finish loading before use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d5706ac0832693e5962afb751aea