### PR TITLE
Limpieza post-consolidación: eliminar lecturas de la colección root vacía

### DIFF
--- a/Mejoras/mejoras-pendientes.md
+++ b/Mejoras/mejoras-pendientes.md
@@ -277,13 +277,12 @@ Los negocios pagan por visibilidad extra dentro de la app.
 
 ---
 
-## CONSOLIDACIÓN DE RESEÑAS (root → listas) — CÓDIGO LISTO, MIGRACIÓN PENDIENTE DE EJECUTAR
+## CONSOLIDACIÓN DE RESEÑAS (root → listas) — COMPLETADA
 
 Ver `docs/REVIEWS-MIGRATION.md`. Resumen:
-- Canónica: `lists/{listId}/reviews`. La colección raíz `reviews/` es legacy y se migra hacia dentro.
-- Hecho en esta rama: callables de auditoría/migración/recuento (`functions/modules/reviews-consolidation.js`), tarjeta en Developer → Mantenimiento, `usePlaceDetails` con una sola query de collection group (antes ~80 queries por lugar), `canonical-items.js` sin query root redundante, índice CG de `reviews.placeId` en `firestore.indexes.json`.
-- Pendiente (manual): desplegar índices + functions + frontend y ejecutar en Developer el flujo Auditar → Migrar → Recontar.
-- Pendiente (código, post-migración): simplificar `ReviewService.deleteReview` y retirar las queries root de `useListDetails`/`GroupPage`/`EditListForm`; decidir destino de reseñas huérfanas.
+- Canónica: `lists/{listId}/reviews`. La colección raíz `reviews/` resultó estar **vacía en producción** (auditoría 2026-07-04: 0 docs), así que no hubo migración de datos.
+- Hecho: callables de auditoría/migración/recuento + tarjeta en Developer → Mantenimiento (quedan como red de seguridad y para sanear contadores), `usePlaceDetails` y `GroupPage` con una sola query de collection group (antes ~80 queries por lugar cada uno), `useListDetails`/`EditListForm`/`deleteReview` sin rutas root, índice CG de `reviews.placeId`, fix del batch `placeClosedStatus` (regla + query).
+- Pendiente (manual): volver a desplegar `firestore.rules` y el frontend con la limpieza.
 
 ---
 

--- a/docs/REVIEWS-MIGRATION.md
+++ b/docs/REVIEWS-MIGRATION.md
@@ -84,18 +84,40 @@ La operación es **idempotente y reanudable**: relanzarla no duplica nada.
 5. Verificar: PlacePage de un lugar con reseñas legacy, ListPage, perfil del
    autor (contador), y `canonicalItemsCount` del lugar.
 
-## Después de la migración (limpieza pendiente, NO hecha aún)
+## Resultado en producción (2026-07-04)
 
-Cuando `adminCountRootReviews` devuelva 0 (salvo huérfanas conscientes):
+`adminCountRootReviews` devolvió **0** y la auditoría dry-run procesó 0
+documentos: la colección raíz ya estaba vacía en el proyecto `listopic`. No hizo
+falta ejecutar la migración ni el recuento. Todo el código de doble lectura era
+defensa contra datos inexistentes.
 
