### PR TITLE
Fix profile reviews stat fallback when `reviewsCount` is missing

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1317,7 +1317,7 @@ export const ProfilePage: React.FC = () => {
   const displayedReviewsCount =
     statsLoadedUserId === targetUserId
       ? advancedStats.totalReviews
-      : profile?.reviewsCount || 0;
+      : profile?.reviewsCount || profile?.reviewCount || 0;
 
   const profileStatCards = useMemo(
     () => [


### PR DESCRIPTION
### Motivation
- Evitar que el contador de reseñas del perfil muestre `0` para usuarios que todavía almacenan el dato bajo la clave legacy `reviewCount` en lugar de `reviewsCount`.

### Description
- Ajusta el cálculo de `displayedReviewsCount` en `frontend/src/pages/ProfilePage.tsx` para usar `profile?.reviewCount` como fallback cuando `profile?.reviewsCount` no existe.

### Testing
- Construido el bundle de frontend con `npm -C frontend run -s build` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6b8498048326ae5fffeff3303f6b)