### PR TITLE
Align header icons and update profile menu

### DIFF
--- a/public/chats.html
+++ b/public/chats.html
@@ -41,22 +41,22 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
         </div>
         <div class="header-right-actions">
-            <a href="search.html" id="search-link-button" class="header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats" aria-current="page">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -68,14 +68,14 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
                     <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
                         <i class="fas fa-download"></i> Instalar Aplicación
                     </button>
@@ -84,9 +84,10 @@
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
 
     <main>

--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -49,7 +49,7 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
@@ -62,15 +62,15 @@
 
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -82,21 +82,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <!-- ***** -->
 

--- a/public/developer.html
+++ b/public/developer.html
@@ -24,18 +24,18 @@
 </head>
 <body>
     <div class="header-actions-container">
-        <div class="header-left-content"> <div class="app-logo-container"><a href="Index.html" title="Ir a la página de inicio"><img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo"></a></div> </div>
+        <div class="header-left-content"> <div class="app-logo-container"><a href="index.html" title="Ir a la página de inicio"><img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo"></a></div> </div>
         <div class="header-right-actions">
-            <a href="search.html" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+            <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -44,22 +44,29 @@
                     <div class="notifications-list" id="notifications-list" hidden></div>
                 </div>
             </div>
+
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
-                    <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
 
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
+                    <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <main class="dev-container">
         <h1><i class="fas fa-tools"></i> Panel de Desarrollador</h1>

--- a/public/grouped-detail-view.html
+++ b/public/grouped-detail-view.html
@@ -48,7 +48,7 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
@@ -61,15 +61,15 @@
 
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -81,21 +81,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <!-- ***** -->
 

--- a/public/index.html
+++ b/public/index.html
@@ -31,22 +31,22 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
         </div>
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -58,13 +58,12 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
 
                     <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
@@ -75,9 +74,10 @@
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
 
     <main>

--- a/public/list-form.html
+++ b/public/list-form.html
@@ -86,7 +86,7 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
@@ -100,18 +100,18 @@
         <div class="header-right-actions">
             <!-- Add forum button -->
             <button id="forum-button" class="forum-button header-action-button" aria-label="Foro de la lista" title="Foro de la lista">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
             </button>
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -123,21 +123,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <!-- ***** -->
 

--- a/public/list-view.html
+++ b/public/list-view.html
@@ -57,7 +57,7 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
@@ -71,18 +71,18 @@
         <div class="header-right-actions">
             <!-- Add forum button -->
             <button id="forum-button" class="forum-button header-action-button" aria-label="Foro de la lista" title="Foro de la lista">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
             </button>
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -94,21 +94,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <!-- ***** -->
 

--- a/public/place-detail.html
+++ b/public/place-detail.html
@@ -17,22 +17,22 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
         </div>
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -44,19 +44,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
 
     <main>

--- a/public/profile.html
+++ b/public/profile.html
@@ -42,23 +42,22 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
         </div>
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
- 
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -70,20 +69,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
                     <a href="chats.html" role="menuitem">Chats</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Mis Listas</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
 
     <main>
@@ -146,7 +151,10 @@
                         <p class="loading-placeholder">Cargando reseñas...</p>
                     </div>
                 </div>
-                <div id="lists-content" class="profile-tab-content">\n                     <div class="list-toggle" id="lists-toggle-main" style="display:flex;gap:8px;margin:8px 0 12px;"></div>\n                     <ul id="my-lists-ul" class="profile-item-list">
+                <div id="lists-content" class="profile-tab-content">
+                    <div id="guardado" class="anchor-offset-target" aria-hidden="true"></div>
+                    <div class="list-toggle" id="lists-toggle-main" style="display:flex;gap:8px;margin:8px 0 12px;"></div>
+                    <ul id="my-lists-ul" class="profile-item-list">
                         <li class="loading-placeholder">Cargando listas...</li>
                     </ul>
                 </div>

--- a/public/review-form.html
+++ b/public/review-form.html
@@ -29,7 +29,7 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
@@ -42,16 +42,15 @@
 
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
-
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -63,21 +62,26 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
+
+                    <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
+                        <i class="fas fa-download"></i> Instalar Aplicación
+                    </button>
+
                     <button type="button" role="menuitem" id="logoutBtnUserMenu">Cerrar sesión</button>
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
     <!-- ***** -->
 

--- a/public/search.html
+++ b/public/search.html
@@ -15,22 +15,22 @@
     <div class="header-actions-container">
         <div class="header-left-content">
             <div class="app-logo-container">
-                <a href="Index.html" title="Ir a la página de inicio">
+                <a href="index.html" title="Ir a la página de inicio">
                     <img src="img/listopic-logo.png" alt="Listopic Logo" class="app-logo">
                 </a>
             </div>
         </div>
         <div class="header-right-actions">
             <a href="search.html" id="search-link-button" class="search-button header-action-button icon-with-badge" aria-label="Buscar">
