### PR TITLE
Validate image size and surface detailed Firebase storage errors in PlacePhotoUploadModal

### DIFF
--- a/frontend/src/components/PlacePhotoUploadModal.tsx
+++ b/frontend/src/components/PlacePhotoUploadModal.tsx
@@ -1,11 +1,35 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { addDoc, collection, doc, serverTimestamp, setDoc } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+import { FirebaseError } from 'firebase/app';
 import type { User } from 'firebase/auth';
 import { Camera, ImagePlus, Loader2, Trash2, X } from 'lucide-react';
 import { db, storage } from '../firebase';
 import { PhotoEditorModal, type ProcessedPhoto } from './PhotoEditorModal';
+
+
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function getUploadErrorMessage(error: unknown): string {
+    if (error instanceof FirebaseError) {
+        if (error.code === 'storage/unauthorized') {
+            return 'No tienes permisos para subir fotos. Revisa permisos de la app y vuelve a iniciar sesión.';
+        }
+        if (error.code === 'storage/retry-limit-exceeded' || error.code === 'storage/canceled') {
+            return 'La subida se interrumpió. Comprueba tu conexión e inténtalo de nuevo.';
+        }
+        if (error.code === 'storage/quota-exceeded') {
+            return 'No hay espacio disponible para guardar más fotos ahora mismo. Inténtalo más tarde.';
+        }
+        if (error.code === 'permission-denied') {
+            return 'No tienes permisos para guardar la foto del lugar.';
+        }
+    }
+
+    return 'No se pudieron subir las fotos. Revisa permisos o inténtalo de nuevo.';
+}
 
 interface PlacePhotoUploadModalProps {
     isOpen: boolean;
@@ -30,6 +54,8 @@ export const PlacePhotoUploadModal: React.FC<PlacePhotoUploadModalProps> = ({
     const [captions, setCaptions] = useState<string[]>([]);
     const [uploading, setUploading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const oversizedCount = useMemo(() => processedPhotos.filter(photo => photo.blob.size > MAX_UPLOAD_BYTES).length, [processedPhotos]);
 
     if (!isOpen) return null;
 
@@ -62,6 +88,13 @@ export const PlacePhotoUploadModal: React.FC<PlacePhotoUploadModalProps> = ({
         }
         if (processedPhotos.length === 0) {
             setError('Añade al menos una foto.');
+            return;
+        }
+
+        if (oversizedCount > 0) {
+            setError(oversizedCount === 1
+                ? 'Una foto supera el tamaño máximo de 10 MB. Reencuádra la imagen o usa otra más ligera.'
+                : 'Hay fotos que superan el tamaño máximo de 10 MB. Reencuádralas o usa imágenes más ligeras.');
             return;
         }
 
@@ -104,7 +137,7 @@ export const PlacePhotoUploadModal: React.FC<PlacePhotoUploadModalProps> = ({
             onClose();
         } catch (err) {
             console.error('Place photo upload failed', err);
-            setError('No se pudieron subir las fotos. Revisa permisos o inténtalo de nuevo.');
+            setError(getUploadErrorMessage(err));
         } finally {
             setUploading(false);
         }


### PR DESCRIPTION
### Motivation

- Prevent users from uploading very large images that would fail or consume excessive storage by enforcing a 10 MB limit client-side.
- Provide clearer, localized error messages for common Firebase Storage failure modes to improve user feedback when uploads fail.

### Description

- Add a `MAX_UPLOAD_BYTES` constant set to 10 MB and compute `oversizedCount` using `useMemo` from `processedPhotos` to detect oversized images.
- Add `getUploadErrorMessage` which maps `FirebaseError` codes to Spanish user-friendly messages and import `FirebaseError` from `firebase/app`.
- Short-circuit `handleUpload` with a localized message when one or more processed photos exceed the size limit, and replace the generic catch message with `getUploadErrorMessage(err)`.
- Import `useMemo` and make small state/reset logic unaffected while preserving existing upload flow and metadata writes to Firestore.

### Testing

- Ran TypeScript type-check and local build (`yarn build`), which completed successfully. 
- Executed the existing frontend automated test suite (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e69b00508326a67e481ce9e89ab9)