### PR TITLE
Liberar usernameClaims al eliminar la cuenta del usuario

### DIFF
--- a/functions/modules/admin/admin-users.js
+++ b/functions/modules/admin/admin-users.js
@@ -326,6 +326,11 @@ const deleteOwnAccount = onCall({ timeoutSeconds: 540, memory: '1GiB' }, async (
   const uid = request.auth.uid;
   const keepReviews = request.data?.keepReviews === true;
   const keepSublists = request.data?.keepSublists === true;
+  const userDocSnap = await db.collection('users').doc(uid).get();
+  const userData = userDocSnap.exists ? (userDocSnap.data() || {}) : {};
+  const usernameLower = typeof userData.usernameLower === 'string'
+    ? userData.usernameLower.trim().toLowerCase()
+    : '';
   const state = { batch: db.batch(), count: 0 };
   const counters = { reviews: 0, lists: 0, subcollections: 0 };
 
@@ -353,6 +358,10 @@ const deleteOwnAccount = onCall({ timeoutSeconds: 540, memory: '1GiB' }, async (
   state.count++;
   state.batch.delete(db.collection('users').doc(uid));
   state.count++;
+  if (usernameLower) {
+    state.batch.delete(db.collection('usernameClaims').doc(usernameLower));
+    state.count++;
+  }
   await commitBatchIfNeeded(state, true);
 
   await getAuth().deleteUser(uid);


### PR DESCRIPTION
### Motivation
- Evitar que el documento de reclamo de username en `usernameClaims/{usernameLower}` quede huérfano y bloquee reutilizar un username tras borrar la cuenta.

### Description
- En `deleteOwnAccount` se lee `users/{uid}` antes de borrar para extraer `usernameLower` si existe.
- Si `usernameLower` está presente, se añade la eliminación de `usernameClaims/{usernameLower}` al batch de borrado junto a `publicProfiles/{uid}` y `users/{uid}`.
- El resto del flujo de borrado (reviews, listas, subcolecciones y eliminación en Auth) se mantiene sin cambios.

### Testing
- Se ejecutó una comprobación de sintaxis con `node -c functions/modules/admin/admin-users.js` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c347a8824832693988858b4868e69)