### PR TITLE
Handle Algolia index quota and stabilize mobile profile edit modal

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2365,11 +2365,11 @@ export const ProfilePage: React.FC = () => {
         {/* Preferences Modal */}
         {isEditing && isOwnProfile && createPortal(
           <div
-            className="fixed inset-0 z-[10000] lt-mobile-overlay flex items-stretch md:items-center justify-center p-0 md:p-4 bg-black/80 backdrop-blur-sm animate-page-fade"
+            className="fixed inset-0 z-[10000] lt-mobile-overlay flex items-start md:items-center justify-center p-0 md:p-4 bg-black/80 backdrop-blur-sm animate-page-fade"
             onClick={() => !savingPreferences && setIsEditing(false)}
           >
             <div
-              className="w-full h-full md:h-[88vh] md:max-h-[88vh] md:max-w-3xl rounded-none md:rounded-2xl border-0 md:border border-white/10 bg-[var(--lt-card-strong)] shadow-none md:shadow-2xl overflow-hidden flex flex-col"
+              className="w-full h-[100dvh] md:h-[88vh] md:max-h-[88vh] md:max-w-3xl rounded-none md:rounded-2xl border-0 md:border border-white/10 bg-[var(--lt-card-strong)] shadow-none md:shadow-2xl overflow-hidden flex flex-col"
               onClick={(event) => event.stopPropagation()}
             >
               <div className="sticky top-0 z-20 px-4 md:px-5 py-3 md:py-4 border-b border-white/10 bg-[var(--lt-card-strong)] flex items-center justify-between" style={{ paddingTop: 'max(0.75rem, env(safe-area-inset-top))' }}>

--- a/functions/modules/algolia.js
+++ b/functions/modules/algolia.js
@@ -104,6 +104,12 @@ const REPLICA_SETTINGS = {
     grouped_items_by_reviews: { customRanking: ["desc(reviewCount)", "desc(avgGeneralScore)", "desc(rankingScore)"] }
 };
 
+
+function isTooManyIndicesError(error) {
+    const message = (error && (error.message || error.msg || String(error))) || "";
+    return /too many indices/i.test(message);
+}
+
 async function getIndexWithSettings(indexName) {
     const index = getIndex(indexName);
     if (!index) {
@@ -125,13 +131,25 @@ async function ensureIndexSettings(indexName, index) {
     try {
         await index.setSettings(settings);
         if (Array.isArray(settings.replicas)) {
-            await Promise.all(settings.replicas.map(async (replicaName) => {
-                const replicaIndex = getIndex(replicaName);
-                const replicaSettings = REPLICA_SETTINGS[replicaName];
-                if (replicaIndex && replicaSettings) {
-                    await replicaIndex.setSettings(replicaSettings);
+            try {
+                await Promise.all(settings.replicas.map(async (replicaName) => {
+                    const replicaIndex = getIndex(replicaName);
+                    const replicaSettings = REPLICA_SETTINGS[replicaName];
+                    if (replicaIndex && replicaSettings) {
+                        await replicaIndex.setSettings(replicaSettings);
+                    }
+                }));
+            } catch (error) {
+                if (isTooManyIndicesError(error)) {
+                    logger.warn(`Algolia: skipping replica settings for ${indexName} because index quota was reached.`, {
+                        indexName,
+                        replicas: settings.replicas,
+                        error: error.message || String(error)
+                    });
+                } else {
+                    throw error;
                 }
-            }));
+            }
         }
         ensuredSettings.add(indexName);
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Evitar que la sincronización/bootstrapping de Algolia falle con HTTP 500 cuando la cuenta alcanza el límite de índices reportado como `Too many indices`. 
- Impedir que el modal de edición de perfil/username en móvil se desplace fuera de vista al abrir el teclado cambiando su anclaje y altura.

### Description
- Añadida la función `isTooManyIndicesError` y se encapsuló la aplicación de settings de réplicas en `functions/modules/algolia.js` para capturar el error de cuota y omitir la configuración de réplicas en ese caso, registrando un `logger.warn` con contexto en lugar de abortar la operación. 
- Mantiene el comportamiento normal frente a otros errores lanzando la excepción para que el flujo de errores siga siendo visible. 
- Ajustado el overlay del modal de preferencias en `frontend/src/pages/ProfilePage.tsx` cambiando la alineación a `items-start` y fijando la altura en móvil a `h-[100dvh]` para reducir saltos al abrir el teclado y mantener el contenido superior visible.

### Testing
- Ejecutado `npm -C frontend run` para validar los scripts disponibles y confirmar que la estructura del frontend es accesible (comando exitoso). 
- Ejecutado `npm -C frontend run -s lint` que falló con numerosos errores de lint preexistentes en el repo que no fueron introducidos por este cambio, por lo que no bloquea la lógica modificada. 
- Los cambios fueron añadidos y confirmados en el repositorio con un commit, y se preparó la PR; no se ejecutaron tests unitarios adicionales para las funciones afectadas en esta revisión.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d66190aac832691511294f8d73c9e)