### PR TITLE
Improve Firestore security and enrich search filters

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,8 +76,8 @@ service cloud.firestore {
 
       match /reviews/{reviewId} {
         allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
-        // El autor de la reseña O un jefe pueden editar o borrarla.
-        allow update, delete: if request.auth != null && (resource.data.userId == request.auth.uid || isJefe(request.auth.uid)); // <-- CAMBIO: Añadido permiso para jefe.
+        // Solo el autor de la reseña puede modificarla o eliminarla.
+        allow update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
       }
 
       match /comments/{commentId} {

--- a/functions/modules/core.js
+++ b/functions/modules/core.js
@@ -11,6 +11,71 @@ const { buildGroupedItemsForList } = require("./grouped-aggregator");
 
 const db = getFirestore();
 
+const VALID_HTTPS_ERROR_CODES = new Set([
+  'ok',
+  'cancelled',
+  'unknown',
+  'invalid-argument',
+  'deadline-exceeded',
+  'not-found',
+  'already-exists',
+  'permission-denied',
+  'resource-exhausted',
+  'failed-precondition',
+  'aborted',
+  'out-of-range',
+  'unimplemented',
+  'internal',
+  'unavailable',
+  'data-loss',
+  'unauthenticated'
+]);
+
+const FRIENDLY_ERROR_MESSAGES = Object.freeze({
+  'permission-denied': 'No tienes permisos para realizar esta acción.',
+  'already-exists': 'Ya existe un recurso con estos datos.',
+  'not-found': 'El recurso solicitado no está disponible.',
+  'resource-exhausted': 'Has alcanzado el límite de esta operación. Inténtalo más tarde.',
+  'deadline-exceeded': 'La operación tardó demasiado en completarse. Inténtalo de nuevo.',
+  'unavailable': 'El servicio no está disponible temporalmente. Inténtalo nuevamente en unos minutos.'
+});
+
+function normalizeHttpsErrorCode(code, fallback = 'internal') {
+  if (!code || typeof code !== 'string') {
+      return fallback;
+  }
+  const normalized = code.toLowerCase();
+  return VALID_HTTPS_ERROR_CODES.has(normalized) ? normalized : fallback;
+}
+
+function buildHttpsErrorFrom(error, fallbackMessage, fallbackCode = 'internal') {
+  if (!error) {
+      return new HttpsError(fallbackCode, fallbackMessage);
+  }
+  if (error instanceof HttpsError) {
+      return error;
+  }
+
+  const normalizedCode = normalizeHttpsErrorCode(error.code, fallbackCode);
+  const message = FRIENDLY_ERROR_MESSAGES[normalizedCode] || fallbackMessage;
+
+  const details = {};
+  if (error.message) {
+      details.originalMessage = error.message;
+  }
+  if (error.status) {
+      details.httpStatus = error.status;
+  }
+  if (error.response?.status) {
+      details.httpStatus = error.response.status;
+  }
+  if (error.response?.data) {
+      details.responseData = error.response.data;
+  }
+
+  return new HttpsError(normalizedCode, message, Object.keys(details).length ? details : undefined);
+}
+
 // Helper: fetch place docs by IDs in chunks of 10 (Firestore 'in' limit)
 async function getPlaceDocsByIds(ids) {
   if (!ids || ids.length === 0) return [];
@@ -442,10 +507,10 @@ const deleteOrOrphanList = onCall({cors: true}, async (request) => {
 
   } catch (error) {
       logger.error(`Error en deleteOrOrphanList para lista ${listId} y usuario ${callerUserId}:`, error);
-      if (error.code) { // Si ya es un HttpsError, lo relanzamos.
-          throw error;
-      }
-      throw new HttpsError('internal', 'OcurriÃƒÂ³ un error inesperado.');
+      throw buildHttpsErrorFrom(
+          error,
+          'No pudimos completar la acción solicitada en este momento. Inténtalo de nuevo más tarde.'
+      );
   }
 });
 
@@ -499,10 +564,10 @@ const createList = onCall(async (data, context) => {
 
     } catch (error) {
         logger.error(`Error en createList para el usuario ${userId} al intentar crear lista "${listName}":`, error, {structuredData: true});
-        if (error.code && typeof error.code === 'string' && error.message) { // Re-lanzar HttpsError
-            throw error;
-        }
-        throw new HttpsError('internal', 'OcurriÃƒÂ³ un error al crear la lista.', error.message);
+        throw buildHttpsErrorFrom(
+            error,
+            'No pudimos crear la lista en este momento. Inténtalo de nuevo más tarde.'
+        );
     }
 });
 
@@ -555,10 +620,10 @@ const createListWithValidation = onCall(async (request) => {
 
   } catch (error) {
       logger.error(`Error en createListWithValidation para usuario ${userId}, lista "${listName}":`, error);
-      if (error.code) {
-           throw error;
-      }
-      throw new HttpsError('internal', 'OcurriÃƒÂ³ un error al crear la lista.');
+      throw buildHttpsErrorFrom(
+          error,
+          'No pudimos crear la lista en este momento. Inténtalo de nuevo más tarde.'
+      );
   }
 });
 
