### PR TITLE
Migrate legacy root reviews collection to canonical nested structure

### DIFF
--- a/Mejoras/mejoras-pendientes.md
+++ b/Mejoras/mejoras-pendientes.md
@@ -19,7 +19,7 @@ Ultima actualizacion: 2026-05-08 (negocios, premium y monetizacion).
 | 5 | Adelgazar `package.json` raíz (eliminar mongoose, bcrypt, jwt, firebase v11 duplicado) | Build + superficie de ataque | Hecho | `package.json` |
 | 6 | Split de `core.js` (4100+ LOC) en submódulos | Mantenibilidad | Parcial: extraído `lib/geo.js` + `lib/auth.js` + `lib/secrets.js`; documentado roadmap en cabecera | `functions/modules/core.js` (header), `functions/modules/lib/*` |
 | 7 | Refactor ProfilePage (3052), HomePage (1255), ListPage (1254) + quitar `any` | Mantenibilidad | Parcial: extraído `ProfileStatsTab` como sample pattern (-98 LOC en ProfilePage). Resto pendiente | `frontend/src/components/profile/ProfileStatsTab.tsx` |
-| 8 | Migrar a TanStack Query o endurecer `queryCache.ts` | Fiabilidad datos | Pendiente | — |
+| 8 | Migrar a TanStack Query o endurecer `queryCache.ts` | Fiabilidad datos | Hecho (los hooks/servicios usan `@tanstack/react-query`) | `frontend/src/hooks/*`, `frontend/src/services/*` |
 | 9 | ErrorBoundary + Sentry + eliminar `console.log` en prod | Observabilidad | Hecho (ErrorBoundary + esbuild.drop + Sentry SDK integrado, espera DSN en `VITE_SENTRY_DSN`) | `frontend/src/components/ErrorBoundary.tsx`, `frontend/src/main.tsx`, `frontend/src/lib/sentry.ts`, `frontend/vite.config.ts`, `docs/SECURITY-SETUP.md` |
 | 10 | Roles admin granulares + audit log + userType reactivo en DeveloperPage | Seguridad + UX | Hecho (`isJefe` reactivo, `adminAuditLog` + `writeAuditLog` en **todas** las funciones admin). Roles granulares (moderator/admin/superadmin) = pendiente | `frontend/src/context/AuthContext.tsx`, `frontend/src/pages/DeveloperPage.tsx`, `functions/modules/lib/auth.js`, `functions/modules/core.js` |
 
@@ -277,6 +277,16 @@ Los negocios pagan por visibilidad extra dentro de la app.
 
 ---
 
+## CONSOLIDACIÓN DE RESEÑAS (root → listas) — CÓDIGO LISTO, MIGRACIÓN PENDIENTE DE EJECUTAR
+
+Ver `docs/REVIEWS-MIGRATION.md`. Resumen:
+- Canónica: `lists/{listId}/reviews`. La colección raíz `reviews/` es legacy y se migra hacia dentro.
+- Hecho en esta rama: callables de auditoría/migración/recuento (`functions/modules/reviews-consolidation.js`), tarjeta en Developer → Mantenimiento, `usePlaceDetails` con una sola query de collection group (antes ~80 queries por lugar), `canonical-items.js` sin query root redundante, índice CG de `reviews.placeId` en `firestore.indexes.json`.
+- Pendiente (manual): desplegar índices + functions + frontend y ejecutar en Developer el flujo Auditar → Migrar → Recontar.
+- Pendiente (código, post-migración): simplificar `ReviewService.deleteReview` y retirar las queries root de `useListDetails`/`GroupPage`/`EditListForm`; decidir destino de reseñas huérfanas.
+
+---
+
 ## OTRAS MEJORAS PENDIENTES
 
 ### Exportación de datos (RGPD) — DeveloperPage
@@ -322,7 +332,7 @@ Los negocios pagan por visibilidad extra dentro de la app.
 **Experiencia de usuario:**
 - Modo offline: guardar listas para consultar sin conexión
 - Lista "quiero ir" con recordatorio
-- Check-in: marcar visita desde el móvil con geolocalización
+- Check-in: marcar visita desde el móvil con geolocalización. IMPORTANTE: nunca automático (si pasas por el local de al lado no cuenta como visita); la geolocalización solo habilita/valida el botón ("Estás a <100 m de X, ¿confirmar visita?") y el usuario confirma manualmente. Mueve el item de WANT_TO_GO a ALREADY_WENT en Archives.
 - Compartir reseña individual como imagen (para Instagram/WhatsApp)
 - Galeria de imagenes de perfil: permitir guardar hasta 3 fotos por usuario, elegir una como principal, decidir si se muestran publicamente solo la principal o las 3, sustituir una foto al superar el limite, y ver/deslizar las fotos publicas desde el modal del avatar del perfil.
 