-- Simplificar `ReviewService.deleteReview` (hoy borra hasta 3 refs defensivas).
-- Quitar las queries a `collection(db, 'reviews')` root en `useListDetails`,
-  `EditListForm`, `GroupPage`, `DeveloperPage`, `ReviewsManagerTab`,
-  `UserDataExportTab` (o dejarlas: devuelven vacío, solo son lecturas extra).
-- Decidir qué hacer con las huérfanas marcadas (`rootMigration.status ==
-  'orphan'`): reasignarlas a una lista o archivarlas en `deleted_items`.
+## Limpieza post-migración (HECHA)
+
+- `ReviewService.deleteReview`: borra solo la ruta canónica (antes hasta 3 refs).
+- `useListDetails`: eliminadas las 2-3 queries root por carga de lista.
+- `EditListForm`: eliminadas las queries root en renombrado de tags y sync de
+  visibilidad.
+- `GroupPage`: eliminado el fan-out de ~80 queries + query root; ahora una sola
+  collectionGroup (mismo patrón que `usePlaceDetails`).
+- `DeveloperPage` (marcar lugar cerrado): el batch de `placeClosedStatus`
+  apuntaba a la root vacía Y la regla `reviewAllowedUpdateKeys` no permitía ese
+  campo (doblemente muerto). Ahora usa collectionGroup con `limit(100)` (tope de
+  las reglas) y `placeClosedStatus` se añadió a las claves permitidas.
+- Se conservan a propósito: el fallback root de `UserDataExportTab` y la
+  distinción root/subcolección de `ReviewsManagerTab` (diagnóstico admin, útil
+  para verificar que la root sigue vacía), y la rama `reviewPath 'reviews/'` de
+  `AddReviewForm` (coste cero, solo se activaría con datos legacy).
+
+## Pendiente
+
 - Actualizar `estructura de base de datos.txt` (capítulos 05/06/19) marcando la
   root como extinta, y añadir `places/{placeId}/items` y `businessSubscriptions`.
+- Desplegar de nuevo `firestore.rules` (clave `placeClosedStatus`) y el frontend
+  con esta limpieza.
+- Las funciones de migración (`adminConsolidateRootReviews`, etc.) pueden
+  retirarse en el futuro si la root sigue a 0; de momento sirven de red de
+  seguridad y el recuento (`adminRecountReviewCounters`) es útil por sí solo
+  para sanear contadores.
 
 ## Rollback
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -110,7 +110,7 @@ service cloud.firestore {
         'photoUrls', 'photoStoragePaths', 'photos', 'placeId',
         'placeName', 'placeAddress', 'placeLat', 'placeLng',
         'criteriaDefinition', 'createdAt', 'updatedAt', 'deletedAt',
-        'moderationStatus'
+        'moderationStatus', 'placeClosedStatus'
       ];
     }
 

--- a/frontend/src/components/EditListForm.tsx
+++ b/frontend/src/components/EditListForm.tsx
@@ -265,10 +265,8 @@ export const EditListForm: React.FC<EditListFormProps> = ({ listId, onSuccess, o
 
                 const reviewSnapshots = await Promise.all([
                     safeQuery(() => getDocs(collection(db, 'lists', listId, 'reviews'))),
-                    safeQuery(() => getDocs(query(collection(db, 'reviews'), where('listId', '==', listId)))),
                     ...(parentListId ? [
-                        safeQuery(() => getDocs(query(collection(db, 'lists', parentListId, 'reviews'), where('sublistId', '==', listId)))),
-                        safeQuery(() => getDocs(query(collection(db, 'reviews'), where('sublistId', '==', listId))))
+                        safeQuery(() => getDocs(query(collection(db, 'lists', parentListId, 'reviews'), where('sublistId', '==', listId))))
                     ] : [])
                 ]);
 
@@ -311,15 +309,9 @@ export const EditListForm: React.FC<EditListFormProps> = ({ listId, onSuccess, o
             const snapshots = parentListId
                 ? await Promise.all([
                     safeGetDocs(() => getDocs(query(collection(db, 'lists', parentListId, 'reviews'), where('sublistId', '==', listId)))),
-                    safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('sublistId', '==', listId)))),
-                    safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('listId', '==', listId)))),
                     safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews')))
                 ])
