### PR TITLE
Adjust mobile review form spacing and enable camera capture

### DIFF
--- a/public/js/page-review-form.js
+++ b/public/js/page-review-form.js
@@ -311,6 +311,7 @@ ListopicApp.pageReviewForm = (() => {
         const uploadArea = document.getElementById('image-drop-area');
         const galleryButton = document.getElementById('browse-gallery-btn');
         const useCameraButton = document.getElementById('use-camera-btn');
+        const cameraCaptureInput = document.getElementById('photo-camera-capture');
         const uiUtils = window.ListopicApp?.uiUtils || {};
 
         if (!photoFileInput || !imagePreviewContainer || !photoUrlInput || !uploadArea) {
@@ -382,6 +383,14 @@ ListopicApp.pageReviewForm = (() => {
             handleImageFile(file);
         });
 
+        cameraCaptureInput?.addEventListener('change', (event) => {
+            const file = event.target.files?.[0];
+            handleImageFile(file);
+            if (cameraCaptureInput) {
+                cameraCaptureInput.value = '';
+            }
+        });
+
         const preventDefaults = (event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -424,7 +433,41 @@ ListopicApp.pageReviewForm = (() => {
 
         useCameraButton?.addEventListener('click', (event) => {
             event.preventDefault();
-            notify('Funcionalidad de cámara en preparación.', 'info');
+
+            const triggerStandaloneCaptureInput = () => {
+                if (!cameraCaptureInput) {
+                    return false;
+                }
+                cameraCaptureInput.value = '';
+                cameraCaptureInput.click();
+                return true;
+            };
+
+            if (triggerStandaloneCaptureInput()) {
+                return;
+            }
+
+            if (photoFileInput) {
+                const restoreCaptureAttribute = () => {
+                    photoFileInput.removeAttribute('capture');
+                    photoFileInput.removeEventListener('change', restoreCaptureAttribute);
+                };
+
+                photoFileInput.setAttribute('capture', 'environment');
+                photoFileInput.addEventListener('change', restoreCaptureAttribute, { once: true });
+                setTimeout(() => {
+                    photoFileInput.removeAttribute('capture');
+                }, 2000);
+
+                photoFileInput.click();
+                return;
+            }
+
+            if (navigator.mediaDevices?.getUserMedia) {
+                notify('No pudimos abrir directamente la cámara. Concede permisos al navegador o usa la subida de archivos.', 'warning');
+            } else {
+                notify('Este dispositivo no permite acceder a la cámara desde el navegador.', 'error');
+            }
         });
     }
 

--- a/public/review-form.html
+++ b/public/review-form.html
@@ -212,6 +212,7 @@
                                     <p>Arrastra imagen aquí o haz clic para seleccionar</p>
                                 </div>
                                 <input type="file" id="photo-file" name="photo_file" accept="image/*" class="file-input-hidden">
+                                <input type="file" id="photo-camera-capture" accept="image/*" capture="environment" class="file-input-hidden">
                                 <div id="image-actions" class="image-actions">
                                     <button type="button" id="browse-gallery-btn"><i class="fas fa-images"></i> Desde Galería</button>
                                     <button type="button" id="use-camera-btn"><i class="fas fa-camera"></i> Usar Cámara</button>

--- a/public/style.css
+++ b/public/style.css
@@ -1290,15 +1290,50 @@ body.light-theme .confirm-modal__dialog {
 
     .form-section {
         background: transparent;
-        border: none;
         border-radius: 0;
-        padding: 20px 0;
+        padding: 20px 16px 24px;
         margin-bottom: 28px;
         box-shadow: none;
+        border-top: 1px solid rgba(255, 255, 255, 0.12);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
     }
 
     .form-section:first-of-type {
         padding-top: 0;
+        border-top: none;
+    }
+
+    .form-section:last-of-type {
+        border-bottom: none;
+        margin-bottom: 0;
+        padding-bottom: 0;
+    }
+
+    body.light-theme .form-section {
+        border-color: rgba(0, 0, 0, 0.08);
+    }
+
+    .form-section__content-grid {
+        gap: 16px;
+    }
+
+    .section-aside-card {
+        padding: 16px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: none;
+    }
+
+    body.light-theme .section-aside-card {
+        background: rgba(0, 0, 0, 0.03);
+        border-color: rgba(0, 0, 0, 0.08);
+    }
+
+    .manual-location-card {
+        margin-top: 12px;
+        padding: 16px;
+        gap: 12px;
     }
 
     .input-action-group {
@@ -1610,12 +1645,15 @@ body.light-theme .criterion-slider-config {
 }
 
 #manual-location-fields {
-    display: none; /* Controlado con JS */
-    border: 1px solid var(--border-color-light);
-    padding: 20px;
-    border-radius: var(--border-radius-medium);
-    margin-top: 10px;
-    background-color: rgba(var(--text-color-rgb, 224, 224, 224), 0.03);
+    border: none;
+    padding: 0;
+    border-radius: 0;
+    margin-top: 18px;
+    background-color: transparent;
+}
+
+#manual-location-fields[hidden] {
+    display: none !important;
 }
 #manual-location-fields label { margin-top: 10px; font-size: 0.9em; }
 #manual-location-fields input.form-input { margin-bottom: 5px; }
@@ -2473,8 +2511,8 @@ body.light-theme #list-circles-ul a:hover {
     border-color: #D1D1D6;
 }
 body.light-theme #manual-location-fields {
-    background-color: #F5F5F7;
-    border-color: #E5E5E5;
+    background-color: transparent;
+    border-color: rgba(0, 0, 0, 0.08);
 }
 
 


### PR DESCRIPTION
## Summary
- refine the review form mobile layout so sections sit flush on the background with clearer separators
- tweak manual location and aside card spacing to keep place and dish inputs compact on small screens
- add a dedicated camera capture input and hook the "Usar Cámara" button to launch it before falling back to the standard picker

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e613b76d588326af2d4e6eaca81e74