### PR TITLE
Improve mobile review form layout and drag-and-drop upload

### DIFF
--- a/public/js/page-review-form.js
+++ b/public/js/page-review-form.js
@@ -82,18 +82,19 @@ ListopicApp.pageReviewForm = (() => {
             });
         }
 
-        // Gestionamos la selección del archivo y la compresión
-        photoFileInput.addEventListener('change', async (event) => {
-            const file = event.target.files[0];
+        const handleImageFile = async (file) => {
             if (!file) return;
 
+            if (!file.type || !file.type.startsWith('image/')) {
+                ListopicApp.services.showNotification('El archivo seleccionado no es una imagen válida.', 'error');
+                return;
+            }
+
             photoUrlInput.value = '';
-            
+
             try {
-                // === INICIO DEL CÓDIGO AÑADIDO ===
                 console.log(`📸 Imagen original: ${(file.size / 1024 / 1024).toFixed(2)} MB`);
-                // === FIN DEL CÓDIGO AÑADIDO ===
-                
+
                 imagePreviewContainer.innerHTML = '<p class="loading-placeholder">Comprimiendo imagen...</p>';
 
                 const compressedFile = await uiUtils.compressImage(file, {
@@ -102,10 +103,8 @@ ListopicApp.pageReviewForm = (() => {
                     quality: 0.7
                 });
 
-                // === INICIO DEL CÓDIGO AÑADIDO ===
                 console.log(`✅ Imagen comprimida: ${(compressedFile.size / 1024 / 1024).toFixed(2)} MB`);
-                // === FIN DEL CÓDIGO AÑADIDO ===
-                
+
                 state.selectedFileForUpload = compressedFile;
 
                 const previewUrl = URL.createObjectURL(compressedFile);
@@ -114,12 +113,62 @@ ListopicApp.pageReviewForm = (() => {
             } catch (error) {
                 console.error("Error al comprimir la imagen:", error);
                 ListopicApp.services.showNotification("Error al procesar la imagen.", 'error');
-                if(uiUtils.clearPreviewGlobal) {
+                if (uiUtils.clearPreviewGlobal) {
                     uiUtils.clearPreviewGlobal(imagePreviewContainer, photoUrlInput, photoFileInput);
                 } else {
                     imagePreviewContainer.innerHTML = '';
                 }
             }
+        };
+
+        const syncInputFiles = (file) => {
+            if (!window.DataTransfer) return;
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(file);
+            photoFileInput.files = dataTransfer.files;
+        };
+
+        // Gestionamos la selección del archivo y la compresión
+        photoFileInput.addEventListener('change', async (event) => {
+            const file = event.target.files[0];
+            await handleImageFile(file);
+        });
+
+        const preventDragDefaults = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        ['dragenter', 'dragover'].forEach((eventName) => {
+            uploadArea.addEventListener(eventName, (event) => {
+                preventDragDefaults(event);
+                uploadArea.classList.add('drag-over');
+            });
+        });
+
+        ['dragleave', 'dragend'].forEach((eventName) => {
+            uploadArea.addEventListener(eventName, (event) => {
+                preventDragDefaults(event);
+                uploadArea.classList.remove('drag-over');
+            });
+        });
+
+        uploadArea.addEventListener('drop', async (event) => {
+            preventDragDefaults(event);
+            uploadArea.classList.remove('drag-over');
+
+            const files = Array.from(event.dataTransfer?.files || []);
+            const file = files.find((candidate) => candidate.type && candidate.type.startsWith('image/'));
+
+            if (!file) {
+                if (files.length) {
+                    ListopicApp.services.showNotification('Solo se admiten imágenes en este apartado.', 'error');
+                }
+                return;
+            }
+
+            syncInputFiles(file);
+            await handleImageFile(file);
         });
 
         // Gestionamos la entrada de URL

--- a/public/style.css
+++ b/public/style.css
@@ -632,7 +632,7 @@ body.light-theme .form-group.place-found .form-input {
 }
 
 .image-actions {
-    margin-top: 12px;
+    margin-top: 0;
     display: flex;
     gap: 12px;
     flex-wrap: wrap;
@@ -640,8 +640,7 @@ body.light-theme .form-group.place-found .form-input {
 }
 
 .image-preview {
-    margin-top: 16px;
-    min-height: 120px;
+    margin-top: 0;
     border-radius: 12px;
     overflow: hidden;
 }
@@ -650,6 +649,9 @@ body.light-theme .form-group.place-found .form-input {
     background: rgba(255, 255, 255, 0.05);
     border-radius: 12px;
     padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
 }
 
 .place-selection-status {
@@ -1084,6 +1086,66 @@ body.light-theme .confirm-modal__dialog {
     }
 }
 
+@media (max-width: 600px) {
+    .review-form-page {
+        padding: clamp(16px, 5vw, 36px) 0 calc(var(--footer-height) + 32px);
+    }
+
+    .review-form-shell {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    .review-form-card {
+        padding: 0 16px;
+    }
+
+    .form-section {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        padding: 20px 0;
+        margin-bottom: 28px;
+        box-shadow: none;
+    }
+
+    .form-section:first-of-type {
+        padding-top: 0;
+    }
+
+    .input-action-group {
+        gap: 12px;
+    }
+
+    .input-action-group .form-input,
+    .input-action-group button {
+        width: 100%;
+        min-width: 0;
+    }
+
+    #find-nearby-btn {
+        width: 100%;
+    }
+
+    .form-input,
+    .form-textarea,
+    .form-input[type=search],
+    select.form-input {
+        padding: 12px 14px;
+    }
+
+    .search-input {
+        padding-left: 44px;
+    }
+
+    .review-form-card .tag-selection {
+        background: transparent;
+        padding: 0;
+    }
+}
+
 @media (max-width: 520px) {
     .help-button {
         width: 100%;
@@ -1300,18 +1362,26 @@ body.light-theme .criterion-slider-config {
 .remove-button { padding: 5px 10px; font-size: 1.2em; line-height: 1; }
 
 /* REVIEW-FORM: Image Upload */
-.image-upload-area { border: 2px dashed var(--input-border); border-radius: 8px; padding: 20px; text-align: center; cursor: pointer; transition: border-color 0.3s ease, background-color 0.3s ease; }
-.image-upload-area.drag-over { border-style: solid; border-color: var(--accent-color-primary); background-color: rgba(var(--accent-color-primary-rgb, 255,209,102), 0.05); }
-.upload-instructions i { font-size: 3em; color: var(--accent-color-primary); margin-bottom: 10px; }
-.upload-instructions p { margin: 5px 0; font-size: 0.9em; }
+.image-upload-area { border: 2px dashed var(--input-border); border-radius: 12px; padding: 18px 20px; cursor: pointer; transition: border-color 0.3s ease, background-color 0.3s ease; display: grid; gap: 14px; justify-items: stretch; align-content: start; background-color: rgba(255, 255, 255, 0.02); }
+.image-upload-area.drag-over { border-style: solid; border-color: var(--accent-color-primary); background-color: rgba(var(--accent-color-primary-rgb, 29, 185, 84), 0.08); }
+.upload-instructions { display: grid; justify-items: center; gap: 8px; text-align: center; }
+.upload-instructions i { font-size: 2.6em; color: var(--accent-color-primary); margin-bottom: 0; }
+.upload-instructions p { margin: 0; font-size: 0.9em; }
 .file-input-hidden { display: none; }
-.image-upload-area .url-input { margin-top: 5px; }
-.image-preview img { max-width: 100%; max-height: 200px; margin-top: 15px; border-radius: 6px; border: 1px solid var(--input-border); }
-#image-actions button { background-color: var(--accent-color-secondary); color: white; border: none; padding: 8px 12px; margin: 5px; border-radius: 5px; cursor: pointer; font-size: 0.9em; }
+.image-upload-area .image-actions { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; }
+.image-upload-area .url-input { margin-top: 0; }
+.image-preview { margin-top: 0; border-radius: 12px; overflow: hidden; display: none; }
+.image-preview:not(:empty) { display: block; }
+.image-preview img { display: block; width: 100%; height: auto; border-radius: 0; border: none; }
+#image-actions button { background-color: var(--accent-color-secondary); color: white; border: none; padding: 8px 12px; margin: 0; border-radius: 5px; cursor: pointer; font-size: 0.9em; }
 #image-actions button:hover { opacity: 0.9; }
 
 /* REVIEW-FORM: Tag Selection (Checkboxes) */
-.tag-selection { display: flex; flex-wrap: wrap; gap: 10px; padding-top: 5px; }
+.tag-selection { display: flex; flex-wrap: wrap; gap: 4px; padding-top: 5px; }
+.tag-selection .fixed-tags-container,
+.tag-selection .user-tags-container { display: flex; flex-wrap: wrap; gap: 4px; width: 100%; }
+.tag-selection .fixed-tags-container h5,
+.tag-selection .user-tags-container h5 { width: 100%; margin: 0; font-size: 0.85rem; opacity: 0.75; }
 .tag-checkbox { background-color: rgba(255,255,255,0); padding: 8px 12px; border-radius: 15px; border: 1px solid transparent; cursor: pointer; transition: background-color 0.2s, border-color 0.2s, color 0.2s; font-size: 0.9em; display: inline-flex; align-items: center; color: var(--text-color); }
 .tag-checkbox:hover { background-color: rgba(255,255,255,0.2); }
 .tag-checkbox input[type="checkbox"] { appearance: none; -webkit-appearance: none; -moz-appearance: none; margin-right: 8px; width: 16px; height: 16px; border: 1px solid var(--input-border); border-radius: 3px; background-color: var(--input-bg); cursor: pointer; position: relative; vertical-align: middle; outline: none; flex-shrink: 0; transition: background-color 0.2s, border-color 0.2s; }


### PR DESCRIPTION
## Summary
- update review form styling so the layout uses the full width on mobile, reduces heavy card chrome, and tightens tag spacing
- refine the image upload area to size to its contents and align controls more cleanly across breakpoints
- add drag-and-drop handling and file validation for the photo uploader

## Testing
- not run (static front-end changes)


------
https://chatgpt.com/codex/tasks/task_e_68e57ad92d048326a4760645fb70496d