-                : await Promise.all([
-                    safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews'))),
-                    safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('listId', '==', listId)))),
-                    safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('parentListId', '==', listId))))
-                ]);
+                : [await safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews')))];
 
             const reviewDocs = new Map<string, QueryDocumentSnapshot<DocumentData>>();
             snapshots.forEach(snap => {

--- a/frontend/src/hooks/useListDetails.ts
+++ b/frontend/src/hooks/useListDetails.ts
@@ -106,26 +106,18 @@ async function fetchListDetails(listId: string): Promise<{ list: ListEntity; rev
         return review.userId === currentUser.uid || review.authorId === currentUser.uid;
     };
 
+    // Las reseñas viven solo en lists/{listId}/reviews (la colección raíz
+    // legacy reviews/ está vacía y ya no se consulta — ver docs/REVIEWS-MIGRATION.md).
     if (listData?.parentListId) {
         const parentListId = listData.parentListId;
-        const [rootBySublist, rootByList, nestedParent, nestedLegacyOwn] = await Promise.all([
-            safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('sublistId', '==', listId)))),
-            safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('listId', '==', listId)))),
+        const [nestedParent, nestedLegacyOwn] = await Promise.all([
             safeGetDocs(() => getDocs(query(collection(db, 'lists', parentListId, 'reviews'), where('sublistId', '==', listId)))),
             safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews'))),
         ]);
-        appendSnapshot(rootBySublist, parentListId);
-        appendSnapshot(rootByList, parentListId);
         appendSnapshot(nestedLegacyOwn, listId);
         appendSnapshot(nestedParent, parentListId);
     } else {
-        const [rootByList, rootByParentList, nestedMain] = await Promise.all([
-            safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('listId', '==', listId)))),
-            safeGetDocs(() => getDocs(query(collection(db, 'reviews'), where('parentListId', '==', listId)))),
-            safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews'))),
-        ]);
-        appendSnapshot(rootByList, listId);
-        appendSnapshot(rootByParentList, listId);
+        const nestedMain = await safeGetDocs(() => getDocs(collection(db, 'lists', listId, 'reviews')));
         appendSnapshot(nestedMain, listId);
     }
 

--- a/frontend/src/pages/DeveloperPage.tsx
+++ b/frontend/src/pages/DeveloperPage.tsx
@@ -5,7 +5,7 @@ import { useUserProfile } from '../hooks/useUserProfile';
 import { PlaceService } from '../services/PlaceService';
 import { BADGE_PRESET_PACKS } from '../config/badgePresets';
 import { db, functions, storage } from '../firebase';
-import { collection, query, where, getDocs, doc, getDoc, getDocFromServer, limit as firestoreLimit, setDoc, updateDoc, deleteDoc, writeBatch, arrayUnion, onSnapshot, orderBy } from 'firebase/firestore';
+import { collection, collectionGroup, query, where, getDocs, doc, getDoc, getDocFromServer, limit as firestoreLimit, setDoc, updateDoc, deleteDoc, writeBatch, arrayUnion, onSnapshot, orderBy } from 'firebase/firestore';
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { useQueryClient } from '@tanstack/react-query';
 import { Terminal, Search, AlertCircle, RefreshCw, List as ListIcon, MapPin, Layers, Database, CloudLightning, Tag, CheckCircle, X, Upload, Flag, MessageSquare, Palette, Users, SlidersHorizontal, ExternalLink, RefreshCcw, FileDown, ClipboardList, Activity, Building2 } from 'lucide-react';
@@ -533,10 +533,11 @@ export const DeveloperPage: React.FC = () => {
                         closedStatusUpdatedAt: new Date(),
                     });
 