@@ -613,11 +678,10 @@ const updateListWithValidation = onCall(async (request) => {
 
   } catch (error) {
       logger.error(`Error en updateListWithValidation para lista ${listId} por usuario ${userId}:`, error);
-      // Si el error ya es un HttpsError, lo relanzamos. Si no, devolvemos uno genÃƒÂ©rico.
-      if (error.code) {
-          throw error;
-      }
-      throw new HttpsError('internal', 'OcurriÃƒÂ³ un error al actualizar la lista.');
+      throw buildHttpsErrorFrom(
+          error,
+          'No pudimos actualizar la lista en este momento. Inténtalo nuevamente más tarde.'
+      );
   }
 });
 

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -322,6 +322,128 @@ ListopicApp.pageSearch = (() => {
             }
             return;
         }
+        const categories = Array.from(categorySet);
+        const hasCachedLists = categories.some((categoryId) => Array.isArray(state.listsCacheByCategory[categoryId]));
+        if (!hasCachedLists) {
+            return;
+        }
+        const allowed = new Set();
+        categories.forEach((categoryId) => {
+            const cached = state.listsCacheByCategory[categoryId];
+            if (Array.isArray(cached)) {
+                cached.forEach((list) => {
+                    if (list && list.id) {
+                        allowed.add(list.id);
+                    }
+                });
+            }
+        });
+        if (allowed.size === 0) {
+            return;
+        }
+        Array.from(listSet).forEach((listId) => {
+            if (!allowed.has(listId)) {
+                listSet.delete(listId);
+            }
+        });
+    }
+
+
+    function getSelectedItemCategoryIds() {
+        const categorySet = state.filters?.items?.categories;
+        if (!(categorySet instanceof Set) || categorySet.size === 0) {
+            return [];
+        }
+        return Array.from(categorySet);
+    }
+
+    function isLoadingListsForCategories(categoryIds) {
+        if (!Array.isArray(categoryIds) || categoryIds.length === 0) {
+            return false;
+        }
+        return categoryIds.some((categoryId) => Boolean(state.listsLoadingByCategory[categoryId]));
+    }
+
+    async function ensureListsForCategories(categoryIds) {
+        if (!Array.isArray(categoryIds) || categoryIds.length === 0) {
+            return;
+        }
+        const db = ListopicApp.services?.db;
+        if (!db) {
+            console.warn("page-search: Firestore no disponible para cargar listas por categoría.");
+            return;
+        }
+        const pendingPromises = categoryIds.map((categoryId) => {
+            if (Array.isArray(state.listsCacheByCategory[categoryId])) {
+                return null;
+            }
+            if (state.listsLoadingByCategory[categoryId]) {
+                return state.listsLoadingByCategory[categoryId];
+            }
+            const query = db
+                .collection("lists")
+                .where("categoryId", "==", categoryId)
+                .where("isPublic", "==", true)
+                .orderBy("followersCount", "desc")
+                .limit(50)
+                .get()
+                .then((snapshot) => {
+                    const lists = [];
+                    snapshot.forEach((doc) => {
+                        const data = doc.data() || {};
+                        const entry = {
+                            id: doc.id,
+                            name: data.name || "Lista sin nombre",
+                            followersCount: typeof data.followersCount === "number" ? data.followersCount : 0,
+                            reviewCount: typeof data.reviewCount === "number" ? data.reviewCount : 0,
+                            categoryId
+                        };
+                        state.listNameById[doc.id] = entry.name;
+                        lists.push(entry);
+                    });
+                    state.listsCacheByCategory[categoryId] = lists;
+                })
+                .catch((error) => {
+                    console.warn(`page-search: no se pudieron cargar las listas para la categoría ${categoryId}.`, error);
+                    state.listsCacheByCategory[categoryId] = [];
+                })
+                .finally(() => {
+                    delete state.listsLoadingByCategory[categoryId];
+                });
+            state.listsLoadingByCategory[categoryId] = query;
+            return query;
+        }).filter(Boolean);
+        if (pendingPromises.length === 0) {
+            return;
+        }
+        await Promise.allSettled(pendingPromises);
+    }
+
+    function getListsForSelectedCategories() {
+        const categories = getSelectedItemCategoryIds();
+        if (categories.length === 0) {
+            return [];
+        }
+        const listMap = new Map();
+        categories.forEach((categoryId) => {
+            const cached = state.listsCacheByCategory[categoryId];
+            if (!Array.isArray(cached)) {
+                return;
+            }
+            cached.forEach((list) => {
+                if (list && list.id && !listMap.has(list.id)) {
+                    listMap.set(list.id, list);
+                }
+            });
+        });
+        return Array.from(listMap.values()).sort((a, b) => {
+            const followersA = typeof a.followersCount === "number" ? a.followersCount : 0;
+            const followersB = typeof b.followersCount === "number" ? b.followersCount : 0;
+            if (followersA === followersB) {
+                return (b.reviewCount || 0) - (a.reviewCount || 0);
+            }
+            return followersB - followersA;
+        });
     }
 
 