-                <i class="fas fa-search"></i>
+                <i class="fas fa-search" aria-hidden="true"></i>
             </a>
             <a href="chats.html" id="chats-link-button" class="header-action-button icon-with-badge" aria-label="Chats">
-                <i class="fas fa-comments"></i>
+                <i class="fas fa-comments" aria-hidden="true"></i>
                 <span class="badge-indicator" id="chats-badge" hidden></span>
             </a>
             <div class="header-icon-group">
                 <button id="notifications-button" class="header-action-button icon-with-badge" aria-label="Notificaciones" aria-expanded="false" aria-haspopup="true">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-bell" aria-hidden="true"></i>
                     <span class="badge-indicator" id="notifications-badge" hidden></span>
                 </button>
                 <div id="notifications-dropdown" class="notifications-dropdown" role="menu" aria-hidden="true">
@@ -42,13 +42,12 @@
 
             <div class="user-profile-menu-container">
                 <button class="user-profile-button header-action-button" id="userProfileBtn" aria-label="Menú de usuario" aria-expanded="false" aria-controls="userMenuDropdown">
-                    <i class="fas fa-user-circle"></i>
+                    <i class="fas fa-user-circle" aria-hidden="true"></i>
                 </button>
                 <div class="user-menu" id="userMenuDropdown" role="menu" aria-labelledby="userProfileBtn">
                     <a href="profile.html" role="menuitem">Perfil</a>
-                    <a href="profile.html#profile-email" role="menuitem">Datos</a>
-                    <a href="profile.html#profile-my-lists" role="menuitem">Listas</a>
-                    <a href="profile.html#profile-my-reviews" role="menuitem">Reviews</a>
+                    <a href="chats.html" role="menuitem">Chats</a>
+                    <a href="profile.html#guardado" role="menuitem">Guardado</a>
                     <hr class="user-menu-divider">
 
                     <button type="button" role="menuitem" id="installPwaBtn" style="display: none;">
@@ -59,9 +58,10 @@
                 </div>
             </div>
             <button id="theme-toggle-button" class="theme-toggle-button header-action-button" title="Cambiar tema">
-                <i class="fas fa-moon"></i>
+                <i class="fas fa-moon" aria-hidden="true"></i>
             </button>
         </div>
+
     </div>
 
     <main>

--- a/public/style.css
+++ b/public/style.css
@@ -54,6 +54,8 @@
     --header-gradient-opacity-top: 0.05;
     --header-noise-opacity: 0.02;
     --header-height: 50px;
+    --header-action-button-size: 44px;
+    --header-action-icon-size: 1.2em;
 }
 
 /* --- TEMA CLARO REFINADO --- */
@@ -1099,7 +1101,7 @@ body.light-theme .user-menu {
   border-color: #D1D5DB;
   box-shadow: 0 8px 20px rgba(0,0,0,0.1);
 }
-body.light-theme .user-menu a, 
+body.light-theme .user-menu a,
 body.light-theme .user-menu button {
   color: var(--text-color);
 }