--- a/docs/REVIEWS-MIGRATION.md
+++ b/docs/REVIEWS-MIGRATION.md
@@ -1,0 +1,108 @@
+# Consolidación de reseñas — root `reviews/` → `lists/{listId}/reviews`
+
+Fecha: 2026-07-03 · Rama: `claude/app-review-architecture-pws4e4`
+
+## Contexto y decisión
+
+Históricamente las reseñas viven en **dos** sitios:
+
+- `lists/{listId}/reviews/{reviewId}` — la ruta que escribe la app actual (canónica).
+- `reviews/{reviewId}` (raíz) — residuo de la app React antigua; **nadie escribe ahí ya**
+  (AddReviewForm incluso borra la copia root al editar).
+
+Esa dualidad obligaba a todos los lectores a hacer doble query + dedupe, y a
+`usePlaceDetails` a un fan-out de hasta ~80 queries por lugar.
+
+**Decisión**: la canónica es la subcolección anidada (es donde apuntan todos los
+triggers de agregados, gamificación y Algolia). La colección raíz se migra hacia
+dentro y queda vacía. NO se mueven las reseñas a `places/…`: la lectura rápida
+por lugar la resuelven los agregados (`places/{placeId}/items` + una única query
+de collection group), sin duplicar documentos.
+
+Nota clave de Firestore: `collectionGroup('reviews')` incluye **también** la
+colección raíz `reviews/` (agrupa todas las colecciones con ese nombre). Por eso
+los lectores basados en collection group funcionan igual antes, durante y
+después de la migración.
+
+## Qué se ha cambiado en el código
+
+| Pieza | Cambio |
+|---|---|
+| `functions/modules/reviews-consolidation.js` | Nuevo. Callables `adminCountRootReviews`, `adminConsolidateRootReviews` (dry-run/migración paginada y reanudable) y `adminRecountReviewCounters`. |
+| `functions/index.js` | Exporta el módulo nuevo. |
+| `functions/modules/canonical-items.js` | Eliminada la query root redundante: una sola collectionGroup con dedupe (prefiere la copia anidada). |
+| `frontend/src/hooks/usePlaceDetails.ts` | El fan-out (3 queries de listas + hasta 80 subqueries + query root) se sustituye por **una** query `collectionGroup('reviews').where('placeId','==',X).limit(100)`, con dedupe root/anidada y filtro de `visibility: 'private'`. |
+| `frontend/src/components/developer/ReviewsConsolidationCard.tsx` | Nueva tarjeta en Developer → Mantenimiento con el flujo Auditar → Migrar → Recontar. |
+| `firestore.indexes.json` | Añadido `fieldOverride` de `reviews.placeId` con scope `COLLECTION_GROUP` (las functions ya usaban esa query; el índice existía solo en producción, creado a mano). |
+
+## Qué hace la migración (`adminConsolidateRootReviews`)
+
+Por cada documento de `reviews/` (páginas de 50, cursor `startAfterId`):
+
+1. **Resuelve la lista destino**: `listId` si la lista existe; si no, vía
+   `sublistId` → `parentListId` de la sublista (o la propia sublista). Sin
+   destino → se marca `rootMigration.status = 'orphan'` y NO se borra.
+2. **Si ya existe** `lists/{listId}/reviews/{mismoId}` (copia duplicada): se
+   mueven las subcolecciones que hubiera bajo la root y se borra el doc root.
+   La anidada gana.
+3. **Si no existe**: se crea la anidada con el mismo ID, normalizando campos
+   (`userId ← userId|authorId`, `userTags ← userTags|tags`, `listId` resuelto)
+   y marcando `migratedFromRoot: true`. Se mueven `reactions`/`comments` y se
+   borra el doc root.
+
+La operación es **idempotente y reanudable**: relanzarla no duplica nada.
+
+### Efecto en triggers y contadores
+
+- La creación anidada dispara `updateAggregatesOnReviewChange` (+1 en
+  `lists.reviewCount`, `users.reviewsCount`, `places.reviewsCount`) y el borrado
+  root **no** los decrementa → tras migrar, los contadores quedan inflados.
+- Por eso el paso 3 es obligatorio: `adminRecountReviewCounters` recalcula desde
+  las reseñas reales `lists.reviewCount`, `users.reviewsCount` + `photosCount`
+  y `places.reviewsCount` + `averageRating` (mismo criterio que
+  `updatePlaceAggregates`). Solo actualiza entidades con ≥1 reseña; las de cero
+  reseñas no las toca (no les afecta la migración).
+- `updatePlaceAggregates` (trigger root) y los rebuilds de canonical-items /
+  grouped-items de Algolia son recálculos completos idempotentes: se disparan de
+  más durante la migración pero convergen solos.
+- Gamificación: `checkBadges` se re-ejecuta (idempotente); `photosCount` lo sana
+  el recuento.
+
+## Orden de despliegue y ejecución
+
+1. `firebase deploy --only firestore:indexes`
+   ⚠️ Si el CLI avisa de que va a **borrar** índices que existen en producción y
+   no están en el archivo, cancela y añádelos antes al JSON (el archivo estaba
+   incompleto respecto a producción).
+2. `firebase deploy --only functions` (nuevo módulo + canonical-items).
+3. Desplegar frontend (Hosting/App Hosting).
+4. En Developer → Mantenimiento → "Consolidación de reseñas":
+   1. **Contar root** (referencia del tamaño).
+   2. **Auditar (dry run)** → revisar huérfanas en el log.
+   3. **Migrar** → borra la root según copia.
+   4. **Recontar contadores**.
+5. Verificar: PlacePage de un lugar con reseñas legacy, ListPage, perfil del
+   autor (contador), y `canonicalItemsCount` del lugar.
+
+## Después de la migración (limpieza pendiente, NO hecha aún)
+
+Cuando `adminCountRootReviews` devuelva 0 (salvo huérfanas conscientes):
+
+- Simplificar `ReviewService.deleteReview` (hoy borra hasta 3 refs defensivas).
+- Quitar las queries a `collection(db, 'reviews')` root en `useListDetails`,
+  `EditListForm`, `GroupPage`, `DeveloperPage`, `ReviewsManagerTab`,
+  `UserDataExportTab` (o dejarlas: devuelven vacío, solo son lecturas extra).
+- Decidir qué hacer con las huérfanas marcadas (`rootMigration.status ==
+  'orphan'`): reasignarlas a una lista o archivarlas en `deleted_items`.
+- Actualizar `estructura de base de datos.txt` (capítulos 05/06/19) marcando la
+  root como extinta, y añadir `places/{placeId}/items` y `businessSubscriptions`.
+
+## Rollback
+
+- La migración mueve (no transforma destructivamente): cada doc migrado conserva
+  todos sus campos originales más `migratedFromRoot`/`migratedFromRootAt`. Si
+  hiciera falta reconstruir la root, un script puede copiar de vuelta los docs
+  `where('migratedFromRoot','==',true)`.
+- `usePlaceDetails` nuevo funciona con datos pre y post migración (collection
+  group cubre ambas ubicaciones), así que el frontend no depende de que la
+  migración se haya ejecutado.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -67,6 +67,15 @@
         { "order": "DESCENDING", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "fieldPath": "placeId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/frontend/src/components/developer/ReviewsConsolidationCard.tsx
+++ b/frontend/src/components/developer/ReviewsConsolidationCard.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../../firebase';
+import { Database, RefreshCw, Search, ArrowDownToLine, Calculator } from 'lucide-react';
+
+interface ConsolidationPageResult {
+    dryRun: boolean;
+    processed: number;
+    migrated: number;
+    alreadyNested: number;
+    orphans: number;
+    orphanSamples: { reviewId: string; reason: string }[];
+    lastDocId: string | null;
+    done: boolean;
+}
+
+interface RecountResult {
+    scannedReviews: number;
+    listsUpdated: number;
+    usersUpdated: number;
+    placesUpdated: number;
+}
+
+/**
+ * Herramienta de consolidación de reseñas: migra la colección raíz legacy
+ * reviews/ hacia la canónica lists/{listId}/reviews. Ver docs/REVIEWS-MIGRATION.md.
+ */
+export const ReviewsConsolidationCard: React.FC = () => {
+    const [busy, setBusy] = useState(false);
+    const [log, setLog] = useState<string[]>([]);
+
+    const appendLog = (message: string) => {
+        setLog(prev => [`${new Date().toLocaleTimeString()} — ${message}`, ...prev].slice(0, 200));
+    };
+
+    const handleCountRoot = async () => {
+        setBusy(true);
+        try {
+            const countFn = httpsCallable(functions, 'adminCountRootReviews');
+            const res = await countFn({});
+            const data = res.data as { rootReviews: number };
+            appendLog(`📊 Reseñas en la colección raíz reviews/: ${data.rootReviews}`);
+        } catch (e) {
+            appendLog(`❌ Error al contar: ${e instanceof Error ? e.message : String(e)}`);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const runConsolidation = async (dryRun: boolean) => {
+        if (!dryRun && !window.confirm(
+            'Vas a MIGRAR las reseñas de la colección raíz reviews/ a lists/{listId}/reviews.\n\n' +
+            'Los documentos raíz se BORRAN tras copiarse (con sus reactions/comments).\n' +
+            'Al terminar, ejecuta "Recontar contadores" para sanear reviewCount/reviewsCount.\n\n¿Continuar?'
+        )) return;
+
+        setBusy(true);
+        const totals = { processed: 0, migrated: 0, alreadyNested: 0, orphans: 0 };
+        let cursor: string | null = null;
+        let pages = 0;
+
+        appendLog(dryRun ? '🔍 Auditoría (dry run) iniciada…' : '🚀 Migración iniciada…');
+        try {
+            const consolidateFn = httpsCallable(functions, 'adminConsolidateRootReviews');
+            for (;;) {
+                const res = await consolidateFn({ dryRun, pageSize: 50, startAfterId: cursor || undefined });
+                const page = res.data as ConsolidationPageResult;
+                pages += 1;
+                totals.processed += page.processed;
+                totals.migrated += page.migrated;
+                totals.alreadyNested += page.alreadyNested;
+                totals.orphans += page.orphans;
+                appendLog(`Página ${pages}: procesadas ${page.processed} · ${dryRun ? 'migrables' : 'migradas'} ${page.migrated} · duplicadas ${page.alreadyNested} · huérfanas ${page.orphans}`);
+                page.orphanSamples?.forEach(sample => appendLog(`   ⚠️ Huérfana ${sample.reviewId}: ${sample.reason}`));
+
+                if (page.done) break;
+                cursor = page.lastDocId;
+                // En migración real los docs se borran, así que la primera página
+                // siempre "avanza"; el cursor solo hace falta por las huérfanas.
+                if (dryRun && !cursor) break;
+            }
+            appendLog(`✅ ${dryRun ? 'Auditoría' : 'Migración'} completada: ${totals.processed} procesadas, ${totals.migrated} ${dryRun ? 'migrables' : 'migradas'}, ${totals.alreadyNested} duplicadas limpiadas, ${totals.orphans} huérfanas.`);
+            if (!dryRun && totals.migrated + totals.alreadyNested > 0) {
+                appendLog('👉 Ejecuta ahora "Recontar contadores" para sanear los agregados.');
+            }
+        } catch (e) {
+            appendLog(`❌ Error: ${e instanceof Error ? e.message : String(e)} (puedes relanzar; la operación es reanudable)`);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRecount = async () => {
+        if (!window.confirm('Recontar reviewCount (listas), reviewsCount/photosCount (usuarios) y reviewsCount/averageRating (lugares) desde las reseñas reales. ¿Continuar?')) return;
+        setBusy(true);
+        appendLog('🧮 Recuento de contadores iniciado (puede tardar)…');
+        try {
+            const recountFn = httpsCallable(functions, 'adminRecountReviewCounters', { timeout: 540000 });
+            const res = await recountFn({});
+            const data = res.data as RecountResult;
+            appendLog(`✅ Recuento completado: ${data.scannedReviews} reseñas → ${data.listsUpdated} listas, ${data.usersUpdated} usuarios y ${data.placesUpdated} lugares actualizados.`);
+        } catch (e) {
+            appendLog(`❌ Error en recuento: ${e instanceof Error ? e.message : String(e)}`);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="bg-[var(--lt-card-strong)] border border-white/10 rounded-xl p-6">
+            <h3 className="text-xl font-bold text-white mb-2 flex items-center gap-2">
+                <Database className="w-5 h-5 text-violet-400" /> Consolidación de reseñas (root → listas)
+            </h3>
+            <p className="text-gray-400 mb-4 text-sm">
+                Migra las reseñas legacy de la colección raíz <code className="text-violet-300 bg-black/30 px-1 rounded">reviews/</code> a
+                la canónica <code className="text-violet-300 bg-black/30 px-1 rounded">lists/{'{listId}'}/reviews</code> conservando el mismo ID
+                y moviendo reactions/comments. Flujo: <strong>1)</strong> Auditar · <strong>2)</strong> Migrar · <strong>3)</strong> Recontar contadores.
+                Detalles en <code className="text-violet-300 bg-black/30 px-1 rounded">docs/REVIEWS-MIGRATION.md</code>.
+            </p>
+            <div className="flex gap-3 flex-wrap">
+                <button
+                    onClick={handleCountRoot}
+                    disabled={busy}
+                    className="px-4 py-2 bg-slate-600 hover:bg-slate-500 disabled:opacity-50 text-white text-sm font-bold rounded-lg flex items-center gap-2 transition-colors"
+                >
+                    {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Calculator className="w-4 h-4" />}
+                    Contar root
+                </button>
+                <button
+                    onClick={() => runConsolidation(true)}
+                    disabled={busy}
+                    className="px-4 py-2 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white text-sm font-bold rounded-lg flex items-center gap-2 transition-colors"
+                >
+                    {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
+                    1 · Auditar (dry run)
+                </button>
+                <button
+                    onClick={() => runConsolidation(false)}
+                    disabled={busy}
+                    className="px-4 py-2 bg-rose-600 hover:bg-rose-500 disabled:opacity-50 text-white text-sm font-bold rounded-lg flex items-center gap-2 transition-colors"
+                >
+                    {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <ArrowDownToLine className="w-4 h-4" />}
+                    2 · Migrar
+                </button>
+                <button
+                    onClick={handleRecount}
+                    disabled={busy}
+                    className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-bold rounded-lg flex items-center gap-2 transition-colors"
+                >
+                    {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Calculator className="w-4 h-4" />}
+                    3 · Recontar contadores
+                </button>
+            </div>
+            {log.length > 0 && (
+                <div className="mt-4 bg-black/40 border border-white/10 rounded-lg p-3 font-mono text-xs max-h-64 overflow-y-auto">
+                    {log.map((entry, i) => (
+                        <div key={i} className="text-gray-300 py-0.5">{entry}</div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/hooks/usePlaceDetails.ts
+++ b/frontend/src/hooks/usePlaceDetails.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { collection, query, where, getDocs, doc, getDoc, getDocFromServer, limit, orderBy } from 'firebase/firestore';
+import { collection, collectionGroup, query, where, getDocs, doc, getDoc, getDocFromServer, limit, orderBy } from 'firebase/firestore';
 import { db } from '../firebase';
 import { type ReviewEntity } from './useListDetails';
 import { firstUsablePlaceImage } from '../utils/placeImages';
@@ -200,51 +200,43 @@ async function fetchPlaceDetails(placeId: string): Promise<PlaceDetails> {
     const { getAuth } = await import('firebase/auth');
     const currentUser = getAuth().currentUser;
 
-    const [publicListsSnap, followingListsSnap, ownListsSnap] = await Promise.all([
-        getDocs(query(collection(db, 'lists'), where('isPublic', '==', true), limit(60))),
-        currentUser ? getDocs(query(collection(db, 'users', currentUser.uid, 'followingLists'), limit(60))) : Promise.resolve(null),
-        currentUser ? getDocs(query(collection(db, 'lists'), where('userId', '==', currentUser.uid), limit(40))) : Promise.resolve(null),
-    ]);
+    // Una sola query de collection group cubre lists/{listId}/reviews y la
+    // colección raíz legacy reviews/ (todas las colecciones llamadas 'reviews').
+    // Las reglas exigen usuario autenticado y limit <= 100.
+    const reviewsSnap = currentUser ? await getDocs(
+        query(collectionGroup(db, 'reviews'), where('placeId', '==', placeId), limit(100))
+    ).catch((e: any) => {
+        if (e?.code !== 'permission-denied') console.warn('Failed to fetch reviews for place', e);
+        return null;
+    }) : null;
 
-    const candidateListIds = Array.from(new Set([
-        ...publicListsSnap.docs.map(d => d.id),
-        ...(followingListsSnap ? followingListsSnap.docs.map(d => d.id) : []),
-        ...(ownListsSnap ? ownListsSnap.docs.map(d => d.id) : []),
-    ])).slice(0, 80);
-
-    const reviewsByList = await Promise.all(candidateListIds.map(async (listId) => {
-        try {
-            const snap = await getDocs(query(collection(db, 'lists', listId, 'reviews'), where('placeId', '==', placeId), limit(20)));
-            return snap.docs.map(d => ({ id: d.id, ...(d.data() as Record<string, unknown>), listId } as ReviewEntity));
-        } catch (e: any) {
-            if (e?.code !== 'permission-denied') console.warn(`Failed loading place reviews for list ${listId}`, e);
-            return [] as ReviewEntity[];
-        }
-    }));
-
-    const globalReviewsSnap = await getDocs(
-        query(collection(db, 'reviews'), where('placeId', '==', placeId), limit(50))
-    ).catch(e => {
-        if (e?.code !== 'permission-denied') console.warn('Failed to fetch global reviews for place', e);
-        return { docs: [] };
-    });
     const placePhotosSnap = await placePhotosSnapPromise;
     const resolvedBusinessSnap = await resolvedBusinessSnapPromise;
     const resolvedBusiness = resolvedBusinessSnap?.exists() ? resolvedBusinessSnap.data() as ResolvedBusinessInfo : undefined;
     const hiddenFields = resolvedBusiness?.hiddenFields || {};
 
-    reviewsByList.push(
-        globalReviewsSnap.docs.map(d => ({ id: d.id, ...(d.data() as Record<string, unknown>) } as ReviewEntity))
-    );
-
+    // Mientras convivan copia root y anidada de una misma reseña comparten id;
+    // preferimos la anidada (canónica).
     const reviewMap = new Map<string, ReviewEntity>();
-    for (const listReviews of reviewsByList) {
-        for (const review of listReviews) {
-            reviewMap.set(`${review.listId || 'unknown'}:${review.id}`, review);
-        }
-    }
+    (reviewsSnap?.docs || []).forEach(d => {
+        const data = d.data() as Record<string, unknown>;
+        const pathParts = d.ref.path.split('/');
+        const isNested = pathParts[0] === 'lists';
+        if (!isNested && reviewMap.has(d.id)) return;
+        const listId = isNested ? pathParts[1] : (typeof data.listId === 'string' ? data.listId : undefined);
+        reviewMap.set(d.id, { id: d.id, ...data, listId } as ReviewEntity);
+    });
 
-    const reviews = Array.from(reviewMap.values()).sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
+    const canViewReview = (review: ReviewEntity) => {
+        const r = review as ReviewEntity & { visibility?: string; userId?: string; authorId?: string };
+        if (r.visibility !== 'private') return true;
+        const uid = currentUser?.uid;
+        return !!uid && (r.userId === uid || r.authorId === uid);
+    };
+
+    const reviews = Array.from(reviewMap.values())
+        .filter(canViewReview)
+        .sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
     const placePhotos = placePhotosSnap.docs
         .map((photoDoc): PlacePhoto | null => {
             const data = photoDoc.data() as Record<string, unknown>;

--- a/frontend/src/pages/DeveloperPage.tsx
+++ b/frontend/src/pages/DeveloperPage.tsx
@@ -24,6 +24,7 @@ const UserDataExportTab = React.lazy(() => import('../components/developer/UserD
 const ApiUsageTab = React.lazy(() => import('../components/developer/ApiUsageTab').then(module => ({ default: module.ApiUsageTab })));
 const BusinessClaimsManagerTab = React.lazy(() => import('../components/developer/BusinessClaimsManagerTab').then(module => ({ default: module.BusinessClaimsManagerTab })));
 const BusinessManagersTab = React.lazy(() => import('../components/developer/BusinessManagersTab').then(module => ({ default: module.BusinessManagersTab })));
+const ReviewsConsolidationCard = React.lazy(() => import('../components/developer/ReviewsConsolidationCard').then(module => ({ default: module.ReviewsConsolidationCard })));
 
 type DeveloperActiveTab = 'console' | 'algolia' | 'maintenance' | 'gamification' | 'reports' | 'businessClaims' | 'businessManagers' | 'branding' | 'others' | 'proyectos' | 'lists' | 'places' | 'reviews' | 'tags' | 'usuarios' | 'rgpd' | 'audit' | 'apiusage';
 
@@ -1175,6 +1176,10 @@ export const DeveloperPage: React.FC = () => {
                                             Backfill authorUserType
                                         </button>
                                     </div>
+
+                                    <React.Suspense fallback={<div className="bg-[var(--lt-card-strong)] border border-white/10 rounded-xl p-6 text-gray-500 text-sm">Cargando consolidación de reseñas…</div>}>
+                                        <ReviewsConsolidationCard />
+                                    </React.Suspense>
 
                                     <div className="bg-[var(--lt-card-strong)] border border-white/10 rounded-xl p-6">
                                         <h3 className="text-xl font-bold text-white mb-2 flex items-center gap-2">

--- a/functions/index.js
+++ b/functions/index.js
@@ -24,6 +24,7 @@ module.exports = {
     ...require('./modules/business-claims'),
     ...require('./modules/stripe-business'),
     ...require('./modules/canonical-items'),
+    ...require('./modules/reviews-consolidation'),
     ...require('./modules/media'),
     ...require('./modules/admin/admin-tags'),
     ...require('./modules/admin/admin-users'),

--- a/functions/modules/canonical-items.js
+++ b/functions/modules/canonical-items.js
@@ -101,39 +101,24 @@ function chooseCanonicalName(existingItem, reviewNameCounts, fallbackName) {
   return first || String(fallbackName || 'Elemento sin nombre').trim();
 }
 
-async function fetchRootReviewsForPlace(placeId) {
-  const snap = await db.collection('reviews').where('placeId', '==', placeId).get();
-  return snap.docs.map((docSnap) => ({
-    id: docSnap.id,
-    refPath: docSnap.ref.path,
-    fallbackListId: docSnap.data().listId || null,
-    ...docSnap.data(),
-  }));
-}
-
-async function fetchNestedReviewsForPlace(placeId) {
+async function fetchReviewsForPlace(placeId) {
+  // collectionGroup('reviews') incluye también la colección raíz reviews/
+  // (legacy), así que una sola query cubre ambas ubicaciones. El Map dedupe
+  // por id las copias root+anidada de una misma reseña mientras convivan.
   const snap = await db.collectionGroup('reviews').where('placeId', '==', placeId).get();
-  return snap.docs.map((docSnap) => {
+  const byId = new Map();
+  snap.docs.forEach((docSnap) => {
     const path = docSnap.ref.path.split('/');
     const fallbackListId = path[0] === 'lists' ? path[1] : docSnap.data().listId || null;
-    return {
+    const review = {
       id: docSnap.id,
       refPath: docSnap.ref.path,
       fallbackListId,
       ...docSnap.data(),
     };
+    // Preferimos la copia anidada (canónica) si ya vimos la root.
+    if (!byId.has(review.id) || path[0] === 'lists') byId.set(review.id, review);
   });
-}
-
-async function fetchReviewsForPlace(placeId) {
-  const [rootReviews, nestedReviews] = await Promise.all([
-    fetchRootReviewsForPlace(placeId),
-    fetchNestedReviewsForPlace(placeId),
-  ]);
-
-  const byId = new Map();
-  rootReviews.forEach((review) => byId.set(review.id, review));
-  nestedReviews.forEach((review) => byId.set(review.id, review));
   return Array.from(byId.values());
 }
 

--- a/functions/modules/reviews-consolidation.js
+++ b/functions/modules/reviews-consolidation.js
@@ -1,0 +1,302 @@
+'use strict';
+
+/**
+ * Consolidación de reseñas: la colección canónica es lists/{listId}/reviews.
+ * La colección raíz reviews/ es legacy (app React antigua); este módulo permite
+ * auditarla y migrar sus documentos hacia la subcolección de su lista,
+ * conservando el mismo reviewId y moviendo también reactions/comments.
+ *
+ * Flujo recomendado (DeveloperPage → Mantenimiento):
+ *   1. adminConsolidateRootReviews { dryRun: true }  → informe sin tocar nada.
+ *   2. adminConsolidateRootReviews { dryRun: false } → migración por páginas.
+ *   3. adminRecountReviewCounters                    → sana contadores
+ *      (la creación anidada dispara los triggers de incremento, así que tras
+ *      migrar los contadores quedan inflados hasta ejecutar el recuento).
+ */
+
+const { onCall, HttpsError } = require('firebase-functions/v2/https');
+const logger = require('firebase-functions/logger');
+const { getFirestore, FieldValue, FieldPath } = require('firebase-admin/firestore');
+const { assertJefeAccess, writeAuditLog } = require('./lib/auth');
+
+const db = getFirestore();
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+const RECOUNT_SCAN_PAGE = 500;
+const BATCH_LIMIT = 450;
+
+function asTrimmedString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+// Mismo criterio que gamification.countReviewPhotos para que el recuento
+// de users.photosCount coincida con lo que mantienen los triggers.
+function countReviewPhotos(reviewData) {
+  if (!reviewData || typeof reviewData !== 'object') return 0;
+  for (const field of ['photos', 'images']) {
+    if (Array.isArray(reviewData[field])) {
+      const count = reviewData[field].filter((photo) => typeof photo === 'string' && photo.trim().length > 0).length;
+      if (count > 0) return count;
+    }
+  }
+  return asTrimmedString(reviewData.photoUrl) ? 1 : 0;
+}
+
+async function listExists(listId, cache) {
+  if (!listId) return false;
+  if (cache.has(listId)) return cache.get(listId);
+  const snap = await db.collection('lists').doc(listId).get();
+  cache.set(listId, snap.exists ? snap : false);
+  return cache.get(listId);
+}
+
+/**
+ * Resuelve la lista destino de una reseña root:
+ * - listId directo si la lista existe.
+ * - Si no, vía sublistId: el parentListId de la sublista (o la propia sublista).
+ * Devuelve { listId } o { orphanReason }.
+ */
+async function resolveTargetListId(review, cache) {
+  const directListId = asTrimmedString(review.listId);
+  if (directListId && await listExists(directListId, cache)) {
+    return { listId: directListId };
+  }
+
+  const sublistId = asTrimmedString(review.sublistId);
+  if (sublistId) {
+    const sublistSnap = await listExists(sublistId, cache);
+    if (sublistSnap) {
+      const parentListId = asTrimmedString(sublistSnap.data().parentListId);
+      if (parentListId && await listExists(parentListId, cache)) {
+        return { listId: parentListId };
+      }
+      return { listId: sublistId };
+    }
+  }
+
+  if (directListId) return { orphanReason: `La lista ${directListId} no existe.` };
+  return { orphanReason: 'La reseña no tiene listId ni sublistId válidos.' };
+}
+
+// Mueve reactions/comments (y cualquier otra subcolección) del doc root al destino.
+async function moveSubcollections(rootRef, targetRef) {
+  const subcollections = await rootRef.listCollections();
+  for (const col of subcollections) {
+    const snap = await col.get();
+    for (const subDoc of snap.docs) {
+      await targetRef.collection(col.id).doc(subDoc.id).set(subDoc.data(), { merge: true });
+      await subDoc.ref.delete();
+    }
+  }
+}
+
+function buildNestedReviewData(review, targetListId) {
+  const userTags = Array.isArray(review.userTags) && review.userTags.length > 0
+    ? review.userTags
+    : (Array.isArray(review.tags) ? review.tags : []);
+
+  return {
+    ...review,
+    listId: targetListId,
+    userId: asTrimmedString(review.userId) || asTrimmedString(review.authorId) || null,
+    userTags,
+    migratedFromRoot: true,
+    migratedFromRootAt: FieldValue.serverTimestamp(),
+  };
+}
+
+const adminConsolidateRootReviews = onCall({ timeoutSeconds: 540, memory: '512MiB' }, async (request) => {
+  const uid = request.auth?.uid;
+  await assertJefeAccess(uid, 'Solo un administrador puede consolidar reseñas.');
+
+  const dryRun = request.data?.dryRun !== false; // por defecto solo informa
+  const pageSize = Math.min(Math.max(Number(request.data?.pageSize) || DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+  const startAfterId = asTrimmedString(request.data?.startAfterId);
+
+  let query = db.collection('reviews').orderBy(FieldPath.documentId()).limit(pageSize);
+  if (startAfterId) query = query.startAfter(startAfterId);
+  const snap = await query.get();
+
+  const listCache = new Map();
+  const result = {
+    dryRun,
+    processed: snap.size,
+    migrated: 0,
+    alreadyNested: 0,
+    orphans: 0,
+    orphanSamples: [],
+    lastDocId: snap.size > 0 ? snap.docs[snap.size - 1].id : null,
+    done: snap.size < pageSize,
+  };
+
+  for (const docSnap of snap.docs) {
+    const review = docSnap.data() || {};
+    const target = await resolveTargetListId(review, listCache);
+
+    if (target.orphanReason) {
+      result.orphans += 1;
+      if (result.orphanSamples.length < 10) {
+        result.orphanSamples.push({ reviewId: docSnap.id, reason: target.orphanReason });
+      }
+      if (!dryRun) {
+        await docSnap.ref.set({
+          rootMigration: { status: 'orphan', reason: target.orphanReason, checkedAt: FieldValue.serverTimestamp() },
+        }, { merge: true });
+      }
+      continue;
+    }
+
+    const targetRef = db.collection('lists').doc(target.listId).collection('reviews').doc(docSnap.id);
+    const targetSnap = await targetRef.get();
+
+    if (targetSnap.exists) {
+      // Copia duplicada: la anidada es la canónica, solo limpiamos la root.
+      result.alreadyNested += 1;
+      if (!dryRun) {
+        await moveSubcollections(docSnap.ref, targetRef);
+        await docSnap.ref.delete();
+      }
+      continue;
+    }
+
+    result.migrated += 1;
+    if (!dryRun) {
+      await targetRef.set(buildNestedReviewData(review, target.listId));
+      await moveSubcollections(docSnap.ref, targetRef);
+      await docSnap.ref.delete();
+    }
+  }
+
+  if (!dryRun) {
+    await writeAuditLog(uid, 'reviews.consolidateRootPage', {
+      processed: result.processed,
+      migrated: result.migrated,
+      alreadyNested: result.alreadyNested,
+      orphans: result.orphans,
+      lastDocId: result.lastDocId,
+    });
+  }
+
+  logger.info('reviewsConsolidation: página procesada', result);
+  return result;
+});
+
+const adminRecountReviewCounters = onCall({ timeoutSeconds: 540, memory: '1GiB' }, async (request) => {
+  const uid = request.auth?.uid;
+  await assertJefeAccess(uid, 'Solo un administrador puede recontar contadores.');
+
+  const listCounts = new Map();
+  const userStats = new Map(); // uid -> { reviews, photos }
+  const placeStats = new Map(); // placeId -> { count, ratingTotal }
+
+  let lastDoc = null;
+  let scanned = 0;
+
+  for (;;) {
+    let query = db.collectionGroup('reviews').limit(RECOUNT_SCAN_PAGE);
+    if (lastDoc) query = query.startAfter(lastDoc);
+    const snap = await query.get();
+    if (snap.empty) break;
+
+    for (const docSnap of snap.docs) {
+      scanned += 1;
+      const data = docSnap.data() || {};
+      const path = docSnap.ref.path.split('/');
+      const nestedListId = path[0] === 'lists' && path.length === 4 ? path[1] : null;
+      const listId = nestedListId || asTrimmedString(data.listId) || null;
+
+      if (listId) listCounts.set(listId, (listCounts.get(listId) || 0) + 1);
+      const sublistId = asTrimmedString(data.sublistId);
+      if (sublistId && sublistId !== listId) {
+        listCounts.set(sublistId, (listCounts.get(sublistId) || 0) + 1);
+      }
+
+      const reviewUserId = asTrimmedString(data.userId) || asTrimmedString(data.authorId);
+      if (reviewUserId) {
+        const stats = userStats.get(reviewUserId) || { reviews: 0, photos: 0 };
+        stats.reviews += 1;
+        stats.photos += countReviewPhotos(data);
+        userStats.set(reviewUserId, stats);
+      }
+
+      const placeId = asTrimmedString(data.placeId);
+      if (placeId) {
+        const stats = placeStats.get(placeId) || { count: 0, ratingTotal: 0 };
+        stats.count += 1;
+        // Mismo criterio que updatePlaceAggregates: rating ausente cuenta como 0.
+        stats.ratingTotal += isNumber(data.overallRating) ? data.overallRating : 0;
+        placeStats.set(placeId, stats);
+      }
+    }
+
+    lastDoc = snap.docs[snap.docs.length - 1];
+    if (snap.size < RECOUNT_SCAN_PAGE) break;
+  }
+
+  let batch = db.batch();
+  let batchCount = 0;
+  const commitIfNeeded = async (force = false) => {
+    if (batchCount === 0 || (!force && batchCount < BATCH_LIMIT)) return;
+    await batch.commit();
+    batch = db.batch();
+    batchCount = 0;
+  };
+
+  for (const [listId, count] of listCounts.entries()) {
+    batch.set(db.collection('lists').doc(listId), {
+      reviewCount: count,
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    batchCount += 1;
+    await commitIfNeeded();
+  }
+
+  for (const [userId, stats] of userStats.entries()) {
+    batch.set(db.collection('users').doc(userId), {
+      reviewsCount: stats.reviews,
+      photosCount: stats.photos,
+    }, { merge: true });
+    batchCount += 1;
+    await commitIfNeeded();
+  }
+
+  for (const [placeId, stats] of placeStats.entries()) {
+    batch.set(db.collection('places').doc(placeId), {
+      reviewsCount: stats.count,
+      averageRating: stats.count > 0 ? Number((stats.ratingTotal / stats.count).toFixed(2)) : null,
+    }, { merge: true });
+    batchCount += 1;
+    await commitIfNeeded();
+  }
+
+  await commitIfNeeded(true);
+
+  const summary = {
+    scannedReviews: scanned,
+    listsUpdated: listCounts.size,
+    usersUpdated: userStats.size,
+    placesUpdated: placeStats.size,
+  };
+
+  await writeAuditLog(uid, 'reviews.recountCounters', summary);
+  logger.info('reviewsConsolidation: recuento completado', summary);
+  return summary;
+});
+
+const adminCountRootReviews = onCall(async (request) => {
+  const uid = request.auth?.uid;
+  await assertJefeAccess(uid, 'Solo un administrador puede consultar la colección root.');
+  const agg = await db.collection('reviews').count().get();
+  return { rootReviews: agg.data().count };
+});
+
+module.exports = {
+  adminConsolidateRootReviews,
+  adminRecountReviewCounters,
+  adminCountRootReviews,
+};


### PR DESCRIPTION
## Summary

This PR implements a comprehensive migration strategy to consolidate reviews from the legacy root `reviews/` collection into the canonical nested `lists/{listId}/reviews` structure. The root collection is a residue from an older React app that is no longer written to, while the nested structure is where all current triggers, gamification, and Algolia integrations point.

## Key Changes

- **New consolidation module** (`functions/modules/reviews-consolidation.js`): Implements the core migration logic with three main operations:
  - `adminCountRootReviews`: Counts legacy root reviews
  - `adminConsolidateRootReviews`: Migrates reviews with dry-run support, handling orphaned reviews and preserving reactions/comments subcollections
  - `adminRecountReviewCounters`: Recalculates aggregated counters after migration (necessary because nested creation triggers counter increments)

- **Developer UI** (`frontend/src/components/developer/ReviewsConsolidationCard.tsx`): New maintenance card in DeveloperPage providing:
  - Root review count inspection
  - Paginated dry-run and live migration with progress tracking
  - Counter recount operation
  - Real-time logging of migration results

- **Query optimization** (`frontend/src/hooks/usePlaceDetails.ts`): Replaces fan-out queries (up to ~80 per place) with efficient `collectionGroup('reviews')` queries against the canonical nested structure

- **Backend cleanup** (`functions/modules/canonical-items.js`): Removes legacy root review fetching logic

- **Firestore index** (`firestore.indexes.json`): Adds composite index for `collectionGroup('reviews')` queries by `placeId`

- **Documentation** (`docs/REVIEWS-MIGRATION.md`): Comprehensive guide explaining the migration rationale, architecture decision, and operational procedures

## Implementation Details

- **Orphan handling**: Reviews without valid target lists are tracked with reasons (missing listId, non-existent list, etc.)
- **Batch safety**: Uses 450-document batches to stay well under Firestore's 500-write limit
- **Subcollection preservation**: Reactions and comments are migrated alongside reviews
- **Idempotent design**: Dry-run mode allows safe inspection before committing changes
- **Counter correction**: Post-migration recount operation fixes inflated counters caused by trigger-based increments during nested document creation

The recommended workflow is: count → dry-run → migrate → recount, all accessible from the new maintenance UI.

https://claude.ai/code/session_01Vc8Q66r21xJmBeLPN99Spn