### PR TITLE
Fix detail view author, location, and criteria display

### DIFF
--- a/public/detail-view.html
+++ b/public/detail-view.html
@@ -107,62 +107,112 @@
 
 </head>
 <body>
-    <main>
-        <div class="container">
-            <!-- Removed theme-toggle-button from here -->
-            <a href="list-view.html" class="back-button">← Volver al Ranking</a> <!-- JS will update href -->
-            <p class="detail-list-name" id="detail-list-name">Estás viendo en Listopic: [Cargando...]</p>
-            
-            <h2 id="detail-restaurant-name">[Cargando nombre del elemento...]</h2>
-            <p class="detail-dish-name" id="detail-dish-name"></p>
-            
-            <p class="review-author-info" style="text-align: center; margin-bottom: 15px; font-size: 0.9em;">
-                Reseña de: <a href="profile.html" id="review-author-name">[Cargando autor...]</a>
-            </p>
+    <main class="detail-page">
+        <div class="container detail-page__container">
+            <a href="list-view.html" class="back-button">← Volver al ranking</a>
+            <p class="detail-list-name" id="detail-list-name">Estás viendo en Listopic: <span class="detail-list-name__loading">[Cargando...]</span></p>
 
-            <div class="detail-content">
-                <div class="detail-image-area">
-                    <img src="https://via.placeholder.com/600x400.png?text=Cargando+imagen..." alt="Foto del elemento" id="detail-image">
-                </div>
-                <div class="detail-info-area">
-                    <div class="detail-overall-score-container">
-                        <span>Valoración General</span>
-                        <strong class="detail-overall-score" id="detail-score-value">?.?</strong>
+            <section class="detail-hero">
+                <div class="detail-hero__media">
+                    <img id="detail-image" alt="Foto del elemento" hidden loading="lazy">
+                    <div class="detail-image-icon-placeholder" hidden>
+                        <i class="fa-solid fa-image"></i>
                     </div>
-                    <ul class="detail-ratings-list" id="detail-ratings">
-                        <li>Cargando valoraciones detalladas...</li>
-                    </ul>
-                    <div id="detail-location-container" style="display: none;"> <!-- Hidden by default, shown by JS if data exists -->
-                        <div class="detail-location">
-                            <a href="#" target="_blank" title="Ver en Google Maps" id="detail-location-link">
+                    <a href="#" class="detail-hero__media-link" id="detail-media-link" hidden target="_blank" rel="noopener"></a>
+                </div>
+                <div class="detail-hero__info">
+                    <h1 id="detail-restaurant-name">[Cargando nombre del elemento...]</h1>
+                    <p class="detail-dish-name" id="detail-dish-name"></p>
+                    <div class="detail-hero__author" id="detail-author-chip" hidden>
+                        <span class="detail-hero__author-avatar" id="detail-author-avatar" aria-hidden="true"></span>
+                        <a href="#" id="detail-author-name" class="detail-hero__author-name">Autor no especificado</a>
+                    </div>
+                    <div class="detail-hero__meta">
+                        <div class="detail-score-badge" aria-live="polite">
+                            <span class="detail-score-badge__label">Valoración general</span>
+                            <span class="detail-score-badge__value" id="detail-score-value">?.?</span>
+                        </div>
+                        <dl class="detail-meta-grid">
+                            <div class="detail-meta-grid__item">
+                                <dt>Lista</dt>
+                                <dd><a href="list-view.html" id="detail-list-link">Ver lista</a></dd>
+                            </div>
+                            <div class="detail-meta-grid__item">
+                                <dt>Lugar</dt>
+                                <dd id="detail-place-link-wrapper"><a href="#" id="detail-place-link" target="_blank" rel="noopener">Ubicación</a></dd>
+                            </div>
+                            <div class="detail-meta-grid__item" id="detail-review-date" hidden>
+                                <dt>Creada</dt>
+                                <dd id="detail-review-date-text"></dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="detail-hero__actions">
+                        <button type="button" class="share-story-button" id="detail-share-button" disabled>
+                            <i class="fas fa-share-alt"></i>
+                            Compartir reseña
+                        </button>
+                        <a href="#" role="button" class="edit-button" data-owner-action hidden>
+                            <i class="fas fa-edit"></i>
+                            Editar reseña
+                        </a>
+                        <button type="button" class="delete-button danger" data-owner-action hidden>
+                            <i class="fas fa-trash-alt"></i>
+                            Eliminar reseña
+                        </button>
+                        <a href="#" class="button tertiary-button detail-group-link" id="detail-group-link" hidden>
+                            <i class="fas fa-layer-group"></i>
+                            Ver grupo del plato
+                        </a>
+                    </div>
+                </div>
+            </section>
+
+            <div class="detail-layout">
+                <section class="detail-primary">
+                    <article class="detail-card detail-card--metrics">
+                        <div class="chart-mode-toggle" role="radiogroup" aria-label="Tipo de gráfico">
+                            <button type="button" class="chart-mode-toggle__button is-active" data-chart-mode="bars" aria-pressed="true">Barras</button>
+                            <button type="button" class="chart-mode-toggle__button" data-chart-mode="radar" aria-pressed="false">Tela de araña</button>
+                        </div>
+                        <div class="detail-chart">
+                            <canvas id="detail-criteria-canvas" role="img" aria-label="Gráfico de criterios"></canvas>
+                            <p class="detail-chart__empty" id="detail-criteria-empty" hidden>No hay valoraciones de criterios suficientes para mostrar un gráfico.</p>
+                        </div>
+                    </article>
+
+                    <article class="detail-card detail-card--comment" id="detail-comment-container" hidden>
+                        <p id="detail-comment-text"></p>
+                    </article>
+
+                    <article class="detail-card detail-card--tags" id="detail-tags-container" hidden>
+                        <div id="detail-tags" class="detail-tags"></div>
+                    </article>
+                </section>
+
+                <aside class="detail-secondary">
+                    <article class="detail-card detail-card--location">
+                        <div id="detail-location-container" hidden>
+                            <a href="#" target="_blank" rel="noopener" class="detail-location-link" id="detail-location-link">
                                 <i class="fa-solid fa-map-marker-alt"></i>
-                                <span id="detail-location-text"></span> <!-- ID AÑADIDO AQUÍ -->
+                                <span id="detail-location-text"></span>
                             </a>
                         </div>
-                    </div>
-                     <div class="detail-no-location" style="display: none;"> <!-- Shown by JS if no location -->
-                        <i class="fa-solid fa-ban"></i>
-                        <span>Ubicación no disponible</span>
-                    </div>
+                        <div class="detail-no-location" id="detail-no-location" hidden>
+                            <i class="fa-solid fa-ban"></i>
+                            <span>Ubicación no disponible</span>
+                        </div>
+                    </article>
 
-                    <div class="detail-comment" id="detail-comment-container" style="display: none;">
-                        <h4>Comentario:</h4>
-                        <p id="detail-comment-text"></p>
-                    </div>
-                    <div class="detail-tags-area" id="detail-tags-container" style="display: none;">
-                        <h4>Etiquetas:</h4>
-                        <div id="detail-tags"></div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="detail-actions">
-                <button type="button" class="share-story-button" id="detail-share-button" disabled>
-                    <i class="fas fa-share-alt"></i>
-                    Compartir reseña
-                </button>
-                <a href="review-form.html" role="button" class="edit-button"><i class="fas fa-edit"></i> Editar Resena</a>
-                <button type="button" class="delete-button danger"><i class="fas fa-trash-alt"></i> Eliminar Resena</button>
+                    <article class="detail-card detail-card--share">
+                        <p>Haz clic en “Compartir reseña” para abrir el panel con opciones de enlace, chats y tarjeta para Instagram.</p>
+                        <button type="button" class="share-story-button share-story-button--secondary" id="detail-share-button-secondary" disabled>
+                            <i class="fas fa-share-alt"></i>
+                            Compartir reseña
+                        </button>
+                    </article>
+                </aside>
             </div>
         </div>
     </main>