@@ -1143,27 +1145,7 @@ body.light-theme .modal-content {
 
 /* --- Estilos para el botÃ³n de cambio de tema --- */
 .theme-toggle-button {
-  /*position: fixed;
-  top: 15px;
-  right: 15px;
-  background-color: var(--container-bg); /* Usa el color de fondo de los contenedores del tema actual */
-  /* position: fixed, top, right, y z-index se eliminan para permitir que este botÃ³n
-     sea un elemento flex dentro de .header-actions-container.
-     Su estilo visual principal deberÃ­a provenir de .header-action-button si se usan juntos. */
-    background-color: var(--container-bg); /* Estas propiedades podrÃ­an ser redundantes si .header-action-button siempre estÃ¡ aplicado */
-  color: var(--text-color); /* Usa el color de texto del tema actual */
-  border: 1px solid var(--input-border); /* Usa el color de borde de input del tema actual */
-  border-radius: 50%;
-  width: 45px;
-  height: 45px;
-  display: flex; /* Asegura que flexbox estÃ© aplicado */
-  align-items: center; /* Centra verticalmente el icono */
-  justify-content: center; /* Centra horizontalmente el icono */
-  font-size: 1.2em; /* Ajusta el tamaÃ±o base para el icono si es necesario */
-  padding: 0; /* Elimina padding si interfiere con el centrado del icono */
-  /*z-index: 1001;*/
-  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  font-size: var(--header-action-icon-size);
 }
 
 .theme-toggle-button:hover {
@@ -1315,42 +1297,19 @@ body.light-theme footer {
 
 
 .search-button {
-      /* position: fixed;  <-- Eliminado para que dependa del contenedor */
-  /* top: 15px;        <-- Eliminado */
-  /* Theme toggle button is at right: 15px, width: 45px. Add 10px gap. */
-  /* 15px (theme-toggle offset) + 45px (theme-toggle width) + 10px (gap) = 70px */
-  /* right: 70px;      <-- Eliminado */
-  /* position: relative; Para el posicionamiento absoluto del menÃº hijo */
-  background-color: var(--container-bg);
-  color: var(--text-color);
-  border: 1px solid var(--input-border);
-  border-radius: 50%;
-  width: 45px;
-  height: 45px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.3em; /* Icon size */
-  padding: 0;
-  /* z-index: 1001;  <-- Manejado por .user-profile-menu-container y .user-menu */
-  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-  cursor: pointer;
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  font-size: var(--header-action-icon-size); /* Alinea el tamaño del icono con el resto del header */
 }
 
-  .search-button:hover {
+.search-button:hover {
     background-color: var(--accent-color-primary); /* Usa el color de acento primario del tema actual */
-    color: var(--main-button-text); /* Usa el color de texto de botÃ³n principal del tema actual */
+    color: var(--main-button-text); /* Usa el color de texto de botón principal del tema actual */
     border-color: var(--accent-color-primary); /* Usa el color de acento primario del tema actual */
     transform: translateY(-1px);
-  }
-  
-  .search-button i {
+}
+
+.search-button i {
     line-height: 1; /* Ayuda a centrar verticalmente el icono de FontAwesome */
-    display: flex; /* Para asegurar que el icono se comporte como un bloque flexible */
-    align-items: center;
-    justify-content: center;
-  }
+}
 
 /* NUEVO: Contenedor para el menÃº de perfil */
 .user-profile-menu-container {
@@ -1366,27 +1325,7 @@ body.light-theme footer {
 
 /* --- User Profile Menu --- */
 .user-profile-button {
-  /* position: fixed;  <-- Eliminado para que dependa del contenedor */
-  /* top: 15px;        <-- Eliminado */
-  /* Theme toggle button is at right: 15px, width: 45px. Add 10px gap. */
-  /* 15px (theme-toggle offset) + 45px (theme-toggle width) + 10px (gap) = 70px */
-  /* right: 70px;      <-- Eliminado */
-  position: relative; /* Para el posicionamiento absoluto del menÃº hijo */
-  background-color: var(--container-bg);
-  color: var(--text-color);
-  border: 1px solid var(--input-border);
-  border-radius: 50%;
-  width: 45px;
-  height: 45px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.3em; /* Icon size */
-  padding: 0;
-  /* z-index: 1001;  <-- Manejado por .user-profile-menu-container y .user-menu */
-  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-  cursor: pointer;
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  font-size: var(--header-action-icon-size);
 }
 
 .user-profile-button:hover {
@@ -1597,6 +1536,13 @@ body.light-theme .user-menu-divider {
     gap: 9px; /* Espacio entre los botones de acciÃ³n */
 }
 
+.anchor-offset-target {
+    display: block;
+    height: 0;
+    width: 100%;
+    scroll-margin-top: 120px;
+}
+
 .header-action-button.notifications-button,
 .header-action-button.chat-button {
     position: relative;
@@ -1621,17 +1567,17 @@ body.light-theme .user-menu-divider {
 
 /* Estilo general para los botones de acciÃ³n del header, incluyendo los que son enlaces */
 .header-action-button,
-a.header-action-button { /* Importante aÃ±adir 'a.header-action-button' */
+a.header-action-button { /* Importante añadir 'a.header-action-button' */
     background-color: var(--container-bg);
     color: var(--text-color); /* Para el color del icono */
     border: 1px solid var(--input-border);
-    border-radius: 45%;
-    width: 40px;
-    height: 40px;
+    border-radius: 50%;
+    width: var(--header-action-button-size);
+    height: var(--header-action-button-size);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.2em; /* TamaÃ±o del icono */
+    font-size: var(--header-action-icon-size); /* Tamaño del icono */
     padding: 0;
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     cursor: pointer;
@@ -1771,7 +1717,7 @@ a.header-action-button:hover {
     text-decoration: none; /* Mantener sin subrayado en hover */
 }
 
-.header-action-button, a.header-action-button i {
+.header-action-button, .header-action-button i {
     line-height: 1;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Standardize header action button styling so icons align consistently and add an offset anchor helper for fixed headers.
- Refresh the header markup across key pages with accessible icons, reinstated forum actions, and updated menu options for Chats and Guardado.
- Link the new Guardado section anchor on the profile page for the dropdown entry.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e393f3f22c8326ba368a6bceb215fb