@@ -540,7 +662,7 @@ ListopicApp.pageSearch = (() => {
         const definitions = FILTER_DEFINITIONS[type] || [];
         const facetFilters = [];
         definitions.forEach((definition) => {
-            if (definition.type !== "facet" && definition.type !== "categoryTags") {
+            if (definition.type !== "facet" && definition.type !== "categoryTags" && definition.type !== "listSelector") {
                 return;
             }
             const selected = state.filters[type][definition.stateKey];
@@ -609,7 +731,7 @@ ListopicApp.pageSearch = (() => {
         let total = 0;
         definitions.forEach((definition) => {
             const value = state.filters[type][definition.stateKey];
-            if ((definition.type === "facet" || definition.type === "categoryTags") && value instanceof Set) {
+            if ((definition.type === "facet" || definition.type === "categoryTags" || definition.type === "listSelector") && value instanceof Set) {
                 total += value.size;
             } else if (definition.type === "numeric" && value !== null && value !== undefined) {
                 total += 1;
@@ -671,6 +793,15 @@ ListopicApp.pageSearch = (() => {
         if (currentType === "items") {
             sanitizeItemBaseTags();
             sanitizeItemLists();
+            const selectedCategories = getSelectedItemCategoryIds();
+            if (selectedCategories.length > 0) {
+                try {
+                    await ensureListsForCategories(selectedCategories);
+                    sanitizeItemLists();
+                } catch (error) {
+                    console.warn("page-search: no se pudieron preparar las listas para los filtros.", error);
+                }
+            }
         }
 
         const hasActiveFilters = currentType !== "all" && countActiveFilters(currentType) > 0;
@@ -821,6 +952,8 @@ ListopicApp.pageSearch = (() => {
                 fragment.appendChild(createNumericSection(type, definition));
             } else if (definition.type === "categoryTags") {
                 fragment.appendChild(createCategoryTagsSection(type, definition));
+            } else if (definition.type === "listSelector") {
+                fragment.appendChild(createListSelectorSection(type, definition));
             } else if (definition.type === "range") {
                 fragment.appendChild(createRangeSection(type, definition));
             }
@@ -891,7 +1024,7 @@ ListopicApp.pageSearch = (() => {
             checkbox.type = "checkbox";
             checkbox.value = value;
             checkbox.checked = selectedSet.has(value);
-            checkbox.addEventListener("change", () => {
+            checkbox.addEventListener("change", async () => {
                 if (checkbox.checked) {
                     selectedSet.add(value);
                 } else {
@@ -900,6 +1033,14 @@ ListopicApp.pageSearch = (() => {
                 if (type === "items") {
                     if (definition.attribute === "listCategoryId") {
                         sanitizeItemBaseTags();
+                        try {
+                            const categoriesToLoad = getSelectedItemCategoryIds();
+                            if (categoriesToLoad.length > 0) {
+                                await ensureListsForCategories(categoriesToLoad);
+                            }
+                        } catch (error) {
+                            console.warn("page-search: no se pudieron actualizar las listas para las categorías seleccionadas.", error);
+                        }
                         sanitizeItemLists();
                     } else if (definition.attribute === "listName") {
                         sanitizeItemLists();
@@ -999,6 +1140,101 @@ ListopicApp.pageSearch = (() => {
 
             option.appendChild(checkbox);
             option.appendChild(labelSpan);
+            optionsWrapper.appendChild(option);
+        });
+
+        return container;
+    }
+
+    function createListSelectorSection(type, definition) {
+        const container = document.createElement("div");
+        container.className = "filter-block";
+
+        const title = document.createElement("h3");
+        title.className = "filter-block__title";
+        title.textContent = definition.label;
+        container.appendChild(title);
+
+        const categories = getSelectedItemCategoryIds();
+        if (categories.length === 0) {
+            const empty = document.createElement("p");
+            empty.className = "filter-block__empty";
+            empty.textContent = "Selecciona una categoría para elegir sus listas destacadas.";
+            container.appendChild(empty);
+            return container;
+        }
+
+        const pending = categories.filter((categoryId) => !Array.isArray(state.listsCacheByCategory[categoryId]));
+        if (pending.length > 0) {
+            ensureListsForCategories(pending)
+                .then(() => {
+                    if (state.currentEntityType === type) {
+                        renderFiltersPanel(type);
+                    }
+                })
+                .catch((error) => {
+                    console.warn("page-search: error al cargar las listas para los filtros de items.", error);
+                });
+        }
+
+        if (pending.length > 0 && isLoadingListsForCategories(pending)) {
+            const loading = document.createElement("p");
+            loading.className = "filter-block__empty";
+            loading.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Cargando listas disponibles...';
+            container.appendChild(loading);
+            return container;
+        }
+
+        const availableLists = getListsForSelectedCategories();
+        if (availableLists.length === 0) {
+            const empty = document.createElement("p");
+            empty.className = "filter-block__empty";
+            empty.textContent = "Todavía no hay listas públicas en las categorías seleccionadas.";
+            container.appendChild(empty);
+            return container;
+        }
+
+        let selectedSet = state.filters[type][definition.stateKey];
+        if (!(selectedSet instanceof Set)) {
+            selectedSet = new Set();
+            state.filters[type][definition.stateKey] = selectedSet;
+        }
+
+        const optionsWrapper = document.createElement("div");
+        optionsWrapper.className = "filter-block__options";
+        container.appendChild(optionsWrapper);
+
+        availableLists.slice(0, 40).forEach((list) => {
+            const option = document.createElement("label");
+            option.className = "filter-option";
+
+            const checkbox = document.createElement("input");
+            checkbox.type = "checkbox";
+            checkbox.value = list.id;
+            checkbox.checked = selectedSet.has(list.id);
+            checkbox.addEventListener("change", () => {
+                if (checkbox.checked) {
+                    selectedSet.add(list.id);
+                } else {
+                    selectedSet.delete(list.id);
+                }
+                performSearch();
+            });
+
+            const labelSpan = document.createElement("span");
+            labelSpan.className = "filter-option__label";
+            const listName = list.name || state.listNameById[list.id] || "Lista sin nombre";
+            labelSpan.textContent = listName;
+            labelSpan.title = listName;
+
+            const countSpan = document.createElement("span");
+            countSpan.className = "filter-option__count";
+            const followers = typeof list.followersCount === "number" ? list.followersCount : 0;
+            countSpan.textContent = followers > 0 ? followers.toLocaleString("es-ES") : "—";
+
+            option.appendChild(checkbox);
+            option.appendChild(labelSpan);
+            option.appendChild(countSpan);
             optionsWrapper.appendChild(option);
         });
 


### PR DESCRIPTION
## Summary
- restrict Firestore review updates/deletes to the original author to close an authorization gap
- add a reusable HTTPS error helper and surface clearer messages from list Cloud Functions
- wire advanced search filters to load category lists, sanitize selections, and apply list-based filters in Algolia queries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3820954688326ba3d94a920820f41