--- a/public/js/page-detail-view.js
+++ b/public/js/page-detail-view.js
@@ -188,6 +188,41 @@ ListopicApp.pageDetailView = (() => {
         return parts.map(part => part.charAt(0).toUpperCase()).join('');
     }
 
+    function humanizeCriteriaKey(key) {
+        if (!key) {
+            return '';
+        }
+        const base = String(key)
+            .replace(/[._-]+/g, ' ')
+            .replace(/([a-záéíóúüñ0-9])([A-ZÁÉÍÓÚÜÑ])/g, '$1 $2')
+            .replace(/\s+/g, ' ')
+            .trim();
+        if (!base) {
+            return '';
+        }
+        return base.charAt(0).toUpperCase() + base.slice(1);
+    }
+
+    function resolveCriteriaLabel(key, definition) {
+        if (definition && typeof definition === 'object') {
+            const candidateProps = ['label', 'displayName', 'name', 'title', 'text', 'labelOriginal'];
+            for (const prop of candidateProps) {
+                const candidate = definition[prop];
+                if (typeof candidate === 'string') {
+                    const trimmed = candidate.trim();
+                    if (trimmed) {
+                        return trimmed;
+                    }
+                }
+            }
+        }
+        const humanized = humanizeCriteriaKey(key);
+        if (humanized) {
+            return humanized;
+        }
+        return key ? String(key) : '';
+    }
+
     function hexToRgba(hex, alpha) {
         if (!hex) {
             return `rgba(255,255,255,${alpha ?? 1})`;
@@ -455,7 +490,11 @@ ListopicApp.pageDetailView = (() => {
                 if (!Number.isFinite(value)) {
                     continue;
                 }
-                availableCriteria.push([key, definition]);
+                const labeledDefinition = {
+                    ...definition,
+                    label: resolveCriteriaLabel(key, definition)
+                };
+                availableCriteria.push([key, labeledDefinition]);
             }
         } else if (review?.scores) {
             for (const key of Object.keys(review.scores)) {
@@ -463,7 +502,7 @@ ListopicApp.pageDetailView = (() => {
                 if (!Number.isFinite(value)) {
                     continue;
                 }
-                availableCriteria.push([key, { label: key, min: 0, max: 10 }]);
+                availableCriteria.push([key, { label: resolveCriteriaLabel(key), min: 0, max: 10 }]);
             }
         }
 
@@ -728,33 +767,487 @@ ListopicApp.pageDetailView = (() => {
         const params = new URLSearchParams(window.location.search);
         const reviewId = params.get('id');
         const listIdFromURL = params.get('listId');
+        const fromPlaceIdParam = params.get('fromPlaceId');
+        const fromItemParam = params.get('fromItem');
+        const fromGroupedParam = params.get('fromGrouped') === 'true';
 
         // Elementos del DOM
         const detailEstablishmentNameEl = document.getElementById('detail-restaurant-name');
         const detailItemNameEl = document.getElementById('detail-dish-name');
-
         const detailScoreValueEl = document.getElementById('detail-score-value');
-        const detailRatingsListEl = document.getElementById('detail-ratings');
         const detailLocationLinkEl = document.getElementById('detail-location-link');
         const detailLocationTextEl = document.getElementById('detail-location-text');
-        const detailNoLocationDivEl = document.querySelector('.detail-no-location');
         const detailLocationContainerEl = document.getElementById('detail-location-container');
+        const detailNoLocationEl = document.getElementById('detail-no-location');
         const detailCommentContainerEl = document.getElementById('detail-comment-container');
         const detailCommentTextEl = document.getElementById('detail-comment-text');
         const detailTagsContainerEl = document.getElementById('detail-tags-container');
         const detailTagsDivEl = document.getElementById('detail-tags');
         const detailListNameEl = document.getElementById('detail-list-name');
-        const reviewAuthorNameEl = document.getElementById('review-author-name');
+        const detailListLinkEl = document.getElementById('detail-list-link');
+        const detailPlaceLinkWrapperEl = document.getElementById('detail-place-link-wrapper');
+        const detailPlaceLinkEl = document.getElementById('detail-place-link');
+        const detailGroupLinkEl = document.getElementById('detail-group-link');
+        const detailMediaLinkEl = document.getElementById('detail-media-link');
+        const detailReviewDateContainerEl = document.getElementById('detail-review-date');
+        const detailReviewDateTextEl = document.getElementById('detail-review-date-text');
+        const detailAuthorChipEl = document.getElementById('detail-author-chip');
+        const detailAuthorAvatarEl = document.getElementById('detail-author-avatar');
+        const detailAuthorNameEl = document.getElementById('detail-author-name');
         const detailImageEl = document.getElementById('detail-image');
+        const detailImagePlaceholderEl = document.querySelector('.detail-image-icon-placeholder');
 
         const backButton = document.querySelector('.container a.back-button');
-        const editButton = document.querySelector('.edit-button');
-        const deleteButton = document.querySelector('.delete-button.danger');
-        const shareButton = document.getElementById('detail-share-button');
+        const editButton = document.querySelector('.edit-button[data-owner-action]');
+        const deleteButton = document.querySelector('.delete-button.danger[data-owner-action]');
+        const ownerActionEls = Array.from(document.querySelectorAll('[data-owner-action]'));
+        const sharePrimaryButton = document.getElementById('detail-share-button');
+        const shareSecondaryButton = document.getElementById('detail-share-button-secondary');
+        const shareButtons = [sharePrimaryButton, shareSecondaryButton].filter(Boolean);
         const showNotification = ListopicApp.services?.showNotification;
         const currentUserId = auth?.currentUser?.uid || null;
 
+        const chartCanvas = document.getElementById('detail-criteria-canvas');
+        const chartEmptyStateEl = document.getElementById('detail-criteria-empty');
+        const chartToggleButtons = Array.from(document.querySelectorAll('.chart-mode-toggle__button'));
+
         let shareModalData = null;
+
+        const chartState = {
+            mode: 'bars',
+            entries: [],
+            resizeTimeout: null
+        };
+
+        const getCssColor = (variableName, fallback) => {
+            if (typeof window === 'undefined' || !window.getComputedStyle) {
+                return fallback;
+            }
+            const styles = window.getComputedStyle(document.documentElement);
+            const value = styles.getPropertyValue(variableName);
+            return value ? value.trim() || fallback : fallback;
+        };
+
+        const chartColors = {
+            accent: getCssColor('--accent-color-primary', '#f97316'),
+            accentSecondary: getCssColor('--accent-color-secondary', '#facc15'),
+            accentTertiary: getCssColor('--accent-color-tertiary', '#06d6a0'),
+            track: 'rgba(255,255,255,0.14)',
+            panel: 'rgba(15,23,42,0.55)',
+            text: '#ffffff',
+            muted: 'rgba(255,255,255,0.7)'
+        };
+
+        const setShareButtonsEnabled = (enabled) => {
+            shareButtons.forEach(button => {
+                if (!button) return;
+                button.disabled = !enabled;
+                if (!enabled) {
+                    button.removeAttribute('data-loading');
+                    button.removeAttribute('aria-busy');
+                }
+            });
+        };
+
+        const updateOwnerActionsVisibility = (isOwner) => {
+            ownerActionEls.forEach(element => {
+                if (!element) {
+                    return;
+                }
+                element.hidden = !isOwner;
+            });
+        };
+
+        updateOwnerActionsVisibility(false);
+
+        const updateAuthorChip = (name, photoUrl, profileUrl) => {
+            if (!detailAuthorChipEl || !detailAuthorAvatarEl || !detailAuthorNameEl) {
+                return;
+            }
+            const displayName = name || 'Autor no especificado';
+            detailAuthorNameEl.textContent = displayName;
+            detailAuthorNameEl.title = displayName;
+            detailAuthorNameEl.setAttribute('aria-label', displayName);
+            if (profileUrl) {
+                detailAuthorNameEl.href = profileUrl;
+            } else {
+                detailAuthorNameEl.removeAttribute('href');
+            }
+
+            detailAuthorAvatarEl.innerHTML = '';
+            if (photoUrl) {
+                const img = document.createElement('img');
+                img.src = photoUrl;
+                img.alt = name ? `Foto de ${name}` : 'Foto del autor';
+                detailAuthorAvatarEl.appendChild(img);
+            } else {
+                const initials = getAuthorInitials(displayName);
+                detailAuthorAvatarEl.textContent = initials || '??';
+            }
+
+            detailAuthorChipEl.hidden = false;
+        };
+
+        const formatReviewDate = (rawDate) => {
+            if (!rawDate) {
+                return '';
+            }
+            let value = rawDate;
+            if (typeof rawDate.toDate === 'function') {
+                value = rawDate.toDate();
+            }
+            if (!(value instanceof Date)) {
+                return '';
+            }
+            try {
+                return new Intl.DateTimeFormat('es-ES', { dateStyle: 'medium' }).format(value);
+            } catch (error) {
+                console.warn('[detailView] No se pudo formatear la fecha de la reseña.', error);
+                return value.toLocaleDateString?.() || '';
+            }
+        };
+
+        const prepareCanvasContext = (canvas, width, height) => {
+            if (!canvas) {
+                return null;
+            }
+            const ratio = window.devicePixelRatio || 1;
+            canvas.width = width * ratio;
+            canvas.height = height * ratio;
+            canvas.style.width = `${width}px`;
+            canvas.style.height = `${height}px`;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                return null;
+            }
+            ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+            ctx.clearRect(0, 0, width, height);
+            return ctx;
+        };
+
+        const drawBarsChart = (entries) => {
+            if (!chartCanvas || !entries.length) {
+                return;
+            }
+            const containerWidth = chartCanvas.parentElement?.clientWidth || 600;
+            const barHeight = 34;
+            const barSpacing = 20;
+            const chartHeight = Math.max(200, entries.length * (barHeight + barSpacing) + 40);
+            const ctx = prepareCanvasContext(chartCanvas, containerWidth, chartHeight);
+            if (!ctx) {
+                return;
+            }
+
+            ctx.font = '16px "Poppins", "Helvetica Neue", Arial';
+            ctx.textBaseline = 'middle';
+
+            const paddingX = 24;
+            const barMaxWidth = containerWidth - paddingX * 2;
+
+            entries.forEach((entry, index) => {
+                const top = 30 + index * (barHeight + barSpacing);
+                const normalized = entry.max > entry.min
+                    ? (entry.value - entry.min) / (entry.max - entry.min)
+                    : entry.value / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const barWidth = Math.max(4, barMaxWidth * clamped);
+
+                ctx.fillStyle = chartColors.track;
+                drawRoundedRectPath(ctx, paddingX, top, barMaxWidth, barHeight, 14);
+                ctx.fill();
+
+                const gradient = ctx.createLinearGradient(paddingX, top, paddingX + barWidth, top + barHeight);
+                gradient.addColorStop(0, chartColors.accent);
+                gradient.addColorStop(1, chartColors.accentSecondary);
+                ctx.fillStyle = gradient;
+                drawRoundedRectPath(ctx, paddingX, top, barWidth, barHeight, 14);
+                ctx.fill();
+
+                ctx.fillStyle = chartColors.text;
+                ctx.textAlign = 'left';
+                ctx.fillText(entry.label, paddingX + 12, top + barHeight / 2);
+
+                ctx.fillStyle = chartColors.muted;
+                ctx.textAlign = 'right';
+                ctx.fillText(entry.value.toFixed(1), paddingX + barMaxWidth - 8, top + barHeight / 2);
+            });
+        };
+
+        const drawRadarChart = (entries) => {
+            if (!chartCanvas || !entries.length) {
+                return;
+            }
+            const containerWidth = chartCanvas.parentElement?.clientWidth || 520;
+            const size = Math.min(520, Math.max(320, containerWidth));
+            const ctx = prepareCanvasContext(chartCanvas, size, size);
+            if (!ctx) {
+                return;
+            }
+
+            const centerX = size / 2;
+            const centerY = size / 2;
+            const radius = Math.min(size / 2 - 50, 220);
+            const levels = 5;
+            const angleStep = (Math.PI * 2) / entries.length;
+
+            ctx.strokeStyle = hexToRgba(chartColors.accentSecondary, 0.25);
+            ctx.lineWidth = 1.5;
+            for (let level = 1; level <= levels; level += 1) {
+                const ratio = level / levels;
+                ctx.beginPath();
+                entries.forEach((entry, index) => {
+                    const angle = angleStep * index - Math.PI / 2;
+                    const x = centerX + Math.cos(angle) * radius * ratio;
+                    const y = centerY + Math.sin(angle) * radius * ratio;
+                    if (index === 0) {
+                        ctx.moveTo(x, y);
+                    } else {
+                        ctx.lineTo(x, y);
+                    }
+                });
+                ctx.closePath();
+                ctx.stroke();
+            }
+
+            ctx.strokeStyle = hexToRgba(chartColors.accentTertiary, 0.5);
+            entries.forEach((entry, index) => {
+                const angle = angleStep * index - Math.PI / 2;
+                ctx.beginPath();
+                ctx.moveTo(centerX, centerY);
+                ctx.lineTo(centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius);
+                ctx.stroke();
+            });
+
+            ctx.beginPath();
+            entries.forEach((entry, index) => {
+                const normalized = entry.max > entry.min
+                    ? (entry.value - entry.min) / (entry.max - entry.min)
+                    : entry.value / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const angle = angleStep * index - Math.PI / 2;
+                const x = centerX + Math.cos(angle) * radius * clamped;
+                const y = centerY + Math.sin(angle) * radius * clamped;
+                if (index === 0) {
+                    ctx.moveTo(x, y);
+                } else {
+                    ctx.lineTo(x, y);
+                }
+            });
+            ctx.closePath();
+            ctx.fillStyle = hexToRgba(chartColors.accent, 0.32);
+            ctx.fill();
+            ctx.lineWidth = 2;
+            ctx.strokeStyle = chartColors.accent;
+            ctx.stroke();
+
+            entries.forEach((entry, index) => {
+                const normalized = entry.max > entry.min
+                    ? (entry.value - entry.min) / (entry.max - entry.min)
+                    : entry.value / 10;
+                const clamped = Math.max(0, Math.min(1, normalized));
+                const angle = angleStep * index - Math.PI / 2;
+                const x = centerX + Math.cos(angle) * radius * clamped;
+                const y = centerY + Math.sin(angle) * radius * clamped;
+                ctx.beginPath();
+                ctx.arc(x, y, 6, 0, Math.PI * 2);
+                ctx.fillStyle = chartColors.text;
+                ctx.fill();
+            });
+
+            ctx.font = '14px "Poppins", "Helvetica Neue", Arial';
+            entries.forEach((entry, index) => {
+                const angle = angleStep * index - Math.PI / 2;
+                const labelRadius = radius + 28;
+                const x = centerX + Math.cos(angle) * labelRadius;
+                const y = centerY + Math.sin(angle) * labelRadius;
+
+                const align = Math.cos(angle) > 0.2 ? 'left' : Math.cos(angle) < -0.2 ? 'right' : 'center';
+                ctx.textAlign = align;
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = chartColors.text;
+                ctx.fillText(entry.label, x, y);
+                ctx.fillStyle = chartColors.muted;
+                ctx.fillText(entry.value.toFixed(1), x, y + 18);
+            });
+        };
+
+        const updateChartModeButtons = () => {
+            chartToggleButtons.forEach(button => {
+                const mode = button?.dataset?.chartMode || 'bars';
+                const isActive = chartState.mode === mode;
+                if (chartState.entries.length < 3 && mode === 'radar') {
+                    button.disabled = true;
+                    button.classList.remove('is-active');
+                    button.setAttribute('aria-pressed', 'false');
+                    return;
+                }
+                button.disabled = false;
+                button.classList.toggle('is-active', isActive);
+                button.setAttribute('aria-pressed', String(isActive));
+            });
+        };
+
+        const renderCriteriaChart = () => {
+            if (!chartCanvas) {
+                return;
+            }
+            if (!chartState.entries.length) {
+                chartCanvas.style.display = 'none';
+                if (chartEmptyStateEl) {
+                    chartEmptyStateEl.hidden = false;
+                    chartEmptyStateEl.style.display = 'flex';
+                }
+                return;
+            }
+            chartCanvas.style.display = 'block';
+            if (chartEmptyStateEl) {
+                chartEmptyStateEl.hidden = true;
+                chartEmptyStateEl.style.display = 'none';
+            }
+            const usableEntries = chartState.mode === 'radar'
+                ? chartState.entries.slice(0, 6)
+                : chartState.entries;
+            if (chartState.mode === 'radar' && usableEntries.length < 3) {
+                chartState.mode = 'bars';
+                updateChartModeButtons();
+                drawBarsChart(chartState.entries);
+                return;
+            }
+            if (chartState.mode === 'radar') {
+                drawRadarChart(usableEntries);
+            } else {
+                drawBarsChart(usableEntries);
+            }
+        };
+
+        const updateChartEntries = (entries) => {
+            chartState.entries = entries.slice();
+            updateChartModeButtons();
+            renderCriteriaChart();
+        };
+
+        const setChartMode = (mode) => {
+            if (mode === 'radar' && chartState.entries.length < 3) {
+                return;
+            }
+            chartState.mode = mode === 'radar' ? 'radar' : 'bars';
+            updateChartModeButtons();
+            renderCriteriaChart();
+        };
+
+        chartToggleButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const mode = button?.dataset?.chartMode || 'bars';
+                setChartMode(mode);
+            });
+        });
+
+        if (typeof window !== 'undefined') {
+            window.addEventListener('resize', () => {
+                if (chartState.resizeTimeout) {
+                    window.clearTimeout(chartState.resizeTimeout);
+                }
+                chartState.resizeTimeout = window.setTimeout(() => {
+                    renderCriteriaChart();
+                }, 150);
+            });
+        }
+
+        const computeCriteriaEntries = () => {
+            if (!reviewDataGlobal?.scores || typeof reviewDataGlobal.scores !== 'object') {
+                return [];
+            }
+            const entries = [];
+            const definitions = state.currentListCriteriaDefinitions;
+            if (definitions && Object.keys(definitions).length > 0) {
+                for (const [key, definition] of Object.entries(definitions)) {
+                    if (reviewDataGlobal.scores[key] === undefined) {
+                        continue;
+                    }
+                    const value = Number.parseFloat(reviewDataGlobal.scores[key]);
+                    if (!Number.isFinite(value)) {
+                        continue;
+                    }
+                    const label = resolveCriteriaLabel(key, definition);
+                    entries.push({
+                        key,
+                        label,
+                        value,
+                        min: Number.isFinite(Number.parseFloat(definition?.min)) ? Number.parseFloat(definition.min) : 0,
+                        max: Number.isFinite(Number.parseFloat(definition?.max)) ? Number.parseFloat(definition.max) : 10,
+                        ponderable: definition?.ponderable !== false
+                    });
+                }
+            } else {
+                for (const [key, rawValue] of Object.entries(reviewDataGlobal.scores)) {
+                    const value = Number.parseFloat(rawValue);
+                    if (!Number.isFinite(value)) {
+                        continue;
+                    }
+                    entries.push({
+                        key,
+                        label: resolveCriteriaLabel(key),
+                        value,
+                        min: 0,
+                        max: 10,
+                        ponderable: true
+                    });
+                }
+            }
+            return entries;
+        };
+
+        const refreshCriteriaVisuals = () => {
+            const entries = computeCriteriaEntries();
+            updateChartEntries(entries);
+        };
+
+        const buildGroupLinkUrl = (placeId, itemName) => {
+            if (!listIdFromURL || !placeId) {
+                return null;
+            }
+            const query = new URLSearchParams({ listId: listIdFromURL, placeId });
+            if (itemName) {
+                query.set('item', itemName);
+            }
+            return `grouped-detail-view.html?${query.toString()}`;
+        };
+
+        const buildPlaceDetailLinkUrl = (placeId) => {
+            if (!placeId) {
+                return null;
+            }
+            const query = new URLSearchParams({ placeId });
+            return `place-detail.html?${query.toString()}`;
+        };
+
+        const applyGroupLink = () => {
+            if (!detailGroupLinkEl || !detailMediaLinkEl) {
+                return;
+            }
+            if (groupLinkUrl) {
+                detailGroupLinkEl.href = groupLinkUrl;
+                detailGroupLinkEl.hidden = false;
+                detailGroupLinkEl.setAttribute('aria-label', 'Ver grupo del plato');
+                detailMediaLinkEl.href = groupLinkUrl;
+                detailMediaLinkEl.hidden = false;
+                detailMediaLinkEl.target = '_self';
+                detailMediaLinkEl.setAttribute('aria-label', 'Abrir el grupo del plato');
+            } else {
+                detailGroupLinkEl.hidden = true;
+                detailGroupLinkEl.removeAttribute('href');
+                detailGroupLinkEl.removeAttribute('target');
+                if (reviewDataGlobal?.photoUrl) {
+                    detailMediaLinkEl.href = reviewDataGlobal.photoUrl;
+                    detailMediaLinkEl.hidden = false;
+                    detailMediaLinkEl.target = '_blank';
+                    detailMediaLinkEl.setAttribute('aria-label', 'Abrir la foto de la reseña en una pestaña nueva');
+                } else {
+                    detailMediaLinkEl.hidden = true;
+                    detailMediaLinkEl.removeAttribute('href');
+                }
+            }
+        };
 
         const ensureShareData = () => {
             const baseData = {
@@ -767,10 +1260,8 @@ ListopicApp.pageDetailView = (() => {
             } else {
                 shareModalData = { ...baseData, ...shareModalData };
             }
-            if (shareButton) {
-                const hasCoreData = Boolean(shareModalData.listId && shareModalData.reviewId);
-                shareButton.disabled = !hasCoreData;
-            }
+            const hasCoreData = Boolean(shareModalData.listId && shareModalData.reviewId);
+            setShareButtonsEnabled(hasCoreData);
         };
 
         const updateShareData = (partial = {}) => {
@@ -814,16 +1305,14 @@ ListopicApp.pageDetailView = (() => {
             }
         };
 
-        if (shareButton) {
-            shareButton.disabled = true;
-            shareButton.addEventListener('click', handleShareButtonClick);
-        }
+        shareButtons.forEach(button => {
+            button.disabled = true;
+            button.addEventListener('click', handleShareButtonClick);
+        });
 
         // Configurar boton de Volver
         if (backButton && listIdFromURL) {
-            const fromPlaceIdParam = params.get('fromPlaceId'); // Usar fromPlaceId
-            const fromItemParam = params.get('fromItem');
-            if (params.get('fromGrouped') === 'true' && fromPlaceIdParam) {
+            if (fromGroupedParam && fromPlaceIdParam) {
                 backButton.href = `grouped-detail-view.html?listId=${listIdFromURL}&placeId=${fromPlaceIdParam}&item=${encodeURIComponent(fromItemParam || '')}`;
             } else {
                 backButton.href = `list-view.html?listId=${listIdFromURL}`;
@@ -850,13 +1339,16 @@ ListopicApp.pageDetailView = (() => {
 
         let reviewDataGlobal;
         let listDataGlobal; // Lo hacemos accesible en un scope mas amplio
+        let placeDataGlobal;
+        let groupLinkUrl = null;
+        let authorNameRaw = 'Autor no especificado';
 
         // 1. Obtener la resena
         db.collection('lists').doc(listIdFromURL).collection('reviews').doc(reviewId).get()
             .then(reviewDoc => {
                 if (!reviewDoc.exists) throw new Error(`Resena no encontrada.`);
                 reviewDataGlobal = { id: reviewDoc.id, ...reviewDoc.data() };
-                const authorNameRaw = reviewDataGlobal.authorName || reviewDataGlobal.userDisplayName || reviewDataGlobal.username || 'Usuario Anonimo';
+                authorNameRaw = reviewDataGlobal.authorName || reviewDataGlobal.userDisplayName || reviewDataGlobal.username || 'Usuario Anonimo';
                 updateShareData({
                     reviewId: reviewDataGlobal.id || reviewId,
                     listId: listIdFromURL,
@@ -868,65 +1360,100 @@ ListopicApp.pageDetailView = (() => {
                     comment: reviewDataGlobal.comment || '',
                     placeId: reviewDataGlobal.placeId || '',
                     placeName: reviewDataGlobal.establishmentName || '',
+                    placeUrl: '',
                     authorId: reviewDataGlobal.userId || null,
                     authorName: authorNameRaw,
                     detailUrl: shareDetailUrl
                 });
                 if (currentUserId && (reviewDataGlobal.userId === currentUserId || reviewDataGlobal.authorId === currentUserId)) {
                     updateShareData({ isOwner: true });
+                    updateOwnerActionsVisibility(true);
+                } else {
+                    updateOwnerActionsVisibility(false);
                 }
 
                 // Mostrar datos basicos de la resena
                 if (detailItemNameEl) detailItemNameEl.textContent = reviewDataGlobal.itemName || '';
                 if (detailScoreValueEl) detailScoreValueEl.textContent = reviewDataGlobal.overallRating !== undefined ? reviewDataGlobal.overallRating.toFixed(1) : 'N/A';
                 
-                if (detailImageEl && detailImageEl.parentNode) {
+                if (detailEstablishmentNameEl) {
+                    detailEstablishmentNameEl.textContent = reviewDataGlobal.establishmentName || reviewDataGlobal.placeName || 'Lugar no especificado';
+                }
+
+                if (detailItemNameEl) {
+                    detailItemNameEl.textContent = reviewDataGlobal.itemName || '';
+                }
+
+                if (detailImageEl) {
                     if (reviewDataGlobal.photoUrl) {
                         detailImageEl.src = reviewDataGlobal.photoUrl;
-                        detailImageEl.alt = `Foto de ${uiUtils.escapeHtml(reviewDataGlobal.itemName || 'resena')}`;
-                        detailImageEl.style.display = 'block';
-                        const placeholderIcon = detailImageEl.parentNode.querySelector('.detail-image-icon-placeholder');
-                        if(placeholderIcon) placeholderIcon.style.display = 'none';
-                    } else {
-                        detailImageEl.style.display = 'none';
-                        let placeholderIconDiv = detailImageEl.parentNode.querySelector('.detail-image-icon-placeholder');
-                        if (!placeholderIconDiv) {
-                            placeholderIconDiv = document.createElement('div');
-                            placeholderIconDiv.className = 'detail-image-icon-placeholder';
-                            detailImageEl.parentNode.insertBefore(placeholderIconDiv, detailImageEl.nextSibling);
+                        detailImageEl.alt = `Foto de ${uiUtils.escapeHtml(reviewDataGlobal.itemName || reviewDataGlobal.establishmentName || 'la reseña')}`;
+                        detailImageEl.hidden = false;
+                        if (detailImagePlaceholderEl) detailImagePlaceholderEl.hidden = true;
+                        if (detailMediaLinkEl) {
+                            detailMediaLinkEl.href = reviewDataGlobal.photoUrl;
+                            detailMediaLinkEl.hidden = false;
+                            detailMediaLinkEl.setAttribute('aria-label', 'Abrir la foto de la reseña en una pestaña nueva');
+                            detailMediaLinkEl.target = '_blank';
                         }
-                        placeholderIconDiv.innerHTML = `<i class="fa-solid fa-image"></i>`;
-                        placeholderIconDiv.style.display = 'flex';
+                    } else {
+                        detailImageEl.hidden = true;
+                        detailImageEl.removeAttribute('src');
+                        if (detailImagePlaceholderEl) detailImagePlaceholderEl.hidden = false;
+                        if (detailMediaLinkEl) {
+                            detailMediaLinkEl.hidden = true;
+                            detailMediaLinkEl.removeAttribute('href');
+                        }
                     }
                 }
 
                 if (detailCommentContainerEl && detailCommentTextEl) {
                     if (reviewDataGlobal.comment) {
                         detailCommentTextEl.innerHTML = uiUtils.escapeHtml(reviewDataGlobal.comment).replace(/\n/g, '<br>');
-                        detailCommentContainerEl.style.display = 'block';
+                        detailCommentContainerEl.hidden = false;
                     } else {
-                        detailCommentContainerEl.style.display = 'none';
+                        detailCommentContainerEl.hidden = true;
                     }
                 }
 
                 if (detailTagsContainerEl && detailTagsDivEl) {
-                    if (reviewDataGlobal.userTags && reviewDataGlobal.userTags.length > 0) {
+                    if (Array.isArray(reviewDataGlobal.userTags) && reviewDataGlobal.userTags.length > 0) {
                         detailTagsDivEl.innerHTML = reviewDataGlobal.userTags.map(tag => `<span class="tag-detail">${uiUtils.escapeHtml(tag)}</span>`).join('');
-                        detailTagsContainerEl.style.display = 'block';
+                        detailTagsContainerEl.hidden = false;
                     } else {
-                        detailTagsContainerEl.style.display = 'none';
+                        detailTagsContainerEl.hidden = true;
+                        detailTagsDivEl.innerHTML = '';
+                    }
+                }
+
+                const reviewTimestamp = reviewDataGlobal.createdAt
+                    || reviewDataGlobal.created_at
+                    || (typeof reviewDoc?.createTime?.toDate === 'function' ? reviewDoc.createTime.toDate() : null);
+                const reviewDateText = formatReviewDate(reviewTimestamp);
+                if (detailReviewDateContainerEl && detailReviewDateTextEl) {
+                    if (reviewDateText) {
+                        detailReviewDateTextEl.textContent = reviewDateText;
+                        detailReviewDateContainerEl.hidden = false;
+                    } else {
+                        detailReviewDateContainerEl.hidden = true;
                     }
                 }
 
                 if (editButton) {
                     let editHref = `review-form.html?listId=${listIdFromURL}&editId=${reviewId}`;
-                    const fromPlaceIdParam = params.get('fromPlaceId'); // Usar fromPlaceId
-                    const fromItemParam = params.get('fromItem');
-                    if (params.get('fromGrouped') === 'true' && fromPlaceIdParam) {
+                    if (fromGroupedParam && fromPlaceIdParam) {
                         editHref += `&fromGrouped=true&fromPlaceId=${fromPlaceIdParam}&fromItem=${encodeURIComponent(fromItemParam || '')}`;
                     }
                     editButton.href = editHref;
                 }
+
+                const authorLinkHref = reviewDataGlobal.userId ? `profile.html?viewUserId=${reviewDataGlobal.userId}` : '';
+                updateAuthorChip(authorNameRaw, reviewDataGlobal.authorPhotoUrl || reviewDataGlobal.userPhotoUrl || '', authorLinkHref);
+
+                refreshCriteriaVisuals();
+
+                groupLinkUrl = buildGroupLinkUrl(reviewDataGlobal.placeId || fromPlaceIdParam || null, reviewDataGlobal.itemName || fromItemParam || '');
+                applyGroupLink();
 
                 // 2. Obtener la definicion de la lista
                 return db.collection('lists').doc(listIdFromURL).get();
@@ -940,65 +1467,48 @@ ListopicApp.pageDetailView = (() => {
                     detailUrl: shareDetailUrl
                 });
 
-                if (detailListNameEl && listDataGlobal.name) {
-                    detailListNameEl.innerHTML = `Estas viendo en Listopic: <a href="list-view.html?listId=${listIdFromURL}">${uiUtils.escapeHtml(listDataGlobal.name)}</a>`;
-                    if (uiUtils.updatePageHeaderInfo) { // Actualizar header comun
-                        const currentCategory = listDataGlobal.categoryId || "Hmm...";
-                        uiUtils.updatePageHeaderInfo(currentCategory, listDataGlobal.name);
+                if (detailListNameEl) {
+                    if (listDataGlobal.name) {
+                        detailListNameEl.innerHTML = `Estás viendo en Listopic: <a href="list-view.html?listId=${listIdFromURL}">${uiUtils.escapeHtml(listDataGlobal.name)}</a>`;
+                    } else {
+                        detailListNameEl.textContent = 'Estás viendo en Listopic: Lista desconocida';
                     }
-                } else if (detailListNameEl) {
-                    detailListNameEl.textContent = "Estas viendo en Listopic: Lista Desconocida";
-                    if (uiUtils.updatePageHeaderInfo) uiUtils.updatePageHeaderInfo();
+                }
+                if (detailListLinkEl) {
+                    if (listDataGlobal.name) {
+                        detailListLinkEl.href = `list-view.html?listId=${listIdFromURL}`;
+                        detailListLinkEl.textContent = listDataGlobal.name;
+                    } else {
+                        detailListLinkEl.removeAttribute('href');
+                        detailListLinkEl.textContent = 'Lista no disponible';
+                    }
+                }
+                if (uiUtils.updatePageHeaderInfo) {
+                    const currentCategory = listDataGlobal?.categoryId || undefined;
+                    uiUtils.updatePageHeaderInfo(currentCategory, listDataGlobal?.name);
                 }
 
-                // Renderizar valoraciones detalladas
-                if (detailRatingsListEl && reviewDataGlobal && reviewDataGlobal.scores) {
-                    detailRatingsListEl.innerHTML = '';
-                    if (typeof state.currentListCriteriaDefinitions === 'object' && Object.keys(state.currentListCriteriaDefinitions).length > 0) {
-                        for (const [critKey, critDef] of Object.entries(state.currentListCriteriaDefinitions)) {
-                            if (reviewDataGlobal.scores[critKey] !== undefined) {
-                                const li = document.createElement('li');
-                                const weightedText = critDef.ponderable === false ? ' <small class="non-weighted-detail">(No pondera)</small>' : '';
-                                li.innerHTML = `<span class="rating-label">${uiUtils.escapeHtml(critDef.label)}${weightedText}</span> <span class="rating-value">${parseFloat(reviewDataGlobal.scores[critKey]).toFixed(1)}</span>`;
-                                detailRatingsListEl.appendChild(li);
-                            }
-                        }
-                    } else {
-                        detailRatingsListEl.innerHTML = '<li>No hay criterios definidos para mostrar valoraciones.</li>';
-                    }
-                } else if (detailRatingsListEl) {
-                     detailRatingsListEl.innerHTML = '<li>No hay valoraciones detalladas disponibles.</li>';
-                }
+                refreshCriteriaVisuals();
 
                 // 3. Obtener datos del autor de la reseña
-                if (reviewDataGlobal.userId && reviewAuthorNameEl) {
+                if (reviewDataGlobal.userId) {
                     return db.collection('users').doc(reviewDataGlobal.userId).get(); // Esto devuelve una promesa
-                } else {
-                    if(reviewAuthorNameEl) reviewAuthorNameEl.textContent = 'Autor no especificado';
-                    return Promise.resolve(null); // Devolver promesa resuelta para el siguiente .then()
                 }
+                return Promise.resolve(null); // Devolver promesa resuelta para el siguiente .then()
             })
             .then(userDocOrNull => { // userDocOrNull es el resultado de la promesa del autor
                 if (userDocOrNull && userDocOrNull.exists) {
                     const userData = userDocOrNull.data();
-                    const authorRaw = userData.username || userData.displayName || 'Usuario Anonimo';
-                    const authorName = uiUtils.escapeHtml(authorRaw);
-
+                    const authorRaw = userData.displayName || userData.username || authorNameRaw || 'Usuario Anónimo';
                     updateShareData({ authorName: authorRaw });
 
-                    const authorLink = document.createElement('a');
-                    authorLink.href = `profile.html?viewUserId=${reviewDataGlobal.userId}`;
-                    authorLink.textContent = authorName;
-
-                    if (reviewAuthorNameEl) {
-                        reviewAuthorNameEl.innerHTML = '';
-                        reviewAuthorNameEl.appendChild(authorLink);
-                    }
-                } else if (reviewDataGlobal.userId && reviewAuthorNameEl) {
-                    reviewAuthorNameEl.textContent = 'Usuario Desconocido';
+                    const authorHref = reviewDataGlobal.userId ? `profile.html?viewUserId=${reviewDataGlobal.userId}` : '';
+                    updateAuthorChip(authorRaw, userData.photoUrl || reviewDataGlobal.authorPhotoUrl || '', authorHref);
+                } else if (reviewDataGlobal.userId) {
+                    updateAuthorChip('Usuario desconocido', reviewDataGlobal.authorPhotoUrl || '', `profile.html?viewUserId=${reviewDataGlobal.userId}`);
                     console.warn(`Autor de reseña con ID ${reviewDataGlobal.userId} no encontrado.`);
                 }
-                
+
                 // 4. Si la reseña tiene placeId, obtener datos del lugar
                 if (reviewDataGlobal && reviewDataGlobal.placeId) {
                     return db.collection('places').doc(reviewDataGlobal.placeId).get(); // Esto devuelve una promesa
@@ -1008,54 +1518,140 @@ ListopicApp.pageDetailView = (() => {
                 if (detailEstablishmentNameEl) {
                     detailEstablishmentNameEl.textContent = reviewDataGlobal.establishmentName || "Establecimiento no especificado";
                 }
-                if (detailLocationContainerEl) detailLocationContainerEl.style.display = 'none';
-                if (detailNoLocationDivEl) detailNoLocationDivEl.style.display = 'flex';
-                updateShareData({ placeId: '', placeName: reviewDataGlobal.establishmentName || '' });
+                if (detailLocationContainerEl) detailLocationContainerEl.hidden = true;
+                if (detailNoLocationEl) detailNoLocationEl.hidden = false;
+                updateShareData({ placeId: '', placeName: reviewDataGlobal.establishmentName || '', placeUrl: '' });
                 return Promise.resolve(null); // Devolver promesa resuelta
             })
             .then(placeDocOrNull => { // placeDocOrNull es el resultado de la promesa del lugar
                 let placeData = null;
+                let placeDetailUrl = null;
                 if (placeDocOrNull && placeDocOrNull.exists) {
-                    placeData = placeDocOrNull.data();
-                    if (detailEstablishmentNameEl) detailEstablishmentNameEl.textContent = placeData.name || "Nombre de lugar desconocido";
-                    
-                    if (detailImageEl && detailImageEl.alt === `Foto de reseña`) {
-                         detailImageEl.alt = `Foto de ${uiUtils.escapeHtml(reviewDataGlobal.itemName || placeData.name)}`;
+                    placeData = { id: placeDocOrNull.id, ...placeDocOrNull.data() };
+                    placeDataGlobal = placeData;
+                    if (detailEstablishmentNameEl) {
+                        detailEstablishmentNameEl.textContent = placeData.name || 'Nombre de lugar desconocido';
+                    }
+                    if (detailImageEl) {
+                        const fallbackAltName = reviewDataGlobal.itemName || placeData.name || 'la reseña';
+                        detailImageEl.alt = `Foto de ${fallbackAltName}`;
                     }
 
-                    if (detailLocationContainerEl && detailLocationTextEl && detailNoLocationDivEl && (placeData.address || placeData.name || placeData.googleMapsUrl || placeData.googlePlaceId)) {
-                        let mapsUrl = "#";
-                        if (placeData.googleMapsUrl) mapsUrl = placeData.googleMapsUrl;
-                        else if (placeData.googlePlaceId) mapsUrl = `https://www.google.com/maps/search/?api=1&query=Google&query_place_id=${placeData.googlePlaceId}`;
-                        else if (placeData.location?.latitude && placeData.location?.longitude) mapsUrl = `https://www.google.com/maps/search/?api=1&query=Google&query_place_id=${placeData.location.latitude},${placeData.location.longitude}`;
-
-                        if (detailLocationLinkEl) {
-                            if (mapsUrl !== "#") {
-                                detailLocationLinkEl.href = mapsUrl;
-                                detailLocationLinkEl.style.pointerEvents = "auto";
-                            } else {
-                                detailLocationLinkEl.removeAttribute('href');
-                                detailLocationLinkEl.style.pointerEvents = "none";
+                    if (detailImageEl && detailImageEl.hidden && !reviewDataGlobal.photoUrl) {
+                        const photosArray = Array.isArray(placeData.photos)
+                            ? placeData.photos
+                            : (placeData.photos ? [placeData.photos] : []);
+                        const primaryPhotoFromArray = photosArray
+                            .map(photoEntry => {
+                                if (!photoEntry) return '';
+                                if (typeof photoEntry === 'string') return photoEntry;
+                                if (typeof photoEntry === 'object') {
+                                    return photoEntry.url || photoEntry.photoUrl || photoEntry.src || '';
+                                }
+                                return '';
+                            })
+                            .find(Boolean);
+                        const fallbackPlacePhoto = primaryPhotoFromArray
+                            || placeData.mainImageUrl
+                            || placeData.mainPhotoUrl
+                            || placeData.photoUrl
+                            || placeData.primaryPhotoUrl
+                            || placeData.coverPhotoUrl
+                            || placeData.coverImageUrl
+                            || placeData.heroImageUrl
+                            || placeData.imageUrl
+                            || '';
+                        if (fallbackPlacePhoto) {
+                            detailImageEl.src = fallbackPlacePhoto;
+                            detailImageEl.hidden = false;
+                            if (detailImagePlaceholderEl) detailImagePlaceholderEl.hidden = true;
+                            if (detailMediaLinkEl && !groupLinkUrl) {
+                                detailMediaLinkEl.href = fallbackPlacePhoto;
+                                detailMediaLinkEl.hidden = false;
+                                detailMediaLinkEl.setAttribute('aria-label', 'Abrir la foto del lugar en una pestaña nueva');
+                                detailMediaLinkEl.target = '_blank';
                             }
                         }
-                        detailLocationTextEl.textContent = placeData.address || placeData.name;
-                        detailNoLocationDivEl.style.display = 'none';
-                        detailLocationContainerEl.style.display = 'block';
-                    } else {
-                        if (detailLocationContainerEl) detailLocationContainerEl.style.display = 'none';
-                        if (detailNoLocationDivEl) detailNoLocationDivEl.style.display = 'flex';
                     }
-                } else if (reviewDataGlobal && reviewDataGlobal.placeId) {
-                    if (detailEstablishmentNameEl) detailEstablishmentNameEl.textContent = "Lugar no encontrado en BD";
-                    console.warn(`Lugar con ID ${reviewDataGlobal.placeId} no encontrado para la reseña ${reviewId}`);
-                    if (detailLocationContainerEl) detailLocationContainerEl.style.display = 'none';
-                    if (detailNoLocationDivEl) detailNoLocationDivEl.style.display = 'flex';
+
+                    placeDetailUrl = buildPlaceDetailLinkUrl(placeData.id);
+
+                    let mapsUrl = '#';
+                    if (placeData.googleMapsUrl) mapsUrl = placeData.googleMapsUrl;
+                    else if (placeData.googlePlaceId) mapsUrl = `https://www.google.com/maps/search/?api=1&query_place_id=${encodeURIComponent(placeData.googlePlaceId)}`;
+                    else if (placeData.location?.latitude && placeData.location?.longitude) mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${placeData.location.latitude},${placeData.location.longitude}`)}`;
+
+                    const hasMapsLink = typeof mapsUrl === 'string' && mapsUrl !== '#';
+                    const locationLabel = placeData.address || placeData.name || '';
+                    const shouldShowLocation = Boolean(locationLabel || hasMapsLink);
+
+                    if (detailLocationContainerEl && detailLocationTextEl && detailLocationLinkEl) {
+                        detailLocationTextEl.textContent = locationLabel || 'Ubicación no disponible';
+                        if (hasMapsLink) {
+                            detailLocationLinkEl.href = mapsUrl;
+                            detailLocationLinkEl.style.pointerEvents = 'auto';
+                            detailLocationLinkEl.target = '_blank';
+                            detailLocationLinkEl.removeAttribute('aria-disabled');
+                            detailLocationLinkEl.removeAttribute('tabindex');
+                        } else {
+                            detailLocationLinkEl.removeAttribute('href');
+                            detailLocationLinkEl.style.pointerEvents = 'none';
+                            detailLocationLinkEl.removeAttribute('target');
+                            detailLocationLinkEl.setAttribute('aria-disabled', 'true');
+                            detailLocationLinkEl.tabIndex = -1;
+                        }
+                        detailLocationContainerEl.hidden = !shouldShowLocation;
+                        if (detailNoLocationEl) detailNoLocationEl.hidden = shouldShowLocation;
+                    } else if (detailLocationContainerEl) {
+                        detailLocationContainerEl.hidden = true;
+                        if (detailNoLocationEl) detailNoLocationEl.hidden = false;
+                    }
+
+                    if (detailPlaceLinkEl) {
+                        detailPlaceLinkEl.textContent = placeData.name || 'Lugar sin nombre';
+                        if (placeDetailUrl) {
+                            detailPlaceLinkEl.href = placeDetailUrl;
+                            detailPlaceLinkEl.target = '_self';
+                            detailPlaceLinkEl.removeAttribute('rel');
+                        } else {
+                            detailPlaceLinkEl.removeAttribute('href');
+                            detailPlaceLinkEl.removeAttribute('target');
+                            detailPlaceLinkEl.removeAttribute('rel');
+                        }
+                    }
+                    if (detailPlaceLinkWrapperEl) {
+                        detailPlaceLinkWrapperEl.hidden = false;
+                    }
+                } else {
+                    placeDataGlobal = null;
+                    placeDetailUrl = null;
+                    if (reviewDataGlobal && reviewDataGlobal.placeId) {
+                        console.warn(`Lugar con ID ${reviewDataGlobal.placeId} no encontrado para la reseña ${reviewId}`);
+                    }
+                    if (detailEstablishmentNameEl) {
+                        detailEstablishmentNameEl.textContent = reviewDataGlobal.establishmentName || 'Establecimiento no especificado';
+                    }
+                    if (detailLocationContainerEl) detailLocationContainerEl.hidden = true;
+                    if (detailNoLocationEl) detailNoLocationEl.hidden = false;
+                    if (detailPlaceLinkEl) {
+                        detailPlaceLinkEl.textContent = reviewDataGlobal.establishmentName || 'Ubicación no disponible';
+                        detailPlaceLinkEl.removeAttribute('href');
+                        detailPlaceLinkEl.removeAttribute('target');
+                        detailPlaceLinkEl.removeAttribute('rel');
+                    }
+                    if (detailPlaceLinkWrapperEl) {
+                        detailPlaceLinkWrapperEl.hidden = false;
+                    }
                 }
+                const placeIdForShare = placeData?.id || reviewDataGlobal?.placeId || fromPlaceIdParam || '';
                 const placeNameForShare = placeData?.name || reviewDataGlobal.establishmentName || '';
                 updateShareData({
-                    placeId: reviewDataGlobal?.placeId || placeData?.id || '',
-                    placeName: placeNameForShare
+                    placeId: placeIdForShare,
+                    placeName: placeNameForShare,
+                    placeUrl: placeDetailUrl || ''
                 });
+                groupLinkUrl = buildGroupLinkUrl(placeIdForShare || null, reviewDataGlobal?.itemName || fromItemParam || '');
+                applyGroupLink();
                 // Si placeDocOrNull es null, ya se manejo el caso sin placeId antes
             })
             .catch(error => {
@@ -1064,9 +1660,7 @@ ListopicApp.pageDetailView = (() => {
                 if (ListopicApp.services && ListopicApp.services.showNotification) {
                      ListopicApp.services.showNotification(error.message || "Error al cargar los detalles.", "error");
                 }
-                if (shareButton) {
-                    shareButton.disabled = true;
-                }
+                setShareButtonsEnabled(false);
             });
 
         // Listener para el boton de eliminar

--- a/public/style.css
+++ b/public/style.css
@@ -836,53 +836,370 @@ small.non-weighted-header { /* Para (NP) en cabeceras */
 
 
 /* DETAIL-VIEW Specifics */
-.detail-list-name { font-size: 0.9em; color: rgba(255,255,255,0.7); margin-bottom: 5px; text-align: center; }
-#detail-restaurant-name { margin-bottom: 5px; }
-.detail-dish-name { font-size: 1.1em; color: var(--accent-color-quinary); margin-bottom: 25px; text-align: center; font-weight: 400; }
-.detail-content { display: flex; flex-wrap: wrap; gap: 30px; margin-bottom: 30px; }
-.detail-image-area { flex: 1; min-width: 280px; }
-.detail-image-area img { width: 100%; max-height: 400px; object-fit: cover; border-radius: 10px; border: 1px solid var(--input-border); box-shadow: 0 5px 15px rgba(0,0,0,0.2); }
-/* Para el placeholder de icono en detail-view */
-.detail-image-icon-placeholder {
+.detail-page__container {
+    max-width: 1200px;
+}
+
+.detail-list-name {
+    font-size: 0.95em;
+    color: rgba(255,255,255,0.7);
+    margin: 10px 0 20px;
+}
+
+.detail-page .back-button {
+    margin-bottom: 8px;
+}
+
+.detail-hero {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    padding: 28px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(15,23,42,0.6), rgba(30,41,59,0.85));
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: 0 18px 40px rgba(8,14,29,0.45);
+    margin-bottom: 40px;
+}
+
+.detail-hero__media {
+    position: relative;
+    flex: 1 1 420px;
+    min-height: 320px;
+    border-radius: 16px;
+    overflow: hidden;
+    background: rgba(15,23,42,0.35);
+}
+
+.detail-hero__media img {
     width: 100%;
-    height: 300px; /* Ajusta a la altura deseada para el placeholder grande */
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    filter: saturate(1.05);
+}
+
+.detail-hero__media img[hidden] {
+    display: none;
+}
+
+.detail-image-icon-placeholder {
+    position: absolute;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--icon-placeholder-bg, rgba(0,0,0,0.25));
-    border-radius: 10px;
-    border: 1px solid var(--input-border);
-}
-.detail-image-icon-placeholder i {
-    font-size: 5em; /* Icono mÃ¡s grande para detail-view */
-    color: var(--icon-placeholder-color, var(--accent-color-primary));
+    color: rgba(255,255,255,0.65);
+    background: rgba(15,23,42,0.65);
+    font-size: 4rem;
 }
 
+.detail-image-icon-placeholder[hidden] {
+    display: none !important;
+}
 
-.detail-info-area { flex: 1; min-width: 280px; text-align: left; background-color: rgba(0,0,0,0.15); padding: 20px; border-radius: 8px; }
-.detail-overall-score-container { text-align: center; margin-bottom: 20px; padding-bottom: 15px; border-bottom: 1px solid rgba(255,255,255,0.1); }
-.detail-overall-score-container span { display: block; font-size: 1em; opacity: 0.8; }
-.detail-overall-score { font-size: 3em; font-weight: 700; color: var(--accent-color-primary); }
-.detail-ratings-list { list-style: none; padding: 0; margin: 0 0 20px 0; }
-.detail-ratings-list li { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.08); }
-.detail-ratings-list li:last-child { border-bottom: none; }
-.detail-ratings-list .rating-label { opacity: 0.9; }
-.detail-ratings-list .rating-value { font-weight: 600; color: var(--accent-color-secondary); }
-small.non-weighted-detail { font-size: 0.85em; opacity: 0.7; font-style: italic; }
+.detail-hero__media-link {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+}
 
+.detail-hero__info {
+    flex: 1 1 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
 
-#detail-location-container { margin-bottom: 20px; }
-.detail-location a, .detail-no-location { display: inline-flex; align-items: center; gap: 8px; color: var(--accent-color-tertiary); text-decoration: none; padding: 8px 12px; background-color: rgba(var(--accent-color-tertiary-rgb, 6,214,160), 0.1); border-radius: 6px; transition: background-color 0.2s; }
-.detail-location a:hover { background-color: rgba(var(--accent-color-tertiary-rgb, 6,214,160), 0.2); }
-.detail-no-location { color: rgba(255,255,255,0.5); background-color: rgba(255,255,255,0.05); }
-.detail-no-location i { opacity: 0.7; }
+#detail-restaurant-name {
+    margin: 0;
+    font-size: clamp(1.9rem, 3vw, 2.6rem);
+    font-weight: 600;
+    color: #fff;
+}
 
-.detail-comment, .detail-tags-area { margin-bottom: 20px; padding-top: 15px; border-top: 1px solid rgba(255,255,255,0.1); }
-.detail-comment h4, .detail-tags-area h4 { margin-top: 0; margin-bottom: 10px; color: var(--accent-color-quaternary); font-weight: 600; }
-#detail-comment-text { line-height: 1.7; opacity: 0.95; }
-#detail-tags { display: flex; flex-wrap: wrap; gap: 8px; }
-.tag-detail { background-color: var(--accent-color-secondary); color: white; padding: 5px 10px; border-radius: 15px; font-size: 0.85em; }
-.detail-actions { margin-top: 30px; display: flex; justify-content: flex-end; gap: 15px; }
+.detail-dish-name {
+    font-size: 1.1rem;
+    color: var(--accent-color-quinary);
+    margin: 0;
+}
+
+.detail-hero__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.detail-score-badge {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 14px 18px;
+    border-radius: 14px;
+    background: rgba(15,23,42,0.45);
+    border: 1px solid rgba(255,255,255,0.1);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.detail-score-badge__label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.6);
+}
+
+.detail-score-badge__value {
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--accent-color-primary);
+    line-height: 1;
+}
+
+.detail-meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px 24px;
+    margin: 0;
+}
+
+.detail-meta-grid__item {
+    background: rgba(15,23,42,0.35);
+    border-radius: 12px;
+    padding: 12px 16px;
+    border: 1px solid rgba(255,255,255,0.06);
+}
+
+.detail-meta-grid__item dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.5);
+    margin-bottom: 4px;
+}
+
+.detail-meta-grid__item dd {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+
+.detail-meta-grid__item a {
+    color: var(--accent-color-tertiary);
+}
+
+.detail-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.detail-group-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.detail-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 28px;
+}
+
+.detail-primary,
+.detail-secondary {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.detail-card {
+    background: rgba(15,23,42,0.5);
+    border-radius: 18px;
+    border: 1px solid rgba(255,255,255,0.06);
+    padding: 24px;
+    box-shadow: 0 12px 26px rgba(8,14,29,0.3);
+}
+
+.detail-card__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.detail-card__header h2 {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.chart-mode-toggle {
+    display: inline-flex;
+    padding: 4px;
+    background: rgba(15,23,42,0.55);
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,0.08);
+}
+
+.chart-mode-toggle__button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: rgba(255,255,255,0.7);
+    padding: 6px 16px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s;
+}
+
+.chart-mode-toggle__button:hover:not(.is-active) {
+    background: rgba(255,255,255,0.08);
+}
+
+.chart-mode-toggle__button.is-active,
+.chart-mode-toggle__button[aria-pressed="true"] {
+    background: var(--accent-color-primary);
+    color: #0f172a;
+    box-shadow: 0 8px 18px rgba(249,115,22,0.35);
+}
+
+.detail-chart {
+    position: relative;
+    min-height: 280px;
+}
+
+#detail-criteria-canvas {
+    width: 100%;
+    height: 320px;
+    display: block;
+}
+
+.detail-chart__empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 0.95rem;
+    color: rgba(255,255,255,0.7);
+}
+
+.detail-card--metrics .chart-mode-toggle {
+    margin-bottom: 18px;
+}
+
+.detail-card--comment p {
+    margin: 0;
+    line-height: 1.7;
+}
+
+.detail-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.detail-tags .tag-detail {
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.08);
+    color: rgba(255,255,255,0.85);
+}
+
+.detail-hero__author {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(15,23,42,0.55);
+    border: 1px solid rgba(255,255,255,0.08);
+    margin: 8px 0 2px;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.detail-hero__author:hover {
+    background: rgba(15,23,42,0.68);
+    border-color: rgba(255,255,255,0.16);
+}
+
+.detail-hero__author-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent-color-primary), var(--accent-color-tertiary));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: rgba(15,23,42,0.95);
+    overflow: hidden;
+}
+
+.detail-hero__author-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.detail-hero__author-name {
+    font-weight: 600;
+    color: #fff;
+    text-decoration: none;
+    font-size: 1rem;
+}
+
+.detail-hero__author-name:hover,
+.detail-hero__author-name:focus {
+    text-decoration: underline;
+}
+
+.detail-location-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--accent-color-tertiary);
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: rgba(6,214,160,0.12);
+    transition: background 0.2s, transform 0.2s;
+}
+
+.detail-location-link:hover {
+    background: rgba(6,214,160,0.22);
+    transform: translateY(-1px);
+}
+
+.detail-no-location {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: rgba(255,255,255,0.05);
+    color: rgba(255,255,255,0.6);
+}
+
+.detail-no-location[hidden],
+#detail-location-container[hidden],
+#detail-author-chip[hidden] {
+    display: none !important;
+}
+
+.share-story-button--secondary {
+    width: 100%;
+    margin-top: 12px;
+}
+
+.detail-card--share p {
+    margin: 0;
+    color: rgba(255,255,255,0.7);
+}
 .share-story-button {
     background: linear-gradient(135deg, #f58529, #dd2a7b, #8134af, #515bd4);
     color: #fff;
@@ -972,7 +1289,33 @@ small.non-weighted-detail { font-size: 0.85em; opacity: 0.7; font-style: italic;
     .list-header-actions { flex-direction: column; align-items: stretch; }
     .list-header-actions h2 { text-align: left; }
     .list-actions { justify-content: center; }
-    .detail-content { flex-direction: column; }
+    .detail-hero {
+        flex-direction: column;
+        padding: 22px;
+    }
+    .detail-hero__media {
+        min-height: 260px;
+    }
+    .detail-hero__author {
+        width: 100%;
+        justify-content: flex-start;
+    }
+    .detail-hero__actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+    .detail-hero__actions .share-story-button,
+    .detail-hero__actions .edit-button,
+    .detail-hero__actions .delete-button,
+    .detail-hero__actions .detail-group-link {
+        flex: 1 1 auto;
+    }
+    .detail-layout {
+        grid-template-columns: 1fr;
+    }
+    .detail-card {
+        padding: 20px;
+    }
     .criterion-item input[name="criteria_title[]"] { flex-basis: 100%; }
     .criterion-item input[name="criteria_label_left[]"], .criterion-item input[name="criteria_label_right[]"] { flex-basis: calc(50% - 1rem); }
     
@@ -994,6 +1337,30 @@ small.non-weighted-detail { font-size: 0.85em; opacity: 0.7; font-style: italic;
     }
     .share-customization__row select {
         width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    .detail-score-badge__value {
+        font-size: 2.4rem;
+    }
+    .detail-card {
+        padding: 18px;
+    }
+    .detail-hero__author {
+        gap: 10px;
+        padding: 6px 10px;
+    }
+    .detail-hero__author-avatar {
+        width: 42px;
+        height: 42px;
+        font-size: 0.95rem;
+    }
+    .detail-meta-grid {
+        grid-template-columns: 1fr;
+    }
+    .detail-hero__meta {
+        gap: 12px;
     }
 }
 
@@ -8414,6 +8781,40 @@ body.chat-list-modal-open {
 
 .review-share-modal__story-feedback[data-type="warning"] {
     color: var(--accent-color-secondary);
+}
+
+@media (max-width: 640px) {
+    .review-share-modal__content {
+        width: 100%;
+        max-width: none;
+        margin: 0;
+        border-radius: 0;
+        min-height: 100vh;
+        padding: 20px 18px 28px;
+    }
+
+    .review-share-modal__link-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .review-share-modal__link-row .button {
+        width: 100%;
+    }
+
+    .review-share-modal__story-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .review-share-modal__story-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .review-share-modal__story-actions .button {
+        width: 100%;
+        justify-content: center;
+    }
 }
 
 .review-share-chat-btn {


### PR DESCRIPTION
## Summary
- Show the author chip in the hero header, drop redundant card headers, and label the review with its creation date
- Update the detail view logic to keep the author chip hydrated, surface proper list/place/Maps links, humanize criteria labels across the chart and share card, and fall back to place imagery without leaving the placeholder overlay
- Tune styles for the hero chip, hidden states, and the share modal so the layout adapts cleanly on mobile screens

## Testing
- Not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e3c13cd2ac8326a4ea8eefb6f65bf7