### PR TITLE
Clear chat notification badge on open

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1020,6 +1020,16 @@ const initializeGlobalRealtimeFeatures = (user) => {
 
     const cleanupFunctions = [];
 
+    if (chatsBadge) {
+        const handleChatUnreadCleared = () => {
+            setBadgeVisibility(chatsBadge, false);
+        };
+        document.addEventListener('listopic:chatUnreadCleared', handleChatUnreadCleared);
+        cleanupFunctions.push(() => {
+            document.removeEventListener('listopic:chatUnreadCleared', handleChatUnreadCleared);
+        });
+    }
+
     if (ListopicApp.services.listenToUserChats && chatsBadge) {
         const unsubscribeChats = ListopicApp.services.listenToUserChats(user.uid, chats => {
             const hasUnread = Array.isArray(chats) && chats.some(chat => (chat.unreadCounts && chat.unreadCounts[user.uid] > 0));

--- a/public/js/page-chats.js
+++ b/public/js/page-chats.js
@@ -65,6 +65,12 @@ ListopicApp.pageChats = (() => {
 
     const sanitizeText = (value) => (typeof value === 'string' ? value : '');
 
+    const notifyChatUnreadCleared = () => {
+        if (typeof document !== 'undefined') {
+            document.dispatchEvent(new CustomEvent('listopic:chatUnreadCleared'));
+        }
+    };
+
     const createSharedReviewCard = (payload, isOwnMessage) => {
         if (!payload || typeof payload !== 'object') {
             return null;
@@ -849,6 +855,7 @@ ListopicApp.pageChats = (() => {
                 const updatedCounts = { ...chat.unreadCounts, [currentUser.uid]: 0 };
                 updateLocalChatData(chat.id, { unreadCounts: updatedCounts });
                 renderChatList(chatsCache);
+                notifyChatUnreadCleared();
             }
         }
 
@@ -885,6 +892,9 @@ ListopicApp.pageChats = (() => {
             if (ListopicApp.services.markChatMessagesAsRead) {
                 try {
                     await ListopicApp.services.markChatMessagesAsRead(chatId, currentUser.uid, unreadMessageIds);
+                    if (unreadMessageIds.length > 0) {
+                        notifyChatUnreadCleared();
+                    }
                 } catch (error) {
                     console.error('[page-chats] Error marcando mensajes como leidos:', error);
                 }


### PR DESCRIPTION
## Summary
- dispatch a custom event when chat unread counts are cleared from the chat page
- listen for the custom event globally to hide the chats badge as soon as a conversation is opened

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3bcc766188326b4ad652d68258b47