-                    // Batch-update root reviews so ReviewCard shows closed status everywhere
+                    // Batch-update de las reseñas del lugar (lists/{listId}/reviews vía
+                    // collection group) para que ReviewCard muestre el estado de cierre.
                     try {
                         const reviewsSnap = await getDocs(
-                            query(collection(db, 'reviews'), where('placeId', '==', placeTargetId), firestoreLimit(400))
+                            query(collectionGroup(db, 'reviews'), where('placeId', '==', placeTargetId), firestoreLimit(100))
                         );
                         const batch = writeBatch(db);
                         reviewsSnap.docs.forEach(d => {

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
-import { collection, query, where, getDocs, doc, getDoc, limit } from 'firebase/firestore';
+import { collection, collectionGroup, query, where, getDocs, doc, getDoc, limit } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../context/AuthContext';
 import { MessageSquare, MapPin, List as ListIcon, Plus, X, Camera, Bookmark, Share2, Flag, Image as ImageIcon, ZoomIn, LayoutGrid, Rows3, ChevronUp } from 'lucide-react';
@@ -128,36 +128,10 @@ export const GroupPage: React.FC = () => {
                 setUnavailableItems(placeData.unavailableItems || []);
             }
 
-            const [publicListsSnap, followingListsSnap, ownListsSnap] = await Promise.all([
-                getDocs(query(collection(db, 'lists'), where('isPublic', '==', true), limit(60))),
-                user ? getDocs(query(collection(db, 'users', user.uid, 'followingLists'), limit(60))) : Promise.resolve(null),
-                user ? getDocs(query(collection(db, 'lists'), where('userId', '==', user.uid), limit(40))) : Promise.resolve(null)
-            ]);
-
+            const ownListsSnap = user
+                ? await getDocs(query(collection(db, 'lists'), where('userId', '==', user.uid), limit(40)))
+                : null;
             const ownListSet = new Set(ownListsSnap ? ownListsSnap.docs.map((d) => d.id) : []);
-            const candidateListIds = Array.from(new Set([
-                ...publicListsSnap.docs.map((d) => d.id),
-                ...(followingListsSnap ? followingListsSnap.docs.map((d) => d.id) : []),
-                ...(ownListsSnap ? ownListsSnap.docs.map((d) => d.id) : [])
-            ])).slice(0, 80);
-
-            const reviewsByList = await Promise.all(candidateListIds.map(async (candidateListId) => {
-                try {
-                    const listReviewsSnap = await getDocs(
-                        query(collection(db, 'lists', candidateListId, 'reviews'), where('placeId', '==', placeId), limit(25))
-                    );
-                    return listReviewsSnap.docs.map((reviewDoc) => ({
-                        id: reviewDoc.id,
-                        ...(reviewDoc.data() as any),
-                        listId: candidateListId
-                    } as ReviewEntity));
-                } catch (error: any) {
-                    if (error?.code !== 'permission-denied') {
-                        console.warn(`Error loading group reviews for list ${candidateListId}`, error);
-                    }
-                    return [] as ReviewEntity[];
-                }
-            }));
 
             const canViewReview = (review: any) => {
                 if (review.visibility !== 'private') return true;
@@ -171,39 +145,27 @@ export const GroupPage: React.FC = () => {
                     || (reviewListId ? ownListSet.has(reviewListId) : false);
             };
 
-            let rootReviews: ReviewEntity[] = [];
-            try {
-                const rootSnap = await getDocs(
-                    query(collection(db, 'reviews'), where('placeId', '==', placeId), limit(120))
-                );
-                rootReviews = rootSnap.docs
-                    .map((reviewDoc) => ({
-                        id: reviewDoc.id,
-                        ...(reviewDoc.data() as any)
-                    } as ReviewEntity))
-                    .filter((review) => canViewReview(review));
-            } catch (error: any) {
-                if (error?.code !== 'permission-denied') {
-                    console.warn('Error loading root reviews for group page', error);
-                }
-            }
-
+            // Una sola query de collection group sobre lists/{listId}/reviews
+            // (las reglas exigen usuario autenticado y limit <= 100).
             const reviewMap = new Map<string, ReviewEntity>();
-            for (const review of rootReviews) {
-                const resolvedListId = review.listId || (review as any).parentListId || '';
-                reviewMap.set(`${resolvedListId || 'unknown'}:${review.id}`, {
-                    ...review,
-                    listId: resolvedListId
-                });
-            }
-            for (const listReviews of reviewsByList) {
-                for (const review of listReviews) {
-                    if (!canViewReview(review)) continue;
-                    const resolvedListId = review.listId || (review as any).parentListId || '';
-                    reviewMap.set(`${resolvedListId || 'unknown'}:${review.id}`, {
-                        ...review,
-                        listId: resolvedListId
+            if (user) {
+                try {
+                    const reviewsSnap = await getDocs(
+                        query(collectionGroup(db, 'reviews'), where('placeId', '==', placeId), limit(100))
+                    );
+                    reviewsSnap.docs.forEach((reviewDoc) => {
+                        const data = reviewDoc.data() as any;
+                        const pathParts = reviewDoc.ref.path.split('/');
+                        const resolvedListId = (pathParts[0] === 'lists' ? pathParts[1] : '')
+                            || data.listId || data.parentListId || '';
+                        const review = { id: reviewDoc.id, ...data, listId: resolvedListId } as ReviewEntity;
+                        if (!canViewReview(review)) return;
+                        reviewMap.set(reviewDoc.id, review);
                     });
+                } catch (error: any) {
+                    if (error?.code !== 'permission-denied') {
+                        console.warn('Error loading reviews for group page', error);
+                    }
                 }
             }
 
@@ -487,11 +449,7 @@ export const GroupPage: React.FC = () => {
                         || review.ownerId === user.uid;
                 };
 
-                const [nestedSnap, rootByListSnap, rootByParentSnap] = await Promise.all([
-                    getDocs(collection(db, 'lists', primaryId, 'reviews')).catch(() => null),
-                    getDocs(query(collection(db, 'reviews'), where('listId', '==', primaryId))).catch(() => null),
-                    getDocs(query(collection(db, 'reviews'), where('parentListId', '==', primaryId))).catch(() => null)
-                ]);
+                const nestedSnap = await getDocs(collection(db, 'lists', primaryId, 'reviews')).catch(() => null);
 
                 const reviewMap = new Map<string, ReviewEntity>();
                 const append = (snap: any) => {
@@ -508,8 +466,6 @@ export const GroupPage: React.FC = () => {
                     });
                 };
 
-                append(rootByListSnap);
-                append(rootByParentSnap);
                 append(nestedSnap);
                 const lReviews = Array.from(reviewMap.values());
 

--- a/frontend/src/services/ReviewService.ts
+++ b/frontend/src/services/ReviewService.ts
@@ -16,14 +16,6 @@ const asReviewData = (value: unknown): Record<string, unknown> => {
     return value && typeof value === 'object' ? value as Record<string, unknown> : {};
 };
 
-const getFirebaseErrorCode = (error: unknown): string | undefined => {
-    if (error && typeof error === 'object') {
-        const maybeError = error as { code?: unknown };
-        return typeof maybeError.code === 'string' ? maybeError.code : undefined;
-    }
-    return undefined;
-};
-
 export const ReviewService = {
     /**
      * Deletes a review from a specific list.
@@ -36,55 +28,22 @@ export const ReviewService = {
         }
 
         try {
-            const refsToDelete: DocumentReference<DocumentData>[] = [];
-            let reviewData: Record<string, unknown> | null = null;
-
-            if (listId) {
-                const canonicalRef = doc(db, 'lists', listId, 'reviews', reviewId);
-                const canonicalSnap = await getDoc(canonicalRef);
-                if (canonicalSnap.exists()) {
-                    refsToDelete.push(canonicalRef);
-                    reviewData = asReviewData(canonicalSnap.data());
-                }
+            // Las reseñas viven únicamente en lists/{listId}/reviews
+            // (la colección raíz legacy está vacía — ver docs/REVIEWS-MIGRATION.md).
+            if (!listId) {
+                console.warn(`[deleteReview] Missing listId for review ${reviewId}, nothing to delete.`);
+                return;
             }
 
-            // Root collection may not be readable for legacy reviews with only authorId.
-            // Wrap in try-catch to gracefully skip if permissions fail.
-            try {
-                const rootRef = doc(db, 'reviews', reviewId);
-                const rootSnap = await getDoc(rootRef);
-                if (rootSnap.exists()) {
-                    refsToDelete.push(rootRef);
-                    if (!reviewData) reviewData = asReviewData(rootSnap.data());
-
-                    const rootListId = rootSnap.data().listId;
-                    if (rootListId && (!listId || rootListId !== listId)) {
-                        if (typeof rootListId === 'string') {
-                            const movedCanonicalRef = doc(db, 'lists', rootListId, 'reviews', reviewId);
-                            const movedCanonicalSnap = await getDoc(movedCanonicalRef);
-                            if (movedCanonicalSnap.exists()) {
-                                refsToDelete.push(movedCanonicalRef);
-                                reviewData = asReviewData(movedCanonicalSnap.data());
-                            }
-                        }
-                    }
-                }
-            } catch (readErr: unknown) {
-                if (getFirebaseErrorCode(readErr) === 'permission-denied') {
-                    console.warn(`[deleteReview] No read access to root reviews/${reviewId}, skipping root path.`);
-                } else {
-                    throw readErr;
-                }
-            }
-
-            if (refsToDelete.length === 0) {
+            const canonicalRef: DocumentReference<DocumentData> = doc(db, 'lists', listId, 'reviews', reviewId);
+            const canonicalSnap = await getDoc(canonicalRef);
+            if (!canonicalSnap.exists()) {
                 console.warn(`Review ${reviewId} not found for deletion.`);
                 return;
             }
 
-            const uniqueRefs = Array.from(new Map(refsToDelete.map((ref) => [ref.path, ref])).values());
-            await Promise.all(uniqueRefs.map((ref) => deleteDoc(ref)));
-            const resolvedReviewData = reviewData || {};
+            const resolvedReviewData = asReviewData(canonicalSnap.data());
+            await deleteDoc(canonicalRef);
 
             // Update Counters (Best effort)
             const updates = [];


### PR DESCRIPTION
## Resumen

Continuación del PR #252. La auditoría en producción confirmó que la colección raíz `reviews/` está **vacía** (0 documentos), así que se retira todo el código de doble lectura que se defendía de datos inexistentes.

## Cambios

- **`useListDetails`**: eliminadas las 2-3 queries root por cada carga de lista.
- **`GroupPage`**: el fan-out de hasta ~80 queries por lugar + query root se sustituye por una única query `collectionGroup('reviews')` por `placeId` (mismo patrón que `usePlaceDetails` en #252); las estadísticas de la lista primaria leen solo la subcolección anidada.
- **`EditListForm`**: eliminadas las queries root en el renombrado de tags y en la sincronización de visibilidad.
- **`ReviewService.deleteReview`**: borra solo la ruta canónica `lists/{listId}/reviews` (antes comprobaba hasta 3 referencias).
- **`DeveloperPage` (marcar lugar cerrado)**: el batch de `placeClosedStatus` apuntaba a la colección root vacía y además la regla `reviewAllowedUpdateKeys` no permitía ese campo, así que nunca funcionó. Ahora usa collectionGroup con `limit(100)` (tope de las reglas) y la clave se añade a `firestore.rules`.
- **Docs**: `REVIEWS-MIGRATION.md` y `mejoras-pendientes.md` actualizados con el resultado de la auditoría y la limpieza.

Se conservan a propósito el fallback root de las herramientas de diagnóstico admin (`ReviewsManagerTab`, `UserDataExportTab`) y las funciones de migración como red de seguridad.

## Después del merge

- `firebase deploy --only firestore:rules` (clave `placeClosedStatus` nueva).
- Desplegar frontend. No hace falta redesplegar functions.

## Verificación

- `tsc --noEmit` limpio, 40/40 tests pasan, `vite build` OK.
- Los errores de lint restantes en `GroupPage`/`DeveloperPage` son preexistentes (verificado contra la versión base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc8Q66r21xJmBeLPN99Spn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc8Q66r21xJmBeLPN99Spn)_