### PR TITLE
Add analytics & sponsored tracking

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -604,17 +604,25 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Emplazamientos patrocinados (home/búsqueda). Lectura pública (es
-    // publicidad etiquetada); escritura solo vía Cloud Functions.
+    // Emplazamientos patrocinados (home/búsqueda). Las campañas activas son
+    // públicas; borradores/rechazos solo los ven creador y jefe.
     match /sponsoredPlacements/{placementId} {
-      allow read: if true;
+      allow read: if resource.data.status == 'active' || (
+        request.auth != null && (
+          resource.data.createdBy == request.auth.uid || isJefe(request.auth.uid)
+        )
+      );
       allow write: if false;
     }
 
-    // Platos destacados por radio (sorteo ponderado por unidades). Lectura
-    // pública para el carrusel; escritura solo vía Cloud Functions.
+    // Platos destacados por radio. Las campañas activas son públicas para el
+    // carrusel; el resto solo lo ven creador y jefe.
     match /sponsoredItemSpotlights/{spotlightId} {
-      allow read: if true;
+      allow read: if resource.data.status == 'active' || (
+        request.auth != null && (
+          resource.data.createdBy == request.auth.uid || isJefe(request.auth.uid)
+        )
+      );
       allow write: if false;
     }
 
@@ -750,6 +758,46 @@ service cloud.firestore {
     match /apiUsageStats/{docId} {
       allow read, list: if request.auth != null && isJefe(request.auth.uid);
       allow write: if false;
+    }
+
+    // Analítica de navegación: el cliente nunca accede directamente. Las
+    // vistas se agregan y consultan mediante Cloud Functions, que aplican
+    // rate-limit y autorización de jefe sin exponer marcadores de sesión.
+    match /pageAnalyticsTotals/{docId} {
+      allow read, write: if false;
+    }
+    match /pageAnalyticsDaily/{docId} {
+      allow read, write: if false;
+    }
+    match /pageAnalyticsGlobal/{docId} {
+      allow read, write: if false;
+    }
+    match /pageAnalyticsGlobalDaily/{docId} {
+      allow read, write: if false;
+    }
+    match /pageAnalyticsSessionMarkers/{docId} {
+      allow read, write: if false;
+    }
+    match /placeAnalyticsDaily/{docId} {
+      allow read, write: if false;
+    }
+    match /connectionGeoDaily/{docId} {
+      allow read, write: if false;
+    }
+    match /connectionGeoMarkers/{docId} {
+      allow read, write: if false;
+    }
+    match /reviewGeoDaily/{docId} {
+      allow read, write: if false;
+    }
+    match /reviewAnalyticsMarkers/{docId} {
+      allow read, write: if false;
+    }
+    match /shareEventMarkers/{docId} {
+      allow read, write: if false;
+    }
+    match /sponsoredEventMarkers/{docId} {
+      allow read, write: if false;
     }
 
     // ==================================================================

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import React, { Suspense } from 'react';
 import { ToastProvider } from './context/ToastContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { Navbar } from './components/Navbar';
-import { useLocation } from './hooks/useLocation';
 import { App as CapApp } from '@capacitor/app';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { Capacitor } from '@capacitor/core';
@@ -15,6 +14,7 @@ import { useAuth } from './context/AuthContext';
 import { NotificationBannerProvider, useNotificationBanner } from './context/NotificationBannerContext';
 import { NotificationBanner } from './components/NotificationBanner';
 import ErrorBoundary from './components/ErrorBoundary';
+import { PageAnalyticsTracker } from './components/PageAnalyticsTracker';
 
 // Lazy Load Pages
 const HomePage = React.lazy(() => import('./pages/HomePage').then(m => ({ default: m.HomePage })));
@@ -41,12 +41,6 @@ const ChildSafetyPage = React.lazy(() => import('./pages/ChildSafetyPage').then(
 const IstariCorePage = React.lazy(() => import('./pages/IstariCorePage').then(m => ({ default: m.IstariCorePage })));
 const TermsPage = React.lazy(() => import('./pages/TermsPage').then(m => ({ default: m.TermsPage })));
 const LabPage = React.lazy(() => import('./pages/LabPage').then(m => ({ default: m.LabPage })));
-
-// Activating location request globally
-const LocationActivator = () => {
-  useLocation();
-  return null;
-};
 
 // Hide Navbar on fullscreen routes like /lab
 const NavbarWrapper = () => {
@@ -262,10 +256,10 @@ const AppRoutes = () => {
 function App() {
   return (
     <ToastProvider>
-      <LocationActivator />
       <NotificationBannerProvider>
         <Router>
           <ScrollToTop />
+          <PageAnalyticsTracker />
           <div className="min-h-screen font-sans selection:bg-[var(--lt-accent-soft)]"
             style={{
               background: 'var(--lt-bg)',

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap, Circle } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { createRatingMarkerIcon, createEmojiMarkerIcon, createSponsoredMarkerIcon, getRatingColor, MAP_LAYERS, DEFAULT_MAP_LAYER, MAP_LAYER_STORAGE_KEY } from '../utils/mapUtils';
-import { getSponsoredPlaceIds } from '../services/BusinessProService';
+import { getSponsoredSearchCampaigns, recordSponsoredEvent } from '../services/BusinessProService';
 import type { MapLayerId } from '../utils/mapUtils';
 import { useLocation } from '../hooks/useLocation';
 import type { Location as UserLocation } from '../hooks/useLocation';
@@ -201,7 +201,7 @@ function MapUpdater({ center, items, range, location }: { center: [number, numbe
 export const MapView: React.FC<MapViewProps> = ({ items, mode = 'global', center = [40.416, -3.703], range = null, showLayerControl = true }) => {
 
     const { location } = useLocation();
-    const { user } = useAuth();
+    const { user, isJefe } = useAuth();
 
     // Capa activa: lee localStorage primero (inmediato), luego Firestore (async)
     const [currentLayer, setCurrentLayer] = useState<MapLayerId>(() => {
@@ -225,12 +225,12 @@ export const MapView: React.FC<MapViewProps> = ({ items, mode = 'global', center
 
     // Lugares con publicidad activa: chincheta dorada con "P" (con cache de
     // 5 min en el servicio para no repetir lecturas por cada mapa).
-    const [sponsoredIds, setSponsoredIds] = useState<Set<string>>(new Set());
+    const [sponsoredCampaigns, setSponsoredCampaigns] = useState<Map<string, string[]>>(new Map());
     useEffect(() => {
         let cancelled = false;
-        getSponsoredPlaceIds()
-            .then((ids) => {
-                if (!cancelled && ids.size > 0) setSponsoredIds(ids);
+        getSponsoredSearchCampaigns()
+            .then((campaigns) => {
+                if (!cancelled && campaigns.size > 0) setSponsoredCampaigns(campaigns);
             })
             .catch(() => {
                 // Marcado patrocinado es best-effort: sin datos, pins normales.
@@ -303,16 +303,24 @@ export const MapView: React.FC<MapViewProps> = ({ items, mode = 'global', center
                 {showLayerControl && <LayerSelectorControl currentLayer={currentLayer} onLayerChange={handleLayerChange} />}
 
                 {validItems.map((item) => {
-                    const isSponsored = sponsoredIds.has(item.placeId || item.id);
+                    const campaignIds = sponsoredCampaigns.get(item.placeId || item.id) || [];
+                    const isSponsored = campaignIds.length > 0;
                     return (
                     <Marker
                         key={item.id}
                         position={[item.lat!, item.lng!]}
-                        icon={item.emoji || item.color
-                            ? createEmojiMarkerIcon(item.emoji || '📍', item.color || '#6366f1')
-                            : isSponsored
-                                ? createSponsoredMarkerIcon(item.rating || 0)
+                        icon={isSponsored
+                            ? createSponsoredMarkerIcon(item.rating || 0)
+                            : item.emoji || item.color
+                                ? createEmojiMarkerIcon(item.emoji || '📍', item.color || '#6366f1')
                                 : createRatingMarkerIcon(item.rating || 0)}
+                        eventHandlers={{
+                            popupopen: () => {
+                                if (!isJefe) campaignIds.forEach((campaignId) => {
+                                    void recordSponsoredEvent('placement', campaignId, 'impression').catch(() => undefined);
+                                });
+                            },
+                        }}
                     >
                         <Popup className="listopic-popup" closeButton={false} maxWidth={270} minWidth={250}>
                             {(() => {
@@ -338,6 +346,11 @@ export const MapView: React.FC<MapViewProps> = ({ items, mode = 'global', center
                                         </div>
 
                                         <div style={{ padding: '10px 14px 12px' }}>
+                                            {isSponsored && (
+                                                <div style={{ display: 'inline-flex', marginBottom: 6, padding: '2px 7px', borderRadius: 999, border: '1px solid rgba(245,158,11,0.35)', background: 'rgba(245,158,11,0.12)', color: '#b45309', fontSize: 9, fontWeight: 800, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                                                    Patrocinado
+                                                </div>
+                                            )}
                                             <div style={{ fontWeight: 700, fontSize: 14, color: '#111827', marginBottom: 2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                                                 {item.name}
                                             </div>
@@ -369,6 +382,14 @@ export const MapView: React.FC<MapViewProps> = ({ items, mode = 'global', center
 
                                             <Link
                                                 to={`/place/${item.placeId || item.id}`}
+                                                onClick={() => {
+                                                    if (!isJefe) campaignIds.forEach((campaignId) => {
+                                                        void Promise.all([
+                                                            recordSponsoredEvent('placement', campaignId, 'impression'),
+                                                            recordSponsoredEvent('placement', campaignId, 'click'),
+                                                        ]).catch(() => undefined);
+                                                    });
+                                                }}
                                                 style={{ display: 'block', width: '100%', padding: '8px 0', background: '#4f46e5', color: '#fff', textAlign: 'center', fontWeight: 700, fontSize: 13, borderRadius: 10, textDecoration: 'none', boxSizing: 'border-box' }}
                                             >
                                                 Ver detalles

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Archive, Bell, Building2, Dice5, Home, Info, Menu, MessageSquare, Plus, Search, User, X } from 'lucide-react';
+import { Archive, Bell, Building2, Dice5, Eye, Home, Info, Menu, MessageSquare, Plus, Search, User, X } from 'lucide-react';
 import { collection, doc, limit, onSnapshot, query, where } from 'firebase/firestore';
 import { useAuth } from '../context/AuthContext';
 import { useAppConfig, useAppConfigLoading } from '../context/AppConfigContext';
@@ -10,6 +10,8 @@ import { db } from '../firebase';
 import { Capacitor } from '@capacitor/core';
 import { NotificationHistoryModal } from './NotificationHistoryModal';
 import { NotificationModal } from './NotificationModal';
+import { PageAnalyticsModal } from './PageAnalyticsModal';
+import { isTrackableAnalyticsPath } from '../services/AnalyticsService';
 
 const FIREBASE_STORAGE_HOST = 'firebasestorage.googleapis.com';
 
@@ -51,7 +53,7 @@ const NavItem = ({ to, icon: Icon, label, badge, count, isActive }: { to: string
 };
 
 export const Navbar: React.FC = () => {
-    const { user } = useAuth();
+    const { user, isJefe } = useAuth();
     const config = useAppConfig();
     const isConfigLoading = useAppConfigLoading();
     const { theme } = useTheme();
@@ -70,6 +72,7 @@ export const Navbar: React.FC = () => {
     const [notificationPanelMode, setNotificationPanelMode] = useState<'desktop' | 'mobile'>('desktop');
     const bellRef = useRef<HTMLDivElement>(null);
     const [showHistory, setShowHistory] = useState(false);
+    const [showPageAnalytics, setShowPageAnalytics] = useState(false);
     const [unreadCount, setUnreadCount] = useState(0);
     const [unreadChatCount, setUnreadChatCount] = useState(0);
     const [managedBusinessCount, setManagedBusinessCount] = useState(0);
@@ -193,6 +196,7 @@ export const Navbar: React.FC = () => {
         const timeoutId = window.setTimeout(() => {
             setIsMenuOpen(false);
             setShowNotifications(false);
+            setShowPageAnalytics(false);
         }, 0);
         return () => window.clearTimeout(timeoutId);
     }, [location.pathname]);
@@ -290,6 +294,18 @@ export const Navbar: React.FC = () => {
                             <span>Crear Sublista</span>
                         </Link>
 
+                        {isJefe && isTrackableAnalyticsPath(location.pathname) && (
+                            <button
+                                type="button"
+                                onClick={() => setShowPageAnalytics(true)}
+                                className="rounded-full p-2.5 text-amber-300 transition-all hover:bg-amber-500/10 hover:text-amber-200"
+                                title="Ojo mágico: estadísticas de esta página"
+                                aria-label="Ver estadísticas de esta página"
+                            >
+                                <Eye className="h-5 w-5" />
+                            </button>
+                        )}
+
                         {user && (
                             <div className="relative" ref={bellRef}>
                                 <button
@@ -347,6 +363,16 @@ export const Navbar: React.FC = () => {
                     </div>
 
                     <div className="md:hidden flex items-center gap-3">
+                        {isJefe && isTrackableAnalyticsPath(location.pathname) && (
+                            <button
+                                type="button"
+                                onClick={() => setShowPageAnalytics(true)}
+                                className="rounded-full p-2 text-amber-300"
+                                aria-label="Ver estadísticas de esta página"
+                            >
+                                <Eye className="h-5 w-5" />
+                            </button>
+                        )}
                         {user && (
                             <Link to={`/profile/${user.uid}`} className="relative shrink-0 group">
                                 <div className="w-9 h-9 rounded-full p-[2px] transition-transform group-active:scale-95 shadow-md" style={{ backgroundImage: 'var(--lt-accent-grad)', boxShadow: '0 2px 8px var(--lt-accent-shadow)' }}>
@@ -443,6 +469,18 @@ export const Navbar: React.FC = () => {
                                     )}
                                 </button>
                             )}
+                            {isJefe && isTrackableAnalyticsPath(location.pathname) && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setIsMenuOpen(false);
+                                        setShowPageAnalytics(true);
+                                    }}
+                                    className="w-full flex items-center gap-3 p-4 rounded-xl border border-amber-500/20 bg-amber-500/10 text-amber-200"
+                                >
+                                    <Eye className="w-5 h-5" /> Ojo mágico · Estadísticas
+                                </button>
+                            )}
                             <Link to="/archive" className="flex items-center gap-3 p-4 rounded-xl bg-white/5 border border-white/5 text-[var(--lt-text)]">
                                 <Archive className="w-5 h-5 text-[var(--lt-accent)]" /> Archivo
                             </Link>
@@ -499,6 +537,7 @@ export const Navbar: React.FC = () => {
             )}
 
             {showHistory && <NotificationHistoryModal onClose={() => setShowHistory(false)} />}
+            {showPageAnalytics && <PageAnalyticsModal pathname={location.pathname} onClose={() => setShowPageAnalytics(false)} />}
 
 
         </header>

--- a/frontend/src/components/PageAnalyticsModal.tsx
+++ b/frontend/src/components/PageAnalyticsModal.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { BarChart3, Eye, Loader2, Monitor, RefreshCw, Share2, UserCheck, Users, X } from 'lucide-react';
+import { getPageAnalytics, normalizeAnalyticsPath, type PageAnalyticsResult } from '../services/AnalyticsService';
+
+const SOURCE_LABELS: Record<string, string> = {
+    direct: 'Directo',
+    internal: 'Navegación interna',
+    search: 'Buscadores',
+    social: 'Redes sociales',
+    external: 'Web externa',
+};
+
+const DEVICE_LABELS: Record<string, string> = {
+    mobile: 'Móvil',
+    tablet: 'Tablet',
+    desktop: 'Escritorio',
+};
+
+const sum = (values: number[]) => values.reduce((total, value) => total + value, 0);
+const SHARE_CHANNEL_LABELS: Record<string, string> = {
+    whatsapp: 'WhatsApp', clipboard: 'Enlace copiado', image: 'Tarjeta generada', chat: 'Chat de Listopic',
+};
+
+export const PageAnalyticsModal: React.FC<{ pathname: string; onClose: () => void }> = ({ pathname, onClose }) => {
+    const [data, setData] = useState<PageAnalyticsResult | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const path = normalizeAnalyticsPath(pathname);
+
+    const load = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            setData(await getPageAnalytics(path, 30));
+        } catch (loadError) {
+            console.error('PageAnalyticsModal: load failed', loadError);
+            setError('No se pudieron cargar las estadísticas de esta página. Comprueba que tu cuenta Jefe tiene el claim admin activo.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [path]);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [onClose]);
+
+    const period = useMemo(() => {
+        const daily = data?.daily || [];
+        const last7 = daily.slice(-7);
+        const views30 = sum(daily.map((row) => row.totalViews));
+        const authenticated30 = sum(daily.map((row) => row.authenticatedViews));
+        return {
+            views7: sum(last7.map((row) => row.totalViews)),
+            views30,
+            shares30: sum(daily.map((row) => row.totalShares)),
+            unique30: sum(daily.map((row) => row.uniqueSessions)),
+            authenticatedPct: views30 > 0 ? Math.round((authenticated30 / views30) * 100) : 0,
+            maxViews: Math.max(1, ...daily.map((row) => row.totalViews)),
+        };
+    }, [data]);
+
+    return (
+        <div className="pointer-events-auto fixed inset-0 z-[90] flex items-center justify-center bg-black/70 p-3 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Estadísticas de la página">
+            <button type="button" className="absolute inset-0 cursor-default" onClick={onClose} aria-label="Cerrar" />
+            <div className="relative z-10 max-h-[90dvh] w-full max-w-3xl overflow-y-auto rounded-3xl border border-white/10 bg-[var(--lt-bg-deep)] p-5 shadow-2xl sm:p-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h2 className="flex items-center gap-2 text-xl font-black text-[var(--lt-text)]">
+                            <Eye className="h-5 w-5 text-[var(--lt-accent)]" />
+                            Ojo mágico
+                        </h2>
+                        <p className="mt-1 break-all font-mono text-xs text-[var(--lt-text-muted)]">{path}</p>
+                    </div>
+                    <div className="flex gap-1">
+                        <button type="button" onClick={load} disabled={loading} className="rounded-full p-2 text-[var(--lt-text-muted)] hover:bg-white/10 hover:text-[var(--lt-text)]" aria-label="Actualizar">
+                            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                        </button>
+                        <button type="button" onClick={onClose} className="rounded-full p-2 text-[var(--lt-text-muted)] hover:bg-white/10 hover:text-[var(--lt-text)]" aria-label="Cerrar">
+                            <X className="h-5 w-5" />
+                        </button>
+                    </div>
+                </div>
+
+                {loading && !data ? (
+                    <div className="grid min-h-64 place-items-center text-sm text-[var(--lt-text-muted)]">
+                        <span className="flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Cargando analítica…</span>
+                    </div>
+                ) : error ? (
+                    <div className="mt-5 rounded-2xl border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>
+                ) : data ? (
+                    <div className="mt-5 space-y-5">
+                        <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+                            {[
+                                { label: 'Vistas totales', value: data.total.totalViews, icon: Eye },
+                                { label: 'Últimos 7 días', value: period.views7, icon: BarChart3 },
+                                { label: 'Sesiones únicas · 30 d', value: period.unique30, icon: Users },
+                                { label: 'Compartidos · 30 d', value: period.shares30, icon: Share2 },
+                                { label: 'Vistas con sesión', value: `${period.authenticatedPct}%`, icon: UserCheck },
+                            ].map(({ label, value, icon: Icon }) => (
+                                <div key={label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
+                                    <div className="flex items-center gap-1.5 text-[11px] text-[var(--lt-text-muted)]"><Icon className="h-3.5 w-3.5 text-[var(--lt-accent)]" />{label}</div>
+                                    <p className="mt-1 text-2xl font-black text-[var(--lt-text)]">{typeof value === 'number' ? value.toLocaleString('es-ES') : value}</p>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                            <div className="mb-3 flex items-center justify-between gap-3">
+                                <h3 className="text-sm font-bold text-[var(--lt-text)]">Vistas · últimos 30 días</h3>
+                                <span className="text-xs text-[var(--lt-text-muted)]">{period.views30.toLocaleString('es-ES')} en el periodo</span>
+                            </div>
+                            <div className="flex h-28 items-end gap-1">
+                                {data.daily.map((row) => (
+                                    <div key={row.date} className="group relative flex h-full flex-1 items-end" title={`${row.date}: ${row.totalViews} vistas`}>
+                                        <div
+                                            className="w-full min-w-[2px] rounded-t bg-[var(--lt-accent)] opacity-65 transition-opacity group-hover:opacity-100"
+                                            style={{ height: `${row.totalViews ? Math.max(5, (row.totalViews / period.maxViews) * 100) : 2}%` }}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <Breakdown title="Origen" values={data.total.bySource} labels={SOURCE_LABELS} />
+                            <Breakdown title="Dispositivo" values={data.total.byDevice} labels={DEVICE_LABELS} icon={<Monitor className="h-4 w-4" />} />
+                            <Breakdown title="Cómo se comparte" values={data.total.byShareChannel} labels={SHARE_CHANNEL_LABELS} icon={<Share2 className="h-4 w-4" />} />
+                        </div>
+
+                        <div className="flex flex-col gap-2 border-t border-white/10 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                            <p className="text-[11px] text-[var(--lt-text-muted)]">Actualización inmediata al pulsar refrescar. No cuenta entorno local ni cuentas Jefe.</p>
+                            <Link
+                                to={`/developer?tab=analytics&path=${encodeURIComponent(path)}`}
+                                onClick={onClose}
+                                className="inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--lt-accent)] px-4 py-2 text-xs font-black text-white"
+                            >
+                                <BarChart3 className="h-4 w-4" /> Ver analítica profunda
+                            </Link>
+                        </div>
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
+const Breakdown: React.FC<{ title: string; values: Record<string, number>; labels: Record<string, string>; icon?: React.ReactNode }> = ({ title, values, labels, icon }) => {
+    const rows = Object.entries(values).sort((a, b) => b[1] - a[1]);
+    const total = Math.max(1, sum(rows.map(([, value]) => value)));
+    return (
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-bold text-[var(--lt-text)]">{icon}{title}</h3>
+            {rows.length === 0 ? <p className="text-xs text-[var(--lt-text-muted)]">Sin datos todavía.</p> : (
+                <div className="space-y-2">
+                    {rows.slice(0, 5).map(([key, value]) => (
+                        <div key={key}>
+                            <div className="mb-1 flex justify-between text-xs"><span className="text-[var(--lt-text-muted)]">{labels[key] || key}</span><span className="font-bold text-[var(--lt-text)]">{value.toLocaleString('es-ES')}</span></div>
+                            <div className="h-1.5 overflow-hidden rounded-full bg-white/5"><div className="h-full rounded-full bg-[var(--lt-accent)]" style={{ width: `${(value / total) * 100}%` }} /></div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/components/PageAnalyticsTracker.tsx
+++ b/frontend/src/components/PageAnalyticsTracker.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { recordConnectionLocation, recordPageView } from '../services/AnalyticsService';
+import { useAuth } from '../context/AuthContext';
+import { useLocation as useDeviceLocation } from '../hooks/useLocation';
+
+export const PageAnalyticsTracker: React.FC = () => {
+    const location = useLocation();
+    const { isJefe } = useAuth();
+    const { location: deviceLocation } = useDeviceLocation();
+    const geoSentRef = React.useRef(false);
+
+    React.useEffect(() => {
+        // Las comprobaciones internas del equipo no deben contaminar los datos.
+        if (isJefe) return;
+        const timeoutId = window.setTimeout(() => {
+            void recordPageView(location.pathname).catch((error) => {
+                console.warn('No se pudo registrar la vista de página.', error);
+            });
+        }, 250);
+        return () => window.clearTimeout(timeoutId);
+    }, [isJefe, location.pathname]);
+
+    React.useEffect(() => {
+        if (isJefe || geoSentRef.current || !deviceLocation) return;
+        geoSentRef.current = true;
+        void recordConnectionLocation(deviceLocation.latitude, deviceLocation.longitude).catch((error) => {
+            geoSentRef.current = false;
+            console.warn('No se pudo registrar la zona aproximada de conexion.', error);
+        });
+    }, [deviceLocation, isJefe]);
+
+    return null;
+};

--- a/frontend/src/components/ReviewCard.tsx
+++ b/frontend/src/components/ReviewCard.tsx
@@ -17,7 +17,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { db } from '../firebase';
 import { NonPonderableGauge } from './NonPonderableGauge';
-import { buildCriteriaStats } from '../utils/shareCriteria';
+import { buildShareCriteriaGroups } from '../utils/shareCriteria';
 import { buildPublicRouteUrl } from '../utils/publicUrl';
 import { CategoryService } from '../services/CategoryService';
 
@@ -519,21 +519,29 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ review, onDelete, onEdit
                 url={reviewShareUrl}
                 text={`¡Mira esta reseña de ${review.itemName} en ${review.placeName}!`}
                 review={review}
-                shareEntity={{
+                shareEntity={(() => {
+                    const shareCriteria = buildShareCriteriaGroups(review.scores, review.criteriaDefinition);
+                    return {
                     type: 'review',
                     id: review.id,
                     title: review.itemName || 'Reseña',
                     subtitle: review.placeName || 'Lugar',
+                    description: review.comment,
                     route: review.placeId && review.itemName ? reviewRoute : undefined,
                     url: reviewShareUrl,
                     imageUrl: review.photoUrl || review.placeMainImage,
+                    imageUrls: [...(review.photoUrls || []), review.photoUrl, review.placeMainImage]
+                        .filter((value): value is string => Boolean(value)),
                     badgeLabel: review.listName,
                     score: review.overallRating,
+                    authorId: review.userId || review.authorId,
                     authorName: review.authorName,
                     authorPhoto: review.authorPhoto,
-                    criteriaStats: buildCriteriaStats(review.scores, review.criteriaDefinition),
+                    criteriaStats: shareCriteria.ponderable,
+                    nonPonderableStats: shareCriteria.nonPonderable,
                     tags: review.userTags || review.tags,
-                }}
+                    };
+                })()}
             />
 
             <ReportModal

--- a/frontend/src/components/ReviewCardList.tsx
+++ b/frontend/src/components/ReviewCardList.tsx
@@ -17,7 +17,7 @@ import { ProgressiveImage } from './ProgressiveImage';
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { db } from '../firebase';
-import { buildCriteriaStats } from '../utils/shareCriteria';
+import { buildShareCriteriaGroups } from '../utils/shareCriteria';
 import { buildPublicRouteUrl } from '../utils/publicUrl';
 import { CategoryService } from '../services/CategoryService';
 
@@ -433,21 +433,29 @@ export const ReviewCardList: React.FC<ReviewCardListProps> = ({ review, onDelete
                 url={reviewShareUrl}
                 text={`¡Mira esta reseña de ${review.itemName} en ${review.placeName}!`}
                 review={review}
-                shareEntity={{
+                shareEntity={(() => {
+                    const shareCriteria = buildShareCriteriaGroups(review.scores, review.criteriaDefinition);
+                    return {
                     type: 'review',
                     id: review.id,
                     title: review.itemName || 'Reseña',
                     subtitle: review.placeName || 'Lugar',
+                    description: review.comment,
                     route: review.placeId && review.itemName ? reviewRoute : undefined,
                     url: reviewShareUrl,
                     imageUrl: review.photoUrl || review.placeMainImage,
+                    imageUrls: [...(review.photoUrls || []), review.photoUrl, review.placeMainImage]
+                        .filter((value): value is string => Boolean(value)),
                     badgeLabel: review.listName,
                     score: review.overallRating,
+                    authorId: review.userId || review.authorId,
                     authorName: review.authorName,
                     authorPhoto: review.authorPhoto,
-                    criteriaStats: buildCriteriaStats(review.scores, review.criteriaDefinition),
+                    criteriaStats: shareCriteria.ponderable,
+                    nonPonderableStats: shareCriteria.nonPonderable,
                     tags: review.userTags || review.tags,
-                }}
+                    };
+                })()}
             />
 
             <ReportModal

--- a/frontend/src/components/ShareCardModern.tsx
+++ b/frontend/src/components/ShareCardModern.tsx
@@ -3,17 +3,11 @@ import { Capacitor } from '@capacitor/core';
 import { Share } from '@capacitor/share';
 import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Check, Download, Share2, X } from 'lucide-react';
-import { getShareEntityLabel, type ShareEntityPayload } from '../types/share';
+import { getShareEntityLabel, type ShareCriteriaStat, type ShareEntityPayload, type ShareProfileStat } from '../types/share';
 import { buildShareText } from '../utils/shareTexts';
 import { buildShareRouteUrl } from '../utils/publicUrl';
 
-export type ModernCardVariant = 'story' | 'square';
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Tarjetas de compartir v2: dibujadas directamente en <canvas> con layout
-// determinista — nada de html2canvas ni datos desencuadrados. Dos variantes
-// cuidadas: Story (9:16) y Post cuadrado (1:1).
-// ─────────────────────────────────────────────────────────────────────────────
+export type ModernCardVariant = 'story' | 'portrait' | 'square' | 'landscape';
 
 interface ShareCardModernProps {
     entity: ShareEntityPayload;
@@ -24,17 +18,20 @@ interface ShareCardModernProps {
 
 const DIMENSIONS: Record<ModernCardVariant, { width: number; height: number }> = {
     story: { width: 1080, height: 1920 },
+    portrait: { width: 1080, height: 1350 },
     square: { width: 1080, height: 1080 },
+    landscape: { width: 1200, height: 630 },
 };
 
 const FONT = "'Manrope', 'Poppins', system-ui, -apple-system, sans-serif";
+const BRAND_LOGO_URL = '/images/listopic-app-icon.png';
 
 const scoreColor = (score?: number): string => {
     if (!Number.isFinite(score as number)) return '#94a3b8';
     if ((score as number) >= 9) return '#34d399';
     if ((score as number) >= 7) return '#84cc16';
     if ((score as number) >= 5) return '#facc15';
-    return '#f87171';
+    return '#fb7185';
 };
 
 const loadImage = async (url?: string): Promise<HTMLImageElement | null> => {
@@ -42,11 +39,13 @@ const loadImage = async (url?: string): Promise<HTMLImageElement | null> => {
     try {
         const response = await fetch(url);
         if (!response.ok) return null;
-        const blob = await response.blob();
-        const objectUrl = URL.createObjectURL(blob);
+        const objectUrl = URL.createObjectURL(await response.blob());
         return await new Promise((resolve) => {
             const image = new Image();
-            image.onload = () => resolve(image);
+            image.onload = () => {
+                URL.revokeObjectURL(objectUrl);
+                resolve(image);
+            };
             image.onerror = () => {
                 URL.revokeObjectURL(objectUrl);
                 resolve(null);
@@ -76,7 +75,99 @@ const drawCover = (ctx: CanvasRenderingContext2D, image: HTMLImageElement, x: nu
     ctx.drawImage(image, x + (w - drawW) / 2, y + (h - drawH) / 2, drawW, drawH);
 };
 
-// Ajusta el tamaño de fuente hasta que el texto quepa en `maxLines` líneas.
+const drawContain = (ctx: CanvasRenderingContext2D, image: HTMLImageElement, x: number, y: number, w: number, h: number) => {
+    const scale = Math.min(w / image.width, h / image.height);
+    const drawW = image.width * scale;
+    const drawH = image.height * scale;
+    ctx.drawImage(image, x + (w - drawW) / 2, y + (h - drawH) / 2, drawW, drawH);
+};
+
+const drawCircularImage = (
+    ctx: CanvasRenderingContext2D,
+    image: HTMLImageElement | null,
+    centerX: number,
+    centerY: number,
+    radius: number,
+    fallbackText: string,
+) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.clip();
+    if (image) {
+        drawCover(ctx, image, centerX - radius, centerY - radius, radius * 2, radius * 2);
+    } else {
+        const gradient = ctx.createLinearGradient(centerX - radius, centerY - radius, centerX + radius, centerY + radius);
+        gradient.addColorStop(0, '#2563eb');
+        gradient.addColorStop(1, '#9333ea');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `900 ${Math.round(radius * 0.9)}px ${FONT}`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText((fallbackText || 'L').slice(0, 1).toUpperCase(), centerX, centerY + radius * 0.04);
+    }
+    ctx.restore();
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.strokeStyle = 'rgba(255,255,255,0.76)';
+    ctx.lineWidth = Math.max(3, radius * 0.035);
+    ctx.stroke();
+};
+
+const drawFallbackBackground = (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+    const gradient = ctx.createLinearGradient(0, 0, w, h);
+    gradient.addColorStop(0, '#0f766e');
+    gradient.addColorStop(0.46, '#312e81');
+    gradient.addColorStop(1, '#7e22ce');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, w, h);
+    [
+        [0.12, 0.18, 250, 'rgba(103,232,249,0.12)'],
+        [0.88, 0.14, 220, 'rgba(255,255,255,0.08)'],
+        [0.72, 0.88, 340, 'rgba(240,171,252,0.11)'],
+    ].forEach(([fx, fy, r, color]) => {
+        ctx.beginPath();
+        ctx.arc(w * (fx as number), h * (fy as number), r as number, 0, Math.PI * 2);
+        ctx.fillStyle = color as string;
+        ctx.fill();
+    });
+};
+
+const fitText = (ctx: CanvasRenderingContext2D, text: string, maxWidth: number) => {
+    if (ctx.measureText(text).width <= maxWidth) return text;
+    let clipped = text;
+    while (clipped.length > 2 && ctx.measureText(`${clipped}…`).width > maxWidth) clipped = clipped.slice(0, -1);
+    return `${clipped}…`;
+};
+
+const wrapText = (
+    ctx: CanvasRenderingContext2D,
+    text: string,
+    maxWidth: number,
+    maxLines: number,
+): string[] => {
+    const words = text.trim().split(/\s+/).filter(Boolean);
+    const lines: string[] = [];
+    let current = '';
+    for (const word of words) {
+        const candidate = current ? `${current} ${word}` : word;
+        if (ctx.measureText(candidate).width <= maxWidth) {
+            current = candidate;
+            continue;
+        }
+        if (current) lines.push(current);
+        current = word;
+        if (lines.length >= maxLines) break;
+    }
+    if (current && lines.length < maxLines) lines.push(current);
+    if (words.length && lines.length === maxLines) {
+        lines[maxLines - 1] = fitText(ctx, lines[maxLines - 1], maxWidth);
+    }
+    return lines;
+};
+
 const layoutTitle = (
     ctx: CanvasRenderingContext2D,
     text: string,
@@ -85,252 +176,489 @@ const layoutTitle = (
     minSize: number,
     maxLines: number,
 ): { lines: string[]; fontSize: number } => {
-    for (let size = startSize; size >= minSize; size -= 6) {
+    for (let size = startSize; size >= minSize; size -= 5) {
         ctx.font = `900 ${size}px ${FONT}`;
-        const words = text.split(/\s+/).filter(Boolean);
-        const lines: string[] = [];
-        let current = '';
-        let overflow = false;
-        for (const word of words) {
-            const candidate = current ? `${current} ${word}` : word;
-            if (ctx.measureText(candidate).width <= maxWidth) {
-                current = candidate;
-            } else if (current) {
-                lines.push(current);
-                current = word;
-                if (lines.length === maxLines) { overflow = true; break; }
-            } else {
-                current = word;
-            }
-        }
-        if (!overflow && current && lines.length < maxLines) lines.push(current);
-        if (!overflow && lines.length <= maxLines && lines.every((line) => ctx.measureText(line).width <= maxWidth)) {
+        const lines = wrapText(ctx, text, maxWidth, maxLines);
+        if (lines.length <= maxLines && lines.every((line) => ctx.measureText(line).width <= maxWidth)) {
             return { lines, fontSize: size };
         }
     }
-    // Última opción: recorta con elipsis.
     ctx.font = `900 ${minSize}px ${FONT}`;
-    let clipped = text;
-    while (clipped.length > 4 && ctx.measureText(`${clipped}…`).width > maxWidth) clipped = clipped.slice(0, -1);
-    return { lines: [`${clipped}…`], fontSize: minSize };
+    return { lines: wrapText(ctx, text, maxWidth, maxLines), fontSize: minSize };
 };
 
-const drawFallbackBackground = (ctx: CanvasRenderingContext2D, w: number, h: number) => {
-    const gradient = ctx.createLinearGradient(0, 0, w, h);
-    gradient.addColorStop(0, '#312e81');
-    gradient.addColorStop(0.5, '#6d28d9');
-    gradient.addColorStop(1, '#0e7490');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, w, h);
-    // Burbujas suaves de decoración.
-    [[0.15, 0.2, 260, 'rgba(255,255,255,0.08)'], [0.85, 0.15, 200, 'rgba(103,232,249,0.12)'], [0.75, 0.85, 320, 'rgba(240,171,252,0.10)']]
-        .forEach(([fx, fy, r, color]) => {
-            ctx.beginPath();
-            ctx.arc(w * (fx as number), h * (fy as number), r as number, 0, Math.PI * 2);
-            ctx.fillStyle = color as string;
-            ctx.fill();
-        });
+const drawGlassPanel = (ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, radius = 28) => {
+    roundRect(ctx, x, y, w, h, radius);
+    ctx.fillStyle = 'rgba(5,8,20,0.68)';
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.16)';
+    ctx.lineWidth = 2;
+    ctx.stroke();
 };
 
-async function renderCard(entity: ShareEntityPayload, variant: ModernCardVariant): Promise<string> {
-    const { width: W, height: H } = DIMENSIONS[variant];
-    const canvas = document.createElement('canvas');
-    canvas.width = W;
-    canvas.height = H;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('Canvas no disponible');
-
-    if (document.fonts?.ready) {
-        try { await document.fonts.ready; } catch { /* seguimos con la fuente del sistema */ }
-    }
-
-    const [hero, avatar] = await Promise.all([
-        loadImage(entity.imageUrl),
-        loadImage(entity.authorPhoto),
-    ]);
-
-    const M = 72; // margen general
-    const contentW = W - M * 2;
-    const isStory = variant === 'story';
-
-    // ── Fondo ──
-    if (hero) {
-        drawCover(ctx, hero, 0, 0, W, H);
-        const top = ctx.createLinearGradient(0, 0, 0, H * 0.35);
-        top.addColorStop(0, 'rgba(0,0,0,0.62)');
-        top.addColorStop(1, 'rgba(0,0,0,0)');
-        ctx.fillStyle = top;
-        ctx.fillRect(0, 0, W, H * 0.35);
-        const bottom = ctx.createLinearGradient(0, H * (isStory ? 0.42 : 0.30), 0, H);
-        bottom.addColorStop(0, 'rgba(4,6,16,0)');
-        bottom.addColorStop(isStory ? 0.45 : 0.5, 'rgba(4,6,16,0.72)');
-        bottom.addColorStop(1, 'rgba(4,6,16,0.96)');
-        ctx.fillStyle = bottom;
-        ctx.fillRect(0, 0, W, H);
+const drawBrand = (
+    ctx: CanvasRenderingContext2D,
+    logo: HTMLImageElement | null,
+    right: number,
+    top: number,
+    compact = false,
+) => {
+    const logoSize = compact ? 48 : 58;
+    const fontSize = compact ? 27 : 32;
+    ctx.font = `900 ${fontSize}px ${FONT}`;
+    const brandWidth = ctx.measureText('Listopic').width;
+    const x = right - logoSize - 14 - brandWidth;
+    if (logo) {
+        drawContain(ctx, logo, x, top, logoSize, logoSize);
     } else {
-        drawFallbackBackground(ctx, W, H);
-        ctx.fillStyle = 'rgba(0,0,0,0.35)';
-        ctx.fillRect(0, 0, W, H);
+        roundRect(ctx, x, top, logoSize, logoSize, 14);
+        const fallback = ctx.createLinearGradient(x, top, x + logoSize, top + logoSize);
+        fallback.addColorStop(0, '#14b8a6');
+        fallback.addColorStop(1, '#7e22ce');
+        ctx.fillStyle = fallback;
+        ctx.fill();
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `900 ${fontSize}px ${FONT}`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('L', x + logoSize / 2, top + logoSize / 2 + 1);
     }
+    ctx.font = `900 ${fontSize}px ${FONT}`;
+    ctx.fillStyle = '#ffffff';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('Listopic', x + logoSize + 14, top + logoSize / 2 + 1);
+};
 
-    // ── Chip superior: tipo de entidad ──
+const drawTypeChip = (ctx: CanvasRenderingContext2D, entity: ShareEntityPayload, x: number, y: number, compact = false) => {
     const label = getShareEntityLabel(entity.type).toUpperCase();
-    ctx.font = `800 30px ${FONT}`;
-    const labelW = ctx.measureText(label).width;
-    roundRect(ctx, M, M, labelW + 56, 64, 32);
-    ctx.fillStyle = 'rgba(0,0,0,0.55)';
+    const fontSize = compact ? 24 : 28;
+    const height = compact ? 50 : 58;
+    ctx.font = `900 ${fontSize}px ${FONT}`;
+    const width = ctx.measureText(label).width + 44;
+    roundRect(ctx, x, y, width, height, height / 2);
+    ctx.fillStyle = 'rgba(3,6,18,0.64)';
     ctx.fill();
     ctx.strokeStyle = 'rgba(255,255,255,0.28)';
     ctx.lineWidth = 2;
     ctx.stroke();
     ctx.fillStyle = '#ffffff';
-    ctx.textBaseline = 'middle';
     ctx.textAlign = 'left';
-    ctx.fillText(label, M + 28, M + 34);
+    ctx.textBaseline = 'middle';
+    ctx.fillText(label, x + 22, y + height / 2 + 1);
+};
 
-    // ── Bloque inferior (se apila de abajo hacia arriba) ──
-    let cursorY = H - M;
+const drawAuthor = (
+    ctx: CanvasRenderingContext2D,
+    entity: ShareEntityPayload,
+    avatar: HTMLImageElement | null,
+    x: number,
+    centerY: number,
+    maxWidth: number,
+    compact = false,
+) => {
+    if (!entity.authorName) return;
+    const radius = compact ? 26 : 32;
+    drawCircularImage(ctx, avatar, x + radius, centerY, radius, entity.authorName);
+    ctx.font = `800 ${compact ? 25 : 29}px ${FONT}`;
+    ctx.fillStyle = 'rgba(255,255,255,0.95)';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(fitText(ctx, entity.authorName, maxWidth - radius * 2 - 18), x + radius * 2 + 18, centerY);
+};
 
-    // Marca
-    ctx.font = `900 34px ${FONT}`;
-    const brand = 'Listopic';
-    const brandW = ctx.measureText(brand).width;
-    const dotR = 13;
-    const brandBlockW = dotR * 2 + 16 + brandW;
-    const brandX = W - M - brandBlockW;
-    ctx.beginPath();
-    ctx.arc(brandX + dotR, cursorY - 22, dotR, 0, Math.PI * 2);
-    const brandGrad = ctx.createLinearGradient(brandX, cursorY - 44, brandX + 26, cursorY);
-    brandGrad.addColorStop(0, '#06b6d4');
-    brandGrad.addColorStop(1, '#6366f1');
-    ctx.fillStyle = brandGrad;
+const drawScorePill = (ctx: CanvasRenderingContext2D, score: number, x: number, y: number, compact = false) => {
+    const height = compact ? 82 : 112;
+    const width = compact ? 195 : 250;
+    const valueSize = compact ? 56 : 78;
+    const color = scoreColor(score);
+    roundRect(ctx, x, y, width, height, compact ? 25 : 32);
+    ctx.fillStyle = 'rgba(3,6,18,0.7)';
     ctx.fill();
-    ctx.fillStyle = 'rgba(255,255,255,0.92)';
-    ctx.fillText(brand, brandX + dotR * 2 + 16, cursorY - 20);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = compact ? 3 : 4;
+    ctx.stroke();
+    ctx.font = `900 ${valueSize}px ${FONT}`;
+    ctx.fillStyle = color;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(score.toFixed(1), x + (compact ? 24 : 30), y + height / 2);
+    ctx.font = `800 ${compact ? 25 : 31}px ${FONT}`;
+    ctx.fillStyle = 'rgba(255,255,255,0.62)';
+    ctx.fillText('/10', x + (compact ? 126 : 164), y + height / 2 + (compact ? 8 : 11));
+};
 
-    // Autor (a la izquierda de la marca)
-    if (entity.authorName) {
-        const avatarR = 34;
-        const authorX = M;
-        const authorCenterY = cursorY - 22;
-        ctx.save();
-        ctx.beginPath();
-        ctx.arc(authorX + avatarR, authorCenterY, avatarR, 0, Math.PI * 2);
-        ctx.closePath();
-        ctx.clip();
-        if (avatar) {
-            drawCover(ctx, avatar, authorX, authorCenterY - avatarR, avatarR * 2, avatarR * 2);
-        } else {
-            ctx.fillStyle = '#4f46e5';
-            ctx.fillRect(authorX, authorCenterY - avatarR, avatarR * 2, avatarR * 2);
-            ctx.fillStyle = '#ffffff';
-            ctx.font = `900 34px ${FONT}`;
-            ctx.textAlign = 'center';
-            ctx.fillText((entity.authorName || 'L').slice(0, 1).toUpperCase(), authorX + avatarR, authorCenterY + 2);
-            ctx.textAlign = 'left';
-        }
-        ctx.restore();
-        ctx.strokeStyle = 'rgba(255,255,255,0.5)';
-        ctx.lineWidth = 3;
-        ctx.beginPath();
-        ctx.arc(authorX + avatarR, authorCenterY, avatarR, 0, Math.PI * 2);
-        ctx.stroke();
-        ctx.font = `800 32px ${FONT}`;
-        ctx.fillStyle = 'rgba(255,255,255,0.92)';
-        ctx.fillText(entity.authorName, authorX + avatarR * 2 + 20, authorCenterY);
-    }
-    cursorY -= 108;
-
-    // Criterios (hasta 4 barras)
-    const criteria = (entity.criteriaStats || []).filter((stat) => Number.isFinite(stat.score)).slice(0, 4);
-    if (criteria.length > 0) {
-        const rowH = 64;
-        const panelH = criteria.length * rowH + 40;
-        roundRect(ctx, M, cursorY - panelH, contentW, panelH, 28);
-        ctx.fillStyle = 'rgba(0,0,0,0.45)';
+const drawCriteriaBars = (
+    ctx: CanvasRenderingContext2D,
+    criteria: ShareCriteriaStat[],
+    x: number,
+    y: number,
+    width: number,
+    rowHeight: number,
+) => {
+    const panelHeight = criteria.length * rowHeight + 34;
+    drawGlassPanel(ctx, x, y, width, panelHeight, 25);
+    criteria.forEach((stat, index) => {
+        const rowY = y + 30 + index * rowHeight;
+        const labelWidth = width * 0.38;
+        ctx.font = `700 ${rowHeight >= 64 ? 27 : 23}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.84)';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(fitText(ctx, stat.label || stat.key, labelWidth), x + 24, rowY);
+        const barX = x + width * 0.43;
+        const barW = width * 0.39;
+        roundRect(ctx, barX, rowY - 8, barW, 16, 8);
+        ctx.fillStyle = 'rgba(255,255,255,0.16)';
         ctx.fill();
-        ctx.strokeStyle = 'rgba(255,255,255,0.12)';
+        const ratio = Math.max(0.025, Math.min(1, stat.score / 10));
+        roundRect(ctx, barX, rowY - 8, barW * ratio, 16, 8);
+        ctx.fillStyle = scoreColor(stat.score);
+        ctx.fill();
+        ctx.font = `900 ${rowHeight >= 64 ? 27 : 23}px ${FONT}`;
+        ctx.fillStyle = '#ffffff';
+        ctx.textAlign = 'right';
+        ctx.fillText(stat.score.toFixed(1), x + width - 24, rowY);
+    });
+    return panelHeight;
+};
+
+const drawNonPonderable = (
+    ctx: CanvasRenderingContext2D,
+    criteria: ShareCriteriaStat[],
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+) => {
+    drawGlassPanel(ctx, x, y, width, height, 25);
+    const cellWidth = width / criteria.length;
+    const radius = Math.min(43, height * 0.28, cellWidth * 0.24);
+    criteria.forEach((stat, index) => {
+        const centerX = x + cellWidth * index + cellWidth / 2;
+        const centerY = y + radius + 20;
+        const color = scoreColor(stat.score);
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(255,255,255,0.14)';
+        ctx.lineWidth = 8;
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, radius, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * Math.max(0, Math.min(1, stat.score / 10)));
+        ctx.strokeStyle = color;
+        ctx.lineCap = 'round';
+        ctx.stroke();
+        ctx.lineCap = 'butt';
+        ctx.font = `900 ${Math.round(radius * 0.72)}px ${FONT}`;
+        ctx.fillStyle = color;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(stat.score.toFixed(stat.score % 1 === 0 ? 0 : 1), centerX, centerY + 1);
+        ctx.font = `700 ${Math.min(21, Math.max(16, cellWidth * 0.08))}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.82)';
+        ctx.textBaseline = 'top';
+        const label = fitText(ctx, stat.label || stat.key, Math.max(70, cellWidth - 18));
+        ctx.fillText(label, centerX, centerY + radius + 13);
+    });
+};
+
+const formatMetricValue = (value: string | number) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return String(value);
+    return new Intl.NumberFormat('es', { notation: value >= 1000 ? 'compact' : 'standard', maximumFractionDigits: 1 }).format(value);
+};
+
+const drawProfileStats = (
+    ctx: CanvasRenderingContext2D,
+    stats: ShareProfileStat[],
+    x: number,
+    y: number,
+    width: number,
+    cellHeight: number,
+    columns = 3,
+) => {
+    const rows = Math.ceil(stats.length / columns);
+    const gap = 14;
+    const cellWidth = (width - gap * (columns - 1)) / columns;
+    stats.forEach((stat, index) => {
+        const column = index % columns;
+        const row = Math.floor(index / columns);
+        const cellX = x + column * (cellWidth + gap);
+        const cellY = y + row * (cellHeight + gap);
+        roundRect(ctx, cellX, cellY, cellWidth, cellHeight, 24);
+        ctx.fillStyle = stat.key === 'level' ? 'rgba(245,158,11,0.24)' : 'rgba(4,8,22,0.62)';
+        ctx.fill();
+        ctx.strokeStyle = stat.key === 'level' ? 'rgba(251,191,36,0.62)' : 'rgba(255,255,255,0.14)';
         ctx.lineWidth = 2;
         ctx.stroke();
+        ctx.font = `900 ${Math.round(cellHeight * 0.38)}px ${FONT}`;
+        ctx.fillStyle = stat.key === 'level' ? '#fbbf24' : '#ffffff';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(formatMetricValue(stat.value), cellX + cellWidth / 2, cellY + cellHeight * 0.4);
+        ctx.font = `800 ${Math.round(cellHeight * 0.16)}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.68)';
+        ctx.fillText(fitText(ctx, stat.label, cellWidth - 18), cellX + cellWidth / 2, cellY + cellHeight * 0.76);
+    });
+    return rows * cellHeight + Math.max(0, rows - 1) * gap;
+};
 
-        criteria.forEach((stat, index) => {
-            const rowY = cursorY - panelH + 44 + index * rowH;
-            const labelText = (stat.label || stat.key).slice(0, 20);
-            ctx.font = `700 28px ${FONT}`;
-            ctx.fillStyle = 'rgba(255,255,255,0.82)';
-            ctx.textAlign = 'left';
-            ctx.fillText(labelText, M + 32, rowY);
-
-            const barX = M + contentW * 0.42;
-            const barW = contentW * 0.42;
-            roundRect(ctx, barX, rowY - 10, barW, 20, 10);
-            ctx.fillStyle = 'rgba(255,255,255,0.16)';
-            ctx.fill();
-            const ratio = Math.max(0.04, Math.min(1, stat.score / 10));
-            roundRect(ctx, barX, rowY - 10, barW * ratio, 20, 10);
-            ctx.fillStyle = scoreColor(stat.score);
-            ctx.fill();
-
-            ctx.font = `900 30px ${FONT}`;
-            ctx.fillStyle = '#ffffff';
-            ctx.textAlign = 'right';
-            ctx.fillText(stat.score.toFixed(1), M + contentW - 32, rowY);
-            ctx.textAlign = 'left';
-        });
-        cursorY -= panelH + 36;
+const paintBackground = (
+    ctx: CanvasRenderingContext2D,
+    hero: HTMLImageElement | null,
+    entity: ShareEntityPayload,
+    width: number,
+    height: number,
+) => {
+    if (hero && entity.type !== 'profile') {
+        drawCover(ctx, hero, 0, 0, width, height);
+    } else {
+        drawFallbackBackground(ctx, width, height);
     }
+    const top = ctx.createLinearGradient(0, 0, 0, height * 0.36);
+    top.addColorStop(0, 'rgba(3,6,18,0.72)');
+    top.addColorStop(1, 'rgba(3,6,18,0)');
+    ctx.fillStyle = top;
+    ctx.fillRect(0, 0, width, height * 0.42);
+    const bottom = ctx.createLinearGradient(0, height * 0.24, 0, height);
+    bottom.addColorStop(0, 'rgba(3,6,18,0)');
+    bottom.addColorStop(0.52, 'rgba(3,6,18,0.64)');
+    bottom.addColorStop(1, 'rgba(3,6,18,0.97)');
+    ctx.fillStyle = bottom;
+    ctx.fillRect(0, 0, width, height);
+};
 
-    // Subtítulo
-    if (entity.subtitle) {
-        ctx.font = `600 ${isStory ? 40 : 34}px ${FONT}`;
-        ctx.fillStyle = 'rgba(255,255,255,0.78)';
-        let subtitle = entity.subtitle;
-        while (subtitle.length > 4 && ctx.measureText(subtitle).width > contentW) subtitle = `${subtitle.slice(0, -2)}…`;
-        ctx.fillText(subtitle, M, cursorY - 16);
-        cursorY -= isStory ? 72 : 62;
-    }
+const drawVerticalProfile = (
+    ctx: CanvasRenderingContext2D,
+    entity: ShareEntityPayload,
+    portrait: HTMLImageElement | null,
+    variant: Exclude<ModernCardVariant, 'landscape'>,
+    width: number,
+) => {
+    const margin = 64;
+    const isStory = variant === 'story';
+    const radius = isStory ? 205 : variant === 'portrait' ? 158 : 132;
+    const centerY = isStory ? 420 : variant === 'portrait' ? 300 : 255;
+    ctx.beginPath();
+    ctx.arc(width / 2, centerY, radius + 28, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.11)';
+    ctx.fill();
+    drawCircularImage(ctx, portrait, width / 2, centerY, radius, entity.title);
 
-    // Título (auto-ajustado, hasta 2-3 líneas)
-    const title = entity.title || 'Listopic';
-    const { lines, fontSize } = layoutTitle(ctx, title, contentW, isStory ? 108 : 84, 52, isStory ? 3 : 2);
+    const titleTop = centerY + radius + (isStory ? 58 : 38);
+    const { lines, fontSize } = layoutTitle(ctx, entity.title, width - margin * 2, isStory ? 88 : 70, 48, 2);
     ctx.font = `900 ${fontSize}px ${FONT}`;
     ctx.fillStyle = '#ffffff';
-    ctx.shadowColor = 'rgba(0,0,0,0.45)';
-    ctx.shadowBlur = 24;
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-        ctx.fillText(lines[i], M, cursorY - 20 - (lines.length - 1 - i) * (fontSize * 1.08));
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    lines.forEach((line, index) => ctx.fillText(line, width / 2, titleTop + index * fontSize * 1.08));
+    let cursorY = titleTop + lines.length * fontSize * 1.08 + 16;
+    if (entity.subtitle) {
+        ctx.font = `700 ${isStory ? 36 : 29}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.68)';
+        ctx.fillText(fitText(ctx, entity.subtitle, width - margin * 2), width / 2, cursorY);
+        cursorY += isStory ? 78 : 58;
+    } else {
+        cursorY += isStory ? 38 : 24;
     }
+
+    const stats = (entity.profileStats || []).slice(0, 6);
+    if (stats.length) {
+        drawProfileStats(ctx, stats, margin, cursorY, width - margin * 2, isStory ? 132 : 104);
+    }
+};
+
+const drawVerticalContent = (
+    ctx: CanvasRenderingContext2D,
+    entity: ShareEntityPayload,
+    avatar: HTMLImageElement | null,
+    variant: Exclude<ModernCardVariant, 'landscape'>,
+    width: number,
+    height: number,
+) => {
+    const margin = 64;
+    const contentWidth = width - margin * 2;
+    const isStory = variant === 'story';
+    const isSquare = variant === 'square';
+    let cursorY = height - margin;
+
+    if (entity.authorName) {
+        drawAuthor(ctx, entity, avatar, margin, cursorY - 32, contentWidth * 0.68, false);
+        cursorY -= 96;
+    }
+
+    const extras = (entity.nonPonderableStats || []).filter((item) => Number.isFinite(item.score))
+        .slice(0, isSquare ? 3 : 4);
+    if (extras.length) {
+        const panelHeight = isStory ? 162 : 140;
+        cursorY -= panelHeight;
+        drawNonPonderable(ctx, extras, margin, cursorY, contentWidth, panelHeight);
+        cursorY -= 22;
+    }
+
+    const criteria = (entity.criteriaStats || []).filter((item) => Number.isFinite(item.score))
+        .slice(0, isStory ? 4 : isSquare ? 2 : 3);
+    if (criteria.length) {
+        const rowHeight = isStory ? 64 : 55;
+        const panelHeight = criteria.length * rowHeight + 34;
+        cursorY -= panelHeight;
+        drawCriteriaBars(ctx, criteria, margin, cursorY, contentWidth, rowHeight);
+        cursorY -= 22;
+    }
+
+    if (entity.description && !isSquare) {
+        const panelHeight = isStory ? 124 : 100;
+        cursorY -= panelHeight;
+        drawGlassPanel(ctx, margin, cursorY, contentWidth, panelHeight, 24);
+        const fontSize = isStory ? 28 : 23;
+        ctx.font = `600 italic ${fontSize}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.78)';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        const lines = wrapText(ctx, `“${entity.description}”`, contentWidth - 48, 2);
+        lines.forEach((line, index) => ctx.fillText(line, margin + 24, cursorY + 22 + index * fontSize * 1.35));
+        cursorY -= 22;
+    }
+
+    const metaParts = [
+        entity.reviewCount ? `${entity.reviewCount} reseña${entity.reviewCount === 1 ? '' : 's'}` : '',
+        entity.city || '',
+    ].filter(Boolean);
+    if (metaParts.length) {
+        ctx.font = `800 ${isStory ? 28 : 23}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.68)';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'bottom';
+        ctx.fillText(fitText(ctx, metaParts.join('  •  '), contentWidth), margin, cursorY);
+        cursorY -= isStory ? 52 : 42;
+    }
+
+    if (entity.subtitle) {
+        ctx.font = `700 ${isStory ? 38 : 31}px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.76)';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'bottom';
+        ctx.fillText(fitText(ctx, entity.subtitle, contentWidth), margin, cursorY);
+        cursorY -= isStory ? 61 : 50;
+    }
+
+    const { lines, fontSize } = layoutTitle(ctx, entity.title || 'Listopic', contentWidth, isStory ? 94 : 76, 48, isStory ? 3 : 2);
+    const titleHeight = lines.length * fontSize * 1.06;
+    cursorY -= titleHeight;
+    ctx.font = `900 ${fontSize}px ${FONT}`;
+    ctx.fillStyle = '#ffffff';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.shadowColor = 'rgba(0,0,0,0.48)';
+    ctx.shadowBlur = 22;
+    lines.forEach((line, index) => ctx.fillText(line, margin, cursorY + index * fontSize * 1.06));
     ctx.shadowBlur = 0;
-    cursorY -= lines.length * fontSize * 1.08 + 44;
+    cursorY -= isStory ? 34 : 24;
 
-    // Nota gigante en burbuja
     if (Number.isFinite(entity.score as number)) {
-        const score = entity.score as number;
-        const color = scoreColor(score);
-        const bubbleH = isStory ? 176 : 150;
-        const scoreText = score.toFixed(1);
-        ctx.font = `900 ${isStory ? 118 : 100}px ${FONT}`;
-        const scoreW = ctx.measureText(scoreText).width;
-        ctx.font = `800 ${isStory ? 44 : 38}px ${FONT}`;
-        const outOfW = ctx.measureText('/10').width;
-        const bubbleW = scoreW + outOfW + 96;
+        const compact = !isStory;
+        const scoreHeight = compact ? 82 : 112;
+        cursorY -= scoreHeight;
+        drawScorePill(ctx, entity.score as number, margin, cursorY, compact);
+    }
+};
 
-        roundRect(ctx, M, cursorY - bubbleH, bubbleW, bubbleH, 40);
-        ctx.fillStyle = 'rgba(0,0,0,0.5)';
-        ctx.fill();
-        ctx.strokeStyle = color;
-        ctx.lineWidth = 5;
-        ctx.shadowColor = color;
-        ctx.shadowBlur = 34;
-        ctx.stroke();
-        ctx.shadowBlur = 0;
+const drawLandscape = (
+    ctx: CanvasRenderingContext2D,
+    entity: ShareEntityPayload,
+    hero: HTMLImageElement | null,
+    avatar: HTMLImageElement | null,
+    logo: HTMLImageElement | null,
+    width: number,
+    height: number,
+) => {
+    const margin = 48;
+    drawTypeChip(ctx, entity, margin, margin, true);
+    drawBrand(ctx, logo, width - margin, margin, true);
 
-        ctx.font = `900 ${isStory ? 118 : 100}px ${FONT}`;
-        ctx.fillStyle = color;
-        ctx.fillText(scoreText, M + 44, cursorY - bubbleH / 2 + 6);
-        ctx.font = `800 ${isStory ? 44 : 38}px ${FONT}`;
-        ctx.fillStyle = 'rgba(255,255,255,0.62)';
-        ctx.fillText('/10', M + 44 + scoreW + 12, cursorY - bubbleH / 2 + (isStory ? 30 : 26));
+    if (entity.type === 'profile') {
+        drawCircularImage(ctx, hero, 174, 302, 112, entity.title);
+        const titleLayout = layoutTitle(ctx, entity.title, 785, 68, 48, 2);
+        ctx.font = `900 ${titleLayout.fontSize}px ${FONT}`;
+        ctx.fillStyle = '#ffffff';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        titleLayout.lines.forEach((line, index) => ctx.fillText(line, 330, 157 + index * titleLayout.fontSize * 1.05));
+        const titleBottom = 157 + titleLayout.lines.length * titleLayout.fontSize * 1.05;
+        if (entity.subtitle) {
+            ctx.font = `700 28px ${FONT}`;
+            ctx.fillStyle = 'rgba(255,255,255,0.68)';
+            ctx.fillText(fitText(ctx, entity.subtitle, 785), 330, titleBottom + 8);
+        }
+        const stats = (entity.profileStats || []).slice(0, 6);
+        if (stats.length) drawProfileStats(ctx, stats, 330, Math.max(320, titleBottom + 58), 820, 92, 3);
+        return;
+    }
+
+    const leftX = margin;
+    const leftWidth = 670;
+    const titleLayout = layoutTitle(ctx, entity.title, leftWidth, 66, 46, 2);
+    ctx.font = `900 ${titleLayout.fontSize}px ${FONT}`;
+    ctx.fillStyle = '#ffffff';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    titleLayout.lines.forEach((line, index) => ctx.fillText(line, leftX, 150 + index * titleLayout.fontSize * 1.04));
+    let cursorY = 150 + titleLayout.lines.length * titleLayout.fontSize * 1.04 + 10;
+    if (entity.subtitle) {
+        ctx.font = `700 28px ${FONT}`;
+        ctx.fillStyle = 'rgba(255,255,255,0.74)';
+        ctx.fillText(fitText(ctx, entity.subtitle, leftWidth), leftX, cursorY);
+        cursorY += 47;
+    }
+    if (Number.isFinite(entity.score as number)) {
+        drawScorePill(ctx, entity.score as number, leftX, cursorY, true);
+    }
+    if (entity.authorName) drawAuthor(ctx, entity, avatar, leftX, height - 54, 500, true);
+
+    const panelX = 780;
+    const panelWidth = width - margin - panelX;
+    const criteria = (entity.criteriaStats || []).filter((item) => Number.isFinite(item.score)).slice(0, 4);
+    const extras = (entity.nonPonderableStats || []).filter((item) => Number.isFinite(item.score)).slice(0, 3);
+    let panelY = 143;
+    if (criteria.length) {
+        const panelHeight = drawCriteriaBars(ctx, criteria, panelX, panelY, panelWidth, 52);
+        panelY += panelHeight + 16;
+    }
+    if (extras.length && panelY + 126 < height - 18) {
+        drawNonPonderable(ctx, extras, panelX, panelY, panelWidth, 126);
+    }
+};
+
+async function renderCard(entity: ShareEntityPayload, variant: ModernCardVariant): Promise<string> {
+    const { width, height } = DIMENSIONS[variant];
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas no disponible');
+
+    if (document.fonts?.ready) {
+        try { await document.fonts.ready; } catch { /* La fuente del sistema mantiene el layout. */ }
+    }
+
+    const [hero, avatar, logo] = await Promise.all([
+        loadImage(entity.imageUrl),
+        loadImage(entity.authorPhoto),
+        loadImage(BRAND_LOGO_URL),
+    ]);
+
+    paintBackground(ctx, hero, entity, width, height);
+
+    if (variant === 'landscape') {
+        drawLandscape(ctx, entity, hero, avatar, logo, width, height);
+    } else {
+        const margin = 64;
+        drawTypeChip(ctx, entity, margin, margin);
+        drawBrand(ctx, logo, width - margin, margin);
+        if (entity.type === 'profile') {
+            drawVerticalProfile(ctx, entity, hero, variant, width);
+        } else {
+            drawVerticalContent(ctx, entity, avatar, variant, width, height);
+        }
     }
 
     return canvas.toDataURL('image/png', 1.0);
@@ -396,7 +724,7 @@ export const ShareCardModern: React.FC<ShareCardModernProps> = ({ entity, varian
                 return;
             }
             if (navigator.clipboard?.writeText) {
-                await navigator.clipboard.writeText(`${text}`);
+                await navigator.clipboard.writeText(text);
                 setFeedback('Tu dispositivo no comparte imágenes: copiamos el texto con el enlace.');
                 return;
             }
@@ -427,10 +755,7 @@ export const ShareCardModern: React.FC<ShareCardModernProps> = ({ entity, varian
 
     return (
         <div className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm" onClick={close}>
-            <div
-                className="flex max-h-full w-full max-w-sm flex-col gap-3"
-                onClick={(event) => event.stopPropagation()}
-            >
+            <div className="flex max-h-full w-full max-w-lg flex-col gap-3" onClick={(event) => event.stopPropagation()}>
                 <img
                     src={previewImage}
                     alt="Tarjeta para compartir"

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -11,10 +11,11 @@ import { ChatService, type Chat } from '../services/ChatService';
 import { algoliaClient, INDEX_NAMES } from '../services/algoliaClient';
 import type { ShareEntityPayload } from '../types/share';
 import { db } from '../firebase';
-import { buildCriteriaStats } from '../utils/shareCriteria';
+import { buildShareCriteriaGroups } from '../utils/shareCriteria';
 import { buildPublicUrl, buildShareRouteUrl, getLocalRouteFromUrl } from '../utils/publicUrl';
 import { buildShareText } from '../utils/shareTexts';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
+import { recordShareEvent, type AnalyticsShareChannel } from '../services/AnalyticsService';
 
 interface ShareModalProps {
     isOpen: boolean;
@@ -66,8 +67,10 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     const [statusTone, setStatusTone] = React.useState<'neutral' | 'success' | 'error'>('neutral');
     const [isCardStylePickerOpen, setIsCardStylePickerOpen] = React.useState(false);
     const [selectedCardVariant, setSelectedCardVariant] = React.useState<ModernCardVariant | null>(null);
+    const [selectedImageUrl, setSelectedImageUrl] = React.useState<string | undefined>(undefined);
+    const [hydratedAuthorPhoto, setHydratedAuthorPhoto] = React.useState<string | undefined>(undefined);
     const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-    // Tarjetas v2: dos variantes dibujadas en canvas con layout determinista
+    // Formatos dibujados en canvas con layout determinista
     // (sin html2canvas ni datos desencuadrados).
     const cardVariantOptions: Array<{ id: ModernCardVariant; label: string; description: string; swatch: string }> = [
         {
@@ -81,6 +84,18 @@ export const ShareModal: React.FC<ShareModalProps> = ({
             label: 'Post',
             description: 'Cuadrada 1:1 para feed y WhatsApp, con los mismos datos bien encuadrados.',
             swatch: 'linear-gradient(135deg, #312e81 0%, #6d28d9 55%, #f59e0b 100%)',
+        },
+        {
+            id: 'portrait',
+            label: 'Retrato',
+            description: 'Vertical 4:5 para publicaciones de Instagram, con más espacio para datos.',
+            swatch: 'linear-gradient(160deg, #0f766e 0%, #312e81 58%, #7e22ce 100%)',
+        },
+        {
+            id: 'landscape',
+            label: 'Banner',
+            description: 'Horizontal 1,91:1 para enlaces, X, Facebook y cabeceras.',
+            swatch: 'linear-gradient(110deg, #111827 0%, #3730a3 55%, #0891b2 100%)',
         },
     ];
 
@@ -101,6 +116,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
         if (review) {
             const itemLabel = review.itemName || 'Elemento';
             const placeLabel = review.placeName || 'Lugar';
+            const shareCriteria = buildShareCriteriaGroups(review.scores, review.criteriaDefinition);
             const route = review.placeId && itemLabel
                 ? `/group/${review.placeId}/${encodeURIComponent(itemLabel)}`
                 : inferLocalRoute(fallbackUrl);
@@ -109,20 +125,33 @@ export const ShareModal: React.FC<ShareModalProps> = ({
                 id: review.id,
                 title: itemLabel,
                 subtitle: placeLabel,
+                description: review.comment,
                 route,
                 url: fallbackUrl,
                 imageUrl: review.photoUrl || review.placeMainImage,
+                imageUrls: [...(review.photoUrls || []), review.photoUrl, review.placeMainImage]
+                    .filter((value): value is string => Boolean(value)),
                 badgeLabel: review.listName,
                 score: review.overallRating,
+                authorId: review.userId || review.authorId,
                 authorName: review.authorName,
                 authorPhoto: review.authorPhoto,
-                criteriaStats: buildCriteriaStats(review.scores, review.criteriaDefinition),
+                criteriaStats: shareCriteria.ponderable,
+                nonPonderableStats: shareCriteria.nonPonderable,
                 tags: review.userTags || review.tags,
             };
         }
 
         if (place) {
             const route = place.placeId ? `/place/${place.placeId}` : inferLocalRoute(fallbackUrl);
+            const placeImages = [
+                place.photoUrl,
+                ...(place.placePhotos || []).map((photo) => photo.url),
+                ...place.reviews.flatMap((item) => [
+                    ...(item.photoUrls || []),
+                    item.photoUrl,
+                ]),
+            ].filter((value): value is string => Boolean(value));
             return {
                 type: 'place',
                 id: place.placeId,
@@ -131,7 +160,10 @@ export const ShareModal: React.FC<ShareModalProps> = ({
                 route,
                 url: fallbackUrl,
                 imageUrl: place.photoUrl,
+                imageUrls: placeImages,
                 score: place.avgScore,
+                reviewCount: place.reviewCount,
+                city: place.city,
             };
         }
 
@@ -143,6 +175,46 @@ export const ShareModal: React.FC<ShareModalProps> = ({
             url: fallbackUrl,
         };
     }, [shareEntity, review, place, fallbackUrl, title, text]);
+
+    const availableImageUrls = React.useMemo(() => Array.from(new Set(
+        [resolvedShareEntity.imageUrl, ...(resolvedShareEntity.imageUrls || [])]
+            .filter((value): value is string => typeof value === 'string' && Boolean(value.trim()))
+            .map((value) => value.trim())
+    )), [resolvedShareEntity.imageUrl, resolvedShareEntity.imageUrls]);
+
+    React.useEffect(() => {
+        if (!isOpen) return;
+        setSelectedImageUrl(availableImageUrls[0]);
+    }, [isOpen, resolvedShareEntity.id, resolvedShareEntity.type, availableImageUrls]);
+
+    React.useEffect(() => {
+        if (!isOpen || resolvedShareEntity.authorPhoto || !resolvedShareEntity.authorId) {
+            setHydratedAuthorPhoto(resolvedShareEntity.authorPhoto);
+            return;
+        }
+
+        let cancelled = false;
+        getDoc(doc(db, 'publicProfiles', resolvedShareEntity.authorId))
+            .then((snapshot) => {
+                if (cancelled || !snapshot.exists()) return;
+                const data = snapshot.data();
+                const photo = typeof data.photoUrl === 'string'
+                    ? data.photoUrl
+                    : (typeof data.photoURL === 'string' ? data.photoURL : undefined);
+                if (photo) setHydratedAuthorPhoto(photo);
+            })
+            .catch(() => undefined);
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isOpen, resolvedShareEntity.authorId, resolvedShareEntity.authorPhoto]);
+
+    const cardEntity = React.useMemo<ShareEntityPayload>(() => ({
+        ...resolvedShareEntity,
+        imageUrl: selectedImageUrl || resolvedShareEntity.imageUrl,
+        authorPhoto: hydratedAuthorPhoto || resolvedShareEntity.authorPhoto,
+    }), [resolvedShareEntity, selectedImageUrl, hydratedAuthorPhoto]);
 
     const privateChatByUserId = React.useMemo<Record<string, string>>(() => {
         if (!user) return {};
@@ -195,6 +267,8 @@ export const ShareModal: React.FC<ShareModalProps> = ({
         setIsSearchingRecipients(false);
         setIsCardStylePickerOpen(false);
         setSelectedCardVariant(null);
+        setSelectedImageUrl(undefined);
+        setHydratedAuthorPhoto(undefined);
     }, []);
 
     const handleRequestClose = React.useCallback(() => {
@@ -292,7 +366,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
                 const response = await algoliaClient.search({
                     requests: [{ indexName: INDEX_NAMES.users, query: searchTerm, hitsPerPage: 8 }]
                 });
-                const hits = ((response.results[0] as any)?.hits || []) as UserSearchHit[];
+                const hits = (response.results[0] as { hits?: UserSearchHit[] } | undefined)?.hits || [];
                 setRecipientResults(
                     hits.filter((hit) => hit.objectID !== user.uid)
                 );
@@ -313,15 +387,24 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     const externalShareUrl = buildShareRouteUrl(resolvedShareEntity.route) || fallbackUrl;
     const shareTextForExternal = `${text || buildShareText(resolvedShareEntity)} ${externalShareUrl}`.trim();
 
+    const trackSuccessfulShare = (channel: AnalyticsShareChannel, count = 1) => {
+        void recordShareEvent(cardEntity, channel, count).catch((error) => {
+            // Compartir debe seguir funcionando aunque la analitica no este disponible.
+            console.warn('No se pudo registrar el compartido.', error);
+        });
+    };
+
     const handleShare = async (platform: 'whatsapp' | 'clipboard' | 'image' | 'chat') => {
         if (platform === 'whatsapp') {
             window.open(`https://wa.me/?text=${encodeURIComponent(shareTextForExternal)}`, '_blank', 'noopener,noreferrer');
+            trackSuccessfulShare('whatsapp');
             return;
         }
 
         if (platform === 'clipboard') {
             try {
                 await navigator.clipboard.writeText(shareTextForExternal);
+                trackSuccessfulShare('clipboard');
                 setStatusTone('success');
                 setStatusMessage('Enlace copiado al portapapeles');
             } catch {
@@ -372,6 +455,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
         setStatusTone('neutral');
         setStatusMessage(null);
         shareCardTriggerRef.current();
+        trackSuccessfulShare('image');
     };
 
     const toggleUser = (hit: UserSearchHit) => {
@@ -428,12 +512,13 @@ export const ShareModal: React.FC<ShareModalProps> = ({
                 user.uid,
                 chatNote.trim(),
                 'share',
-                { share: resolvedShareEntity }
+                { share: cardEntity }
             ))
         );
 
         const successCount = results.filter((row) => row.status === 'fulfilled').length;
         const failedCount = results.length - successCount;
+        if (successCount > 0) trackSuccessfulShare('chat', successCount);
 
         if (failedCount === 0) {
             setStatusTone('success');
@@ -457,7 +542,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     const modalContent = (
         <div className="fixed inset-0 z-[10000] lt-mobile-overlay flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-fade-in" onClick={handleRequestClose}>
             <ShareCardModern
-                entity={resolvedShareEntity}
+                entity={cardEntity}
                 variant={selectedCardVariant || 'story'}
                 triggerRef={shareCardTriggerRef}
                 onRequestClose={handleRequestClose}
@@ -536,6 +621,43 @@ export const ShareModal: React.FC<ShareModalProps> = ({
                         </div>
 
                         <div className="p-4 space-y-3">
+                            {availableImageUrls.length > 1 && (
+                                <div>
+                                    <div className="mb-2 flex items-center justify-between gap-3">
+                                        <div className="text-[11px] font-bold uppercase tracking-wider text-gray-400">
+                                            Elige la foto
+                                        </div>
+                                        <div className="text-[11px] text-gray-500">
+                                            {availableImageUrls.length} disponibles
+                                        </div>
+                                    </div>
+                                    <div className="flex gap-2 overflow-x-auto pb-2">
+                                        {availableImageUrls.map((imageUrl, index) => {
+                                            const isSelected = selectedImageUrl === imageUrl;
+                                            return (
+                                                <button
+                                                    key={`${imageUrl}-${index}`}
+                                                    type="button"
+                                                    onClick={() => setSelectedImageUrl(imageUrl)}
+                                                    className={`relative h-20 w-20 shrink-0 overflow-hidden rounded-xl border-2 transition-all ${isSelected
+                                                        ? 'border-[var(--lt-accent)] shadow-lg shadow-[var(--lt-accent-shadow)]'
+                                                        : 'border-white/10 opacity-70 hover:opacity-100'
+                                                        }`}
+                                                    aria-label={`Usar foto ${index + 1}`}
+                                                >
+                                                    <img src={imageUrl} alt="" className="h-full w-full object-cover" />
+                                                    {isSelected && (
+                                                        <span className="absolute right-1 top-1 grid h-5 w-5 place-items-center rounded-full bg-[var(--lt-accent)] text-white shadow">
+                                                            <Check className="h-3 w-3" />
+                                                        </span>
+                                                    )}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            )}
+
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
                                 {cardVariantOptions.map((option) => {
                                     const isSelected = selectedCardVariant === option.id;

--- a/frontend/src/components/business/BusinessProSections.tsx
+++ b/frontend/src/components/business/BusinessProSections.tsx
@@ -10,11 +10,13 @@ import {
     Pencil,
     Plus,
     Save,
+    Share2,
     Sparkles,
     Tags,
     Trash2,
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
+import { getBusinessPlaceAnalytics, type BusinessPlaceAnalyticsResult } from '../../services/AnalyticsService';
 import { getCanonicalPlaceItems, type CanonicalPlaceItem } from '../../services/CanonicalItemService';
 import {
     ALLERGEN_OPTIONS,
@@ -40,6 +42,7 @@ import {
     requestItemSpotlight,
     requestSponsoredPlacement,
     saveBusinessOffer,
+    SPOTLIGHT_RADIUS_STEP_KM,
     submitItemProposal,
     updateBusinessMenuSections,
     updateBusinessVisual,
@@ -58,6 +61,19 @@ import {
 } from '../../services/BusinessProService';
 
 type Message = { type: 'success' | 'error'; text: string } | null;
+const BUSINESS_SHARE_CHANNEL_LABELS: Record<string, string> = {
+    whatsapp: 'WhatsApp',
+    clipboard: 'Enlace copiado',
+    image: 'Tarjeta generada',
+    chat: 'Chat Listopic',
+};
+const BUSINESS_SHARE_ENTITY_LABELS: Record<string, string> = {
+    place: 'Ficha del lugar',
+    group: 'Grupo o elemento',
+    review: 'Reseña',
+    list: 'Lista',
+    sublist: 'Sublista',
+};
 
 const inputClass = 'w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-[var(--lt-text)] outline-none transition-colors placeholder:text-[var(--lt-text-muted)] focus:border-[var(--lt-accent-border)]';
 
@@ -1092,6 +1108,10 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
                     setItems(itemRows);
                     setSpotlights(spotlightRows);
                     setPricing(pricingConfig);
+                    setSpotlightRadius((current) => {
+                        const clamped = Math.max(pricingConfig.minRadiusKm, Math.min(pricingConfig.maxRadiusKm, current));
+                        return Number((Math.round(clamped / SPOTLIGHT_RADIUS_STEP_KM) * SPOTLIGHT_RADIUS_STEP_KM).toFixed(1));
+                    });
                     setSpotlightCredits(creditsBalance);
                 }
             } catch (error) {
@@ -1107,6 +1127,7 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
     }, [placeId]);
 
     const spotlightUnitPrice = computeSpotlightUnitPrice(pricing, spotlightRadius, spotlightWeeks);
+    const spotlightRadiusSteps = Math.ceil((spotlightRadius / SPOTLIGHT_RADIUS_STEP_KM) - 1e-9);
     const spotlightCreditsUsed = Math.min(spotlightCredits, spotlightUnits);
     const spotlightBilledUnits = spotlightUnits - spotlightCreditsUsed;
     const spotlightTotal = Number((spotlightUnitPrice * spotlightBilledUnits).toFixed(2));
@@ -1418,7 +1439,7 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
                                     type="range"
                                     min={pricing.minRadiusKm}
                                     max={pricing.maxRadiusKm}
-                                    step={0.5}
+                                    step={SPOTLIGHT_RADIUS_STEP_KM}
                                     value={spotlightRadius}
                                     onChange={(event) => setSpotlightRadius(Number(event.target.value))}
                                     className="mt-3 w-full accent-[var(--lt-accent)]"
@@ -1444,7 +1465,7 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
                         <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/10 px-3 py-2.5">
                             <p className="text-xs text-[var(--lt-text-muted)]">
                                 {spotlightUnits} impulso{spotlightUnits === 1 ? '' : 's'} × {spotlightUnitPrice.toFixed(2)} €
-                                <span className="block text-[10px]">({pricing.pricePerKmPerWeek.toFixed(2)} €/km·semana × {spotlightRadius} km × {spotlightWeeks} sem.)</span>
+                                <span className="block text-[10px]">({pricing.pricePerRadiusStepPerWeek.toFixed(2)} € × {spotlightRadiusSteps} tramos de 0,2 km × {spotlightWeeks} sem.)</span>
                                 {spotlightCreditsUsed > 0 && (
                                     <span className="block text-[10px] text-yellow-200">− {spotlightCreditsUsed} de regalo → pagas {spotlightBilledUnits}</span>
                                 )}
@@ -1475,6 +1496,11 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
                                                     {spotlight.endsAt ? ` · hasta ${spotlight.endsAt}` : ''}
                                                 </p>
                                                 {spotlight.adminNotes && <p className="text-[11px] text-[var(--lt-text-muted)]">Admin: {spotlight.adminNotes}</p>}
+                                                {spotlight.status === 'active' && (
+                                                    <p className="text-[11px] font-bold text-amber-300/80">
+                                                        {spotlight.metrics.impressions} impresiones · {spotlight.metrics.clicks} clics · CTR {spotlight.metrics.impressions > 0 ? ((spotlight.metrics.clicks / spotlight.metrics.impressions) * 100).toFixed(1) : '0,0'}%
+                                                    </p>
+                                                )}
                                             </div>
                                             <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-black uppercase ${meta.className}`}>
                                                 {meta.label}
@@ -1549,6 +1575,11 @@ export const BusinessSponsoredSection: React.FC<{ placeId: string }> = ({ placeI
                                                     {placement.headline && <p className="mt-0.5 truncate text-[11px] text-[var(--lt-text-muted)]">{placement.headline}</p>}
                                                     {dates && <p className="mt-0.5 text-[11px] text-[var(--lt-text-muted)]">{dates}</p>}
                                                     {placement.adminNotes && <p className="mt-0.5 text-[11px] text-[var(--lt-text-muted)]">Admin: {placement.adminNotes}</p>}
+                                                    {placement.status === 'active' && (
+                                                        <p className="mt-0.5 text-[11px] font-bold text-cyan-300/80">
+                                                            {placement.metrics.impressions} impresiones · {placement.metrics.clicks} clics · CTR {placement.metrics.impressions > 0 ? ((placement.metrics.clicks / placement.metrics.impressions) * 100).toFixed(1) : '0,0'}%
+                                                        </p>
+                                                    )}
                                                 </div>
                                                 <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-black uppercase ${meta.className}`}>
                                                     {meta.label}
@@ -1595,6 +1626,7 @@ const lastMonths = (count: number): string[] => {
 export const BusinessStatsSection: React.FC<{ placeId: string }> = ({ placeId }) => {
     const [reviews, setReviews] = useState<ManagerPlaceReview[]>([]);
     const [items, setItems] = useState<CanonicalPlaceItem[]>([]);
+    const [traffic, setTraffic] = useState<BusinessPlaceAnalyticsResult | null>(null);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
@@ -1602,13 +1634,15 @@ export const BusinessStatsSection: React.FC<{ placeId: string }> = ({ placeId })
         const load = async () => {
             setLoading(true);
             try {
-                const [reviewRows, itemRows] = await Promise.all([
+                const [reviewRows, itemRows, trafficRows] = await Promise.all([
                     getPlaceReviewsForManager(placeId).catch(() => [] as ManagerPlaceReview[]),
                     getCanonicalPlaceItems(placeId).catch(() => [] as CanonicalPlaceItem[]),
+                    getBusinessPlaceAnalytics(placeId, 30).catch(() => null),
                 ]);
                 if (!cancelled) {
                     setReviews(reviewRows);
                     setItems(itemRows);
+                    setTraffic(trafficRows);
                 }
             } finally {
                 if (!cancelled) setLoading(false);
@@ -1656,8 +1690,26 @@ export const BusinessStatsSection: React.FC<{ placeId: string }> = ({ placeId })
             .sort((a, b) => (b.stats?.reviewCount || 0) - (a.stats?.reviewCount || 0))
             .slice(0, 5);
 
-        return { total: reviews.length, average, monthly, maxCount, topItems };
-    }, [reviews, items]);
+        const pageDaily = traffic?.page.daily || [];
+        const relatedDaily = traffic?.relatedDaily || [];
+        const pageViews = pageDaily.reduce((sum, row) => sum + row.totalViews, 0);
+        const uniqueSessions = pageDaily.reduce((sum, row) => sum + row.uniqueSessions, 0);
+        const relatedShares = relatedDaily.reduce((sum, row) => sum + row.totalShares, 0);
+        const shareChannels = relatedDaily.reduce<Record<string, number>>((totals, row) => {
+            Object.entries(row.byShareChannel).forEach(([channel, count]) => {
+                totals[channel] = (totals[channel] || 0) + count;
+            });
+            return totals;
+        }, {});
+        const shareEntityTypes = relatedDaily.reduce<Record<string, number>>((totals, row) => {
+            Object.entries(row.byShareEntityType).forEach(([entityType, count]) => {
+                totals[entityType] = (totals[entityType] || 0) + count;
+            });
+            return totals;
+        }, {});
+
+        return { total: reviews.length, average, monthly, maxCount, topItems, pageViews, uniqueSessions, relatedShares, shareChannels, shareEntityTypes };
+    }, [reviews, items, traffic]);
 
     if (loading) {
         return (
@@ -1688,6 +1740,34 @@ export const BusinessStatsSection: React.FC<{ placeId: string }> = ({ placeId })
                     <p className="mt-1 text-xs font-bold uppercase tracking-wider text-[var(--lt-text-muted)]">Elementos en carta</p>
                 </div>
             </div>
+
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+                <div className="rounded-2xl border border-violet-400/20 bg-violet-400/[0.06] p-4 text-center">
+                    <p className="text-3xl font-black text-[var(--lt-text)]">{stats.pageViews.toLocaleString('es-ES')}</p>
+                    <p className="mt-1 text-xs font-bold uppercase tracking-wider text-[var(--lt-text-muted)]">Vistas de la ficha · 30 días</p>
+                </div>
+                <div className="rounded-2xl border border-violet-400/20 bg-violet-400/[0.06] p-4 text-center">
+                    <p className="text-3xl font-black text-[var(--lt-text)]">{stats.uniqueSessions.toLocaleString('es-ES')}</p>
+                    <p className="mt-1 text-xs font-bold uppercase tracking-wider text-[var(--lt-text-muted)]">Sesiones únicas · 30 días</p>
+                </div>
+                <div className="rounded-2xl border border-violet-400/20 bg-violet-400/[0.06] p-4 text-center">
+                    <p className="flex items-center justify-center gap-2 text-3xl font-black text-[var(--lt-text)]"><Share2 className="h-5 w-5 text-violet-300" />{stats.relatedShares.toLocaleString('es-ES')}</p>
+                    <p className="mt-1 text-xs font-bold uppercase tracking-wider text-[var(--lt-text-muted)]">Compartidos relacionados · 30 días</p>
+                </div>
+            </div>
+
+            {Object.keys(stats.shareChannels).length > 0 && (
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                        <h3 className="mb-3 text-sm font-black text-[var(--lt-text)]">Cómo se ha compartido</h3>
+                        <StatBreakdown values={stats.shareChannels} labels={BUSINESS_SHARE_CHANNEL_LABELS} />
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                        <h3 className="mb-3 text-sm font-black text-[var(--lt-text)]">Qué contenido relacionado se comparte</h3>
+                        <StatBreakdown values={stats.shareEntityTypes} labels={BUSINESS_SHARE_ENTITY_LABELS} />
+                    </div>
+                </div>
+            )}
 
             <div className="mt-4 grid gap-4 lg:grid-cols-2">
                 <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
@@ -1739,3 +1819,14 @@ export const BusinessStatsSection: React.FC<{ placeId: string }> = ({ placeId })
         </ProSectionShell>
     );
 };
+
+const StatBreakdown: React.FC<{ values: Record<string, number>; labels: Record<string, string> }> = ({ values, labels }) => (
+    <div className="grid gap-2 sm:grid-cols-2">
+        {Object.entries(values).sort((a, b) => b[1] - a[1]).map(([key, count]) => (
+            <div key={key} className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm">
+                <span className="text-[var(--lt-text-muted)]">{labels[key] || key}</span>
+                <strong className="text-[var(--lt-text)]">{count.toLocaleString('es-ES')}</strong>
+            </div>
+        ))}
+    </div>
+);

--- a/frontend/src/components/business/SponsoredHomeSpotlight.tsx
+++ b/frontend/src/components/business/SponsoredHomeSpotlight.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Building2, MapPin } from 'lucide-react';
-import { getActiveHomePlacements, type SponsoredPlacement } from '../../services/BusinessProService';
+import { getActiveHomePlacements, recordSponsoredEvent, type SponsoredPlacement } from '../../services/BusinessProService';
+import { useAuth } from '../../context/AuthContext';
 
 // Destacados patrocinados de la home (Business Pro). Se autoalimenta de los
 // emplazamientos activos aprobados por admin; si no hay ninguno no pinta nada.
 // Siempre con etiqueta "Patrocinado" y sin tocar rankings orgánicos.
 export const SponsoredHomeSpotlight: React.FC = () => {
     const [placements, setPlacements] = useState<SponsoredPlacement[]>([]);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { isJefe } = useAuth();
 
     useEffect(() => {
         let cancelled = false;
@@ -23,15 +26,46 @@ export const SponsoredHomeSpotlight: React.FC = () => {
         };
     }, []);
 
+    useEffect(() => {
+        if (isJefe) return;
+        const elements = Array.from(containerRef.current?.querySelectorAll<HTMLElement>('[data-sponsored-id]') || []);
+        if (elements.length === 0) return;
+        const register = (element: HTMLElement) => {
+            const id = element.dataset.sponsoredId;
+            if (id) void recordSponsoredEvent('placement', id, 'impression').catch(() => undefined);
+        };
+        if (!('IntersectionObserver' in window)) {
+            elements.forEach(register);
+            return;
+        }
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                    register(entry.target as HTMLElement);
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.5 });
+        elements.forEach((element) => observer.observe(element));
+        return () => observer.disconnect();
+    }, [isJefe, placements]);
+
     if (placements.length === 0) return null;
 
     return (
         <div className="mx-auto mt-8 w-full max-w-4xl">
-            <div className={`grid gap-3 ${placements.length > 1 ? 'sm:grid-cols-2' : ''} ${placements.length > 2 ? 'lg:grid-cols-3' : ''}`}>
+            <div ref={containerRef} className={`grid gap-3 ${placements.length > 1 ? 'sm:grid-cols-2' : ''} ${placements.length > 2 ? 'lg:grid-cols-3' : ''}`}>
                 {placements.map((placement) => (
                     <Link
                         key={placement.id}
+                        data-sponsored-id={placement.id}
                         to={`/place/${placement.placeId}`}
+                        onClick={() => {
+                            if (!isJefe) void Promise.all([
+                                recordSponsoredEvent('placement', placement.id, 'impression'),
+                                recordSponsoredEvent('placement', placement.id, 'click'),
+                            ]).catch(() => undefined);
+                        }}
                         className="group relative flex items-center gap-3 overflow-hidden rounded-2xl border border-amber-500/20 bg-[var(--lt-card-strong)] p-3 shadow-lg transition-transform hover:scale-[1.01]"
                     >
                         <div className="h-16 w-16 shrink-0 overflow-hidden rounded-xl bg-white/5">

--- a/frontend/src/components/business/SponsoredItemsCarousel.tsx
+++ b/frontend/src/components/business/SponsoredItemsCarousel.tsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Star, UtensilsCrossed } from 'lucide-react';
 import { useLocation } from '../../hooks/useLocation';
 import {
     getActiveItemSpotlights,
+    recordSponsoredEvent,
     weightedSampleSpotlights,
     type ItemSpotlight,
 } from '../../services/BusinessProService';
+import { useAuth } from '../../context/AuthContext';
 
 const MAX_CAROUSEL_ITEMS = 6;
 
@@ -19,6 +21,8 @@ export const SponsoredItemsCarousel: React.FC<{ listId?: string; className?: str
     const { location, calculateDistance } = useLocation();
     const [spotlights, setSpotlights] = useState<ItemSpotlight[]>([]);
     const [loaded, setLoaded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { isJefe } = useAuth();
 
     useEffect(() => {
         let cancelled = false;
@@ -52,6 +56,30 @@ export const SponsoredItemsCarousel: React.FC<{ listId?: string; className?: str
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [loaded, spotlights, listId, location?.latitude, location?.longitude]);
 
+    useEffect(() => {
+        if (isJefe) return;
+        const elements = Array.from(containerRef.current?.querySelectorAll<HTMLElement>('[data-sponsored-id]') || []);
+        if (elements.length === 0) return;
+        const register = (element: HTMLElement) => {
+            const id = element.dataset.sponsoredId;
+            if (id) void recordSponsoredEvent('spotlight', id, 'impression').catch(() => undefined);
+        };
+        if (!('IntersectionObserver' in window)) {
+            elements.forEach(register);
+            return;
+        }
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                    register(entry.target as HTMLElement);
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.5 });
+        elements.forEach((element) => observer.observe(element));
+        return () => observer.disconnect();
+    }, [isJefe, picked]);
+
     if (picked.length === 0) return null;
 
     return (
@@ -63,11 +91,18 @@ export const SponsoredItemsCarousel: React.FC<{ listId?: string; className?: str
                     Patrocinado
                 </span>
             </div>
-            <div className="flex gap-3 overflow-x-auto pb-2 hide-scrollbar">
+            <div ref={containerRef} className="flex gap-3 overflow-x-auto pb-2 hide-scrollbar">
                 {picked.map((spotlight) => (
                     <Link
                         key={spotlight.id}
+                        data-sponsored-id={spotlight.id}
                         to={`/group/${spotlight.placeId}/${encodeURIComponent(spotlight.itemName)}`}
+                        onClick={() => {
+                            if (!isJefe) void Promise.all([
+                                recordSponsoredEvent('spotlight', spotlight.id, 'impression'),
+                                recordSponsoredEvent('spotlight', spotlight.id, 'click'),
+                            ]).catch(() => undefined);
+                        }}
                         className="group w-44 shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] shadow-lg transition-transform hover:scale-[1.02]"
                     >
                         <div className="relative h-24 w-full overflow-hidden bg-white/5">

--- a/frontend/src/components/developer/GeoAnalyticsTab.tsx
+++ b/frontend/src/components/developer/GeoAnalyticsTab.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { CircleMarker, MapContainer, Popup, TileLayer, useMap } from 'react-leaflet';
+import { latLngBounds, type LatLngExpression } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Database, Loader2, MapPinned, RefreshCw, ShieldCheck } from 'lucide-react';
+import {
+    backfillReviewHeatmap,
+    getAnalyticsHeatmaps,
+    type AnalyticsHeatPoint,
+    type AnalyticsHeatmapsResult,
+    type ReviewHeatmapBackfillResult,
+} from '../../services/AnalyticsService';
+
+type PeriodDays = 7 | 30 | 90 | 365;
+
+const DEFAULT_CENTER: LatLngExpression = [40.2, -3.7];
+
+const FitAnalyticsBounds: React.FC<{ points: AnalyticsHeatPoint[] }> = ({ points }) => {
+    const map = useMap();
+    const signature = points.map((point) => `${point.lat},${point.lng}`).join('|');
+
+    useEffect(() => {
+        if (points.length === 0) return;
+        if (points.length === 1) {
+            map.setView([points[0].lat, points[0].lng], 9);
+            return;
+        }
+        map.fitBounds(latLngBounds(points.map((point) => [point.lat, point.lng])), {
+            padding: [28, 28],
+            maxZoom: 11,
+        });
+        // signature representa exclusivamente las coordenadas visibles.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [map, signature]);
+    return null;
+};
+
+const HeatMapPanel: React.FC<{
+    title: string;
+    description: string;
+    points: AnalyticsHeatPoint[];
+    color: string;
+    emptyText: string;
+}> = ({ title, description, points, color, emptyText }) => {
+    const maxCount = Math.max(1, ...points.map((point) => point.count));
+
+    return (
+        <section className="overflow-hidden rounded-2xl border border-white/10 bg-[var(--lt-card-strong)]">
+            <div className="border-b border-white/10 p-4">
+                <h3 className="font-black text-white">{title}</h3>
+                <p className="mt-1 text-xs leading-relaxed text-gray-400">{description}</p>
+            </div>
+            <div className="relative h-[430px] bg-black/20">
+                <MapContainer center={DEFAULT_CENTER} zoom={5} scrollWheelZoom className="h-full w-full listopic-map">
+                    <TileLayer
+                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    />
+                    <FitAnalyticsBounds points={points} />
+                    {points.map((point) => (
+                        <CircleMarker
+                            key={point.id}
+                            center={[point.lat, point.lng]}
+                            radius={Math.max(8, Math.min(34, 8 + (Math.sqrt(point.count / maxCount) * 26)))}
+                            pathOptions={{ color, fillColor: color, fillOpacity: 0.48, weight: 2 }}
+                        >
+                            <Popup>
+                                <strong>{point.label || 'Zona aproximada'}</strong><br />
+                                {point.count.toLocaleString('es-ES')} {point.placeId ? 'reseñas' : 'sesiones'}
+                            </Popup>
+                        </CircleMarker>
+                    ))}
+                </MapContainer>
+                {points.length === 0 && (
+                    <div className="pointer-events-none absolute inset-x-4 bottom-4 z-[500] rounded-xl border border-white/15 bg-black/75 px-4 py-3 text-center text-xs text-gray-200 backdrop-blur">
+                        {emptyText}
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+};
+
+export const GeoAnalyticsTab: React.FC = () => {
+    const [days, setDays] = useState<PeriodDays>(30);
+    const [data, setData] = useState<AnalyticsHeatmapsResult | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [backfilling, setBackfilling] = useState(false);
+    const [backfillResult, setBackfillResult] = useState<ReviewHeatmapBackfillResult | null>(null);
+
+    const load = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            setData(await getAnalyticsHeatmaps(days));
+        } catch (loadError) {
+            console.error('GeoAnalyticsTab: load failed', loadError);
+            setError('No se pudieron cargar los mapas. Comprueba que las Functions nuevas están desplegadas.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { void load(); }, [days]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const rebuildReviews = async () => {
+        if (!window.confirm('¿Reconstruir el histórico geográfico de reseñas? Esta operación lee las reseñas existentes una sola vez.')) return;
+        setBackfilling(true);
+        setBackfillResult(null);
+        setError('');
+        try {
+            const result = await backfillReviewHeatmap();
+            setBackfillResult(result);
+            await load();
+        } catch (backfillError) {
+            console.error('GeoAnalyticsTab: backfill failed', backfillError);
+            setError('No se pudo reconstruir el histórico de reseñas.');
+        } finally {
+            setBackfilling(false);
+        }
+    };
+
+    const totals = useMemo(() => ({
+        connections: data?.connections.reduce((sum, point) => sum + point.count, 0) || 0,
+        reviews: data?.reviews.reduce((sum, point) => sum + point.count, 0) || 0,
+    }), [data]);
+
+    return (
+        <div className="mx-auto max-w-7xl space-y-5">
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-5 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h2 className="flex items-center gap-2 text-2xl font-black text-white"><MapPinned className="h-6 w-6 text-cyan-300" /> Mapas analíticos</h2>
+                    <p className="mt-1 max-w-3xl text-sm text-gray-400">Conexiones por zona aproximada y lugares donde se publican reseñas. Acceso exclusivo para cuentas Jefe.</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <select value={days} onChange={(event) => setDays(Number(event.target.value) as PeriodDays)} className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                        <option value={7}>7 días</option><option value={30}>30 días</option><option value={90}>90 días</option><option value={365}>1 año</option>
+                    </select>
+                    <button type="button" onClick={load} disabled={loading} className="rounded-xl border border-white/10 bg-white/5 p-2.5 text-gray-300 hover:bg-white/10" aria-label="Actualizar">
+                        <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                    </button>
+                </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+                <Summary label="Sesiones visibles" value={totals.connections} />
+                <Summary label="Reseñas geolocalizadas" value={totals.reviews} />
+                <Summary label="Zonas protegidas" value={data?.suppressedConnections || 0} suffix="sesiones ocultas" />
+            </div>
+
+            <div className="flex flex-col gap-3 rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.06] p-4 text-sm text-cyan-100 sm:flex-row sm:items-center sm:justify-between">
+                <p className="flex items-start gap-2"><ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />La conexión se redondea a una cuadrícula aproximada de 0,1° y una zona solo aparece con al menos {data?.privacyThreshold || 3} sesiones. No se almacena la IP ni la coordenada precisa.</p>
+                <button type="button" onClick={rebuildReviews} disabled={backfilling} className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl border border-cyan-300/25 bg-black/20 px-3 py-2 text-xs font-black hover:bg-black/30 disabled:opacity-60">
+                    {backfilling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Database className="h-4 w-4" />} Reconstruir reseñas
+                </button>
+            </div>
+
+            {backfillResult && (
+                <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-3 text-sm text-emerald-100">
+                    Histórico reconstruido: {backfillResult.scanned.toLocaleString('es-ES')} reseñas leídas, {backfillResult.aggregatedRows.toLocaleString('es-ES')} agrupaciones y {backfillResult.skipped.toLocaleString('es-ES')} sin coordenadas.
+                </div>
+            )}
+            {error && <div className="rounded-xl border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>}
+            {data?.coverageCapped && <div className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4 text-sm text-amber-200">El periodo alcanzó el límite de seguridad; el mapa puede ser parcial.</div>}
+
+            {loading && !data ? (
+                <div className="grid min-h-72 place-items-center rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] text-gray-400"><span className="flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Cargando mapas…</span></div>
+            ) : data ? (
+                <div className="grid gap-5 xl:grid-cols-2">
+                    <HeatMapPanel
+                        title="Zonas de conexión"
+                        description="Una sesión cuenta una vez al día. Las celdas con poco tráfico se ocultan para impedir que pueda reconocerse a una persona."
+                        points={data.connections}
+                        color="#8b5cf6"
+                        emptyText={`Todavía no hay ninguna zona que alcance ${data.privacyThreshold} sesiones en este intervalo.`}
+                    />
+                    <HeatMapPanel
+                        title="Lugares donde se publican reseñas"
+                        description="Cada punto representa un lugar público; su intensidad es el número de reseñas publicadas dentro del intervalo."
+                        points={data.reviews}
+                        color="#f59e0b"
+                        emptyText="Todavía no hay reseñas agregadas. Usa “Reconstruir reseñas” una vez para incorporar el histórico."
+                    />
+                </div>
+            ) : null}
+        </div>
+    );
+};
+
+const Summary: React.FC<{ label: string; value: number; suffix?: string }> = ({ label, value, suffix }) => (
+    <div className="rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-4">
+        <p className="text-xs font-bold uppercase tracking-wider text-gray-500">{label}</p>
+        <p className="mt-2 text-3xl font-black text-white">{value.toLocaleString('es-ES')}</p>
+        {suffix && <p className="mt-1 text-[11px] text-gray-500">{suffix}</p>}
+    </div>
+);

--- a/frontend/src/components/developer/PageAnalyticsTab.tsx
+++ b/frontend/src/components/developer/PageAnalyticsTab.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { BarChart3, Eye, Loader2, Monitor, RefreshCw, Search, Share2, UserCheck, Users, X } from 'lucide-react';
+import {
+    getAnalyticsOverview,
+    getPageAnalytics,
+    type AnalyticsOverviewResult,
+    type PageAnalyticsResult,
+} from '../../services/AnalyticsService';
+
+const PAGE_TYPE_LABELS: Record<string, string> = {
+    home: 'Inicio', search: 'Búsqueda', list: 'Lista', place: 'Lugar', item: 'Plato/elemento',
+    profile: 'Perfil', users: 'Usuarios', information: 'Información', other: 'Otra',
+};
+const SOURCE_LABELS: Record<string, string> = {
+    direct: 'Directo', internal: 'Interno', search: 'Buscadores', social: 'Social', external: 'Web externa',
+};
+const DEVICE_LABELS: Record<string, string> = { mobile: 'Móvil', tablet: 'Tablet', desktop: 'Escritorio' };
+const sum = (values: number[]) => values.reduce((total, value) => total + value, 0);
+const SHARE_CHANNEL_LABELS: Record<string, string> = {
+    whatsapp: 'WhatsApp', clipboard: 'Enlace copiado', image: 'Tarjeta generada', chat: 'Chat de Listopic',
+};
+
+export const PageAnalyticsTab: React.FC = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedPath = searchParams.get('path');
+    const [days, setDays] = useState<7 | 30 | 90>(30);
+    const [overview, setOverview] = useState<AnalyticsOverviewResult | null>(null);
+    const [detail, setDetail] = useState<PageAnalyticsResult | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [detailLoading, setDetailLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [search, setSearch] = useState('');
+
+    const load = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            setOverview(await getAnalyticsOverview(days));
+        } catch (loadError) {
+            console.error('PageAnalyticsTab: overview failed', loadError);
+            setError('No se pudo cargar la analítica. Si acabas de activar el rol Jefe, provisiona o refresca el claim admin.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { void load(); }, [days]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (!selectedPath) { setDetail(null); return; }
+        let cancelled = false;
+        setDetailLoading(true);
+        getPageAnalytics(selectedPath, days)
+            .then((result) => { if (!cancelled) setDetail(result); })
+            .catch((loadError) => {
+                console.error('PageAnalyticsTab: detail failed', loadError);
+                if (!cancelled) setDetail(null);
+            })
+            .finally(() => { if (!cancelled) setDetailLoading(false); });
+        return () => { cancelled = true; };
+    }, [days, selectedPath]);
+
+    const period = useMemo(() => {
+        const daily = overview?.daily || [];
+        const views = sum(daily.map((row) => row.totalViews));
+        const authenticated = sum(daily.map((row) => row.authenticatedViews));
+        return {
+            views,
+            shares: sum(daily.map((row) => row.totalShares)),
+            unique: sum(daily.map((row) => row.uniqueSessions)),
+            authenticated,
+            authPct: views > 0 ? Math.round((authenticated / views) * 100) : 0,
+            maxViews: Math.max(1, ...daily.map((row) => row.totalViews)),
+        };
+    }, [overview]);
+
+    const filteredPages = useMemo(() => {
+        const needle = search.trim().toLocaleLowerCase('es');
+        if (!needle) return overview?.topPages || [];
+        return (overview?.topPages || []).filter((page) => `${page.title} ${page.path} ${page.pageType}`.toLocaleLowerCase('es').includes(needle));
+    }, [overview, search]);
+
+    const choosePage = (path: string | null) => {
+        const next = new URLSearchParams(searchParams);
+        next.set('tab', 'analytics');
+        if (path) next.set('path', path); else next.delete('path');
+        setSearchParams(next, { replace: true });
+    };
+
+    return (
+        <div className="mx-auto max-w-6xl space-y-5">
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-5 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h2 className="flex items-center gap-2 text-2xl font-black text-white"><BarChart3 className="h-6 w-6 text-violet-300" /> Analítica de páginas</h2>
+                    <p className="mt-1 text-sm text-gray-400">Datos agregados al instante; pulsa actualizar para releerlos. El entorno local y las visitas de cuentas Jefe no se contabilizan.</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <select value={days} onChange={(event) => setDays(Number(event.target.value) as 7 | 30 | 90)} className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                        <option value={7}>7 días</option><option value={30}>30 días</option><option value={90}>90 días</option>
+                    </select>
+                    <button type="button" onClick={load} disabled={loading} className="rounded-xl border border-white/10 bg-white/5 p-2.5 text-gray-300 hover:bg-white/10" aria-label="Actualizar">
+                        <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                    </button>
+                </div>
+            </div>
+
+            {error && <div className="rounded-xl border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>}
+            {overview?.coverageCapped && <div className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4 text-sm text-amber-200">El periodo superó 10.000 filas diarias; el ranking de páginas puede ser parcial.</div>}
+
+            {loading && !overview ? (
+                <div className="grid min-h-72 place-items-center rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] text-gray-400"><span className="flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Cargando…</span></div>
+            ) : overview ? (
+                <>
+                    <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+                        <Metric label={`Vistas · ${days} d`} value={period.views} icon={Eye} />
+                        <Metric label={`Sesiones únicas · ${days} d`} value={period.unique} icon={Users} />
+                        <Metric label={`Compartidos · ${days} d`} value={period.shares} icon={Share2} />
+                        <Metric label="Vistas autenticadas" value={`${period.authPct}%`} icon={UserCheck} />
+                        <Metric label="Vistas históricas" value={overview.allTime.totalViews} icon={BarChart3} />
+                    </div>
+
+                    <div className="grid gap-5 lg:grid-cols-[1.45fr,1fr]">
+                        <div className="rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-5">
+                            <div className="mb-4 flex items-center justify-between"><h3 className="font-bold text-white">Evolución diaria</h3><span className="text-xs text-gray-500">Zona horaria: Europe/Madrid</span></div>
+                            <div className="flex h-44 items-end gap-1">
+                                {overview.daily.map((row) => (
+                                    <div key={row.date} className="group relative flex h-full flex-1 items-end" title={`${row.date}: ${row.totalViews} vistas · ${row.uniqueSessions} sesiones`}>
+                                        <div className="w-full min-w-[2px] rounded-t bg-violet-400/70 group-hover:bg-violet-300" style={{ height: `${row.totalViews ? Math.max(4, (row.totalViews / period.maxViews) * 100) : 1}%` }} />
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                            <Breakdown title="Adquisición histórica" values={overview.allTime.bySource} labels={SOURCE_LABELS} />
+                            <Breakdown title="Dispositivos históricos" values={overview.allTime.byDevice} labels={DEVICE_LABELS} icon={<Monitor className="h-4 w-4 text-violet-300" />} />
+                            <Breakdown title="Cómo se comparte" values={overview.allTime.byShareChannel} labels={SHARE_CHANNEL_LABELS} icon={<Share2 className="h-4 w-4 text-violet-300" />} />
+                        </div>
+                    </div>
+
+                    {selectedPath && (
+                        <div className="rounded-2xl border border-violet-500/25 bg-violet-500/5 p-5">
+                            <div className="flex items-start justify-between gap-4">
+                                <div><p className="text-xs font-black uppercase tracking-wider text-violet-300">Detalle de página</p><p className="mt-1 break-all font-mono text-sm text-white">{selectedPath}</p></div>
+                                <button type="button" onClick={() => choosePage(null)} className="rounded-full p-2 text-gray-400 hover:bg-white/10 hover:text-white"><X className="h-4 w-4" /></button>
+                            </div>
+                            {detailLoading ? <p className="mt-4 flex items-center gap-2 text-sm text-gray-400"><Loader2 className="h-4 w-4 animate-spin" /> Cargando detalle…</p> : detail && (
+                                <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-5">
+                                    <SmallMetric label="Vistas totales" value={detail.total.totalViews} />
+                                    <SmallMetric label={`Vistas · ${days} d`} value={sum(detail.daily.map((row) => row.totalViews))} />
+                                    <SmallMetric label={`Sesiones · ${days} d`} value={sum(detail.daily.map((row) => row.uniqueSessions))} />
+                                    <SmallMetric label={`Compartidos · ${days} d`} value={sum(detail.daily.map((row) => row.totalShares))} />
+                                    <SmallMetric label="Última vista" value={detail.total.lastViewedAtMs ? new Date(detail.total.lastViewedAtMs).toLocaleDateString('es-ES') : '—'} />
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    <div className="rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-5">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div><h3 className="font-bold text-white">Páginas con más tráfico</h3><p className="text-xs text-gray-500">Ranking del periodo seleccionado, hasta 100 páginas.</p></div>
+                            <label className="relative block"><Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" /><input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Buscar página…" className="rounded-xl border border-white/10 bg-black/25 py-2 pl-9 pr-3 text-sm text-white outline-none focus:border-violet-400/50" /></label>
+                        </div>
+                        <div className="mt-4 overflow-x-auto">
+                            <table className="w-full min-w-[700px] text-sm">
+                                <thead><tr className="border-b border-white/10 text-left text-[11px] uppercase tracking-wider text-gray-500"><th className="px-3 py-2">Página</th><th className="px-3 py-2">Tipo</th><th className="px-3 py-2 text-right">Vistas</th><th className="px-3 py-2 text-right">Sesiones</th><th className="px-3 py-2 text-right">Compartidos</th><th className="px-3 py-2 text-right">Autenticadas</th><th className="px-3 py-2" /></tr></thead>
+                                <tbody>{filteredPages.map((page) => (
+                                    <tr key={page.path} className={`border-b border-white/5 hover:bg-white/[0.03] ${selectedPath === page.path ? 'bg-violet-500/10' : ''}`}>
+                                        <td className="max-w-sm px-3 py-3"><p className="truncate font-bold text-white" title={page.title}>{page.title || page.path}</p><p className="truncate font-mono text-[10px] text-gray-500">{page.path}</p></td>
+                                        <td className="px-3 py-3 text-gray-400">{PAGE_TYPE_LABELS[page.pageType] || page.pageType}</td>
+                                        <td className="px-3 py-3 text-right font-bold text-white">{page.totalViews.toLocaleString('es-ES')}</td>
+                                        <td className="px-3 py-3 text-right text-gray-300">{page.uniqueSessions.toLocaleString('es-ES')}</td>
+                                        <td className="px-3 py-3 text-right text-gray-300">{page.totalShares.toLocaleString('es-ES')}</td>
+                                        <td className="px-3 py-3 text-right text-gray-300">{page.totalViews ? `${Math.round((page.authenticatedViews / page.totalViews) * 100)}%` : '—'}</td>
+                                        <td className="px-3 py-3"><div className="flex justify-end gap-1"><button type="button" onClick={() => choosePage(page.path)} className="rounded-lg p-2 text-violet-300 hover:bg-violet-500/10" title="Ver detalle"><Eye className="h-4 w-4" /></button><Link to={page.path} target="_blank" className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-white" title="Abrir página">↗</Link></div></td>
+                                    </tr>
+                                ))}</tbody>
+                            </table>
+                            {filteredPages.length === 0 && <p className="py-10 text-center text-sm text-gray-500">Aún no hay páginas con datos en este periodo.</p>}
+                        </div>
+                    </div>
+                </>
+            ) : null}
+        </div>
+    );
+};
+
+const Metric: React.FC<{ label: string; value: number | string; icon: React.ElementType }> = ({ label, value, icon: Icon }) => (
+    <div className="rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-4"><div className="flex items-center gap-2 text-xs text-gray-400"><Icon className="h-4 w-4 text-violet-300" />{label}</div><p className="mt-2 text-3xl font-black text-white">{typeof value === 'number' ? value.toLocaleString('es-ES') : value}</p></div>
+);
+const SmallMetric: React.FC<{ label: string; value: number | string }> = ({ label, value }) => <div className="rounded-xl border border-white/10 bg-black/15 p-3"><p className="text-[11px] text-gray-500">{label}</p><p className="mt-1 text-xl font-black text-white">{typeof value === 'number' ? value.toLocaleString('es-ES') : value}</p></div>;
+const Breakdown: React.FC<{ title: string; values: Record<string, number>; labels: Record<string, string>; icon?: React.ReactNode }> = ({ title, values, labels, icon }) => {
+    const rows = Object.entries(values).sort((a, b) => b[1] - a[1]);
+    const total = Math.max(1, sum(rows.map(([, value]) => value)));
+    return <div className="rounded-2xl border border-white/10 bg-[var(--lt-card-strong)] p-4"><h3 className="mb-3 flex items-center gap-2 text-sm font-bold text-white">{icon}{title}</h3>{rows.length === 0 ? <p className="text-xs text-gray-500">Sin datos todavía.</p> : <div className="space-y-2">{rows.map(([key, value]) => <div key={key}><div className="mb-1 flex justify-between text-xs"><span className="text-gray-400">{labels[key] || key}</span><span className="font-bold text-white">{value.toLocaleString('es-ES')}</span></div><div className="h-1.5 overflow-hidden rounded-full bg-white/5"><div className="h-full rounded-full bg-violet-400" style={{ width: `${(value / total) * 100}%` }} /></div></div>)}</div>}</div>;
+};

--- a/frontend/src/components/developer/ProProposalsTab.tsx
+++ b/frontend/src/components/developer/ProProposalsTab.tsx
@@ -13,6 +13,8 @@ import {
     reviewItemProposal,
     reviewItemSpotlight,
     reviewSponsoredPlacement,
+    SPOTLIGHT_RADIUS_STEP_KM,
+    updateSpotlightPricing,
     type ItemProposal,
     type ItemSpotlight,
     type SponsoredPlacement,
@@ -85,9 +87,9 @@ export const ProProposalsTab: React.FC = () => {
         setSavingPricing(true);
         setMessage(null);
         try {
-            // config/{id} permite escritura directa de jefe según las reglas.
-            await setDoc(doc(db, 'config', 'sponsoredPricing'), pricing, { merge: true });
-            setMessage({ type: 'success', text: 'Fórmula de precios guardada.' });
+            const savedPricing = await updateSpotlightPricing(pricing);
+            setPricing(savedPricing);
+            setMessage({ type: 'success', text: 'Fórmula de precios guardada y validada en el servidor.' });
         } catch (error) {
             console.error('ProProposalsTab: save pricing failed', error);
             setMessage({ type: 'error', text: getErrorMessage(error, 'No se pudo guardar la fórmula de precios.') });
@@ -225,7 +227,7 @@ export const ProProposalsTab: React.FC = () => {
                     <div>
                         <h2 className="text-2xl font-bold text-white flex items-center gap-2">
                             <Inbox className="w-6 h-6 text-indigo-300" />
-                            Propuestas Pro
+                            Gestión Pro y patrocinios
                         </h2>
                         <p className="mt-1 max-w-2xl text-sm text-gray-400">
                             Propuestas de carta de los negocios (fusiones de duplicados, renombres, mover reseñas)
@@ -365,6 +367,11 @@ export const ProProposalsTab: React.FC = () => {
                                             {placement.startsAt || '—'} → {placement.endsAt || 'sin fin'}
                                         </p>
                                     )}
+                                    {placement.status === 'active' && (
+                                        <p className="mt-1 text-xs text-cyan-200/80">
+                                            {placement.metrics.impressions} impresiones únicas · {placement.metrics.clicks} clics · CTR {placement.metrics.impressions > 0 ? ((placement.metrics.clicks / placement.metrics.impressions) * 100).toFixed(1) : '0,0'}%
+                                        </p>
+                                    )}
                                 </div>
                                 <div className="flex shrink-0 gap-2">
                                     {placement.status === 'requested' && (
@@ -445,6 +452,11 @@ export const ProProposalsTab: React.FC = () => {
                                         {typeof spotlight.totalPriceEur === 'number' ? ` · ${spotlight.totalPriceEur.toFixed(2)} €` : ''}
                                         {spotlight.endsAt ? ` · activa hasta ${spotlight.endsAt}` : ' · el periodo empieza al activarla'}
                                     </p>
+                                    {spotlight.status === 'active' && (
+                                        <p className="mt-1 text-xs text-amber-200/80">
+                                            {spotlight.metrics.impressions} impresiones únicas · {spotlight.metrics.clicks} clics · CTR {spotlight.metrics.impressions > 0 ? ((spotlight.metrics.clicks / spotlight.metrics.impressions) * 100).toFixed(1) : '0,0'}%
+                                        </p>
+                                    )}
                                 </div>
                                 <div className="flex shrink-0 gap-2">
                                     {spotlight.status === 'requested' && (
@@ -570,14 +582,14 @@ export const ProProposalsTab: React.FC = () => {
                     Fórmula de precios de platos destacados
                 </h3>
                 <p className="mt-1 text-sm text-gray-400">
-                    Precio por <strong>impulso</strong> = €/km·semana × radio × semanas. Ejemplo con los valores por
-                    defecto: 5 km × 1 semana → {`${(DEFAULT_SPOTLIGHT_PRICING.pricePerKmPerWeek * 5).toFixed(2)}`} €/impulso.
-                    Barato a propósito: quien quiera más visibilidad compra más impulsos (más papeletas en el sorteo),
+                    Precio por <strong>impulso</strong> = precio por tramo de 0,2 km × número de tramos × semanas. Con los valores por
+                    defecto: 1 km × 1 semana → {`${(DEFAULT_SPOTLIGHT_PRICING.pricePerRadiusStepPerWeek * (1 / SPOTLIGHT_RADIUS_STEP_KM)).toFixed(2)}`} €/impulso.
+                    Quien quiera más visibilidad compra más impulsos (más papeletas en el sorteo),
                     no tarifas más caras.
                 </p>
                 <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
                     {([
-                        ['pricePerKmPerWeek', '€ por km·semana'],
+                        ['pricePerRadiusStepPerWeek', '€ por cada 0,2 km · semana'],
                         ['minRadiusKm', 'Radio mínimo (km)'],
                         ['maxRadiusKm', 'Radio máximo (km)'],
                         ['maxUnitsPerCampaign', 'Impulsos máx.'],
@@ -588,7 +600,7 @@ export const ProProposalsTab: React.FC = () => {
                             <input
                                 type="number"
                                 min={0}
-                                step={key === 'pricePerKmPerWeek' ? 0.05 : key === 'minRadiusKm' ? 0.5 : 1}
+                                step={key === 'pricePerRadiusStepPerWeek' ? 0.01 : (key === 'minRadiusKm' || key === 'maxRadiusKm') ? SPOTLIGHT_RADIUS_STEP_KM : 1}
                                 value={pricing[key]}
                                 onChange={(event) => setPricing((prev) => ({ ...prev, [key]: Number(event.target.value) || 0 }))}
                                 className="w-full rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none focus:border-[var(--lt-accent-border)]"

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -195,6 +195,24 @@ async function fetchReviewsPage(
             });
             hasMore = false;
 
+        } else if (userId && listId) {
+            // En perfiles, filtrar por lista debe lanzar una consulta propia. No
+            // usamos las reseñas ya paginadas del perfil porque eso obligaría a
+            // recorrer primero todo el feed. Al consultar la subcolección de la
+            // lista evitamos además un índice compuesto userId+listId+createdAt.
+            const pageSize = customLimit || 20;
+            const constraints: any[] = [where('userId', '==', userId)];
+            if (lastDoc) constraints.push(startAfter(lastDoc));
+            constraints.push(limit(pageSize));
+
+            const snap = await getDocs(query(collection(db, 'lists', listId, 'reviews'), ...constraints));
+            hasMore = snap.docs.length >= pageSize;
+            if (snap.docs.length > 0) nextLastDoc = snap.docs[snap.docs.length - 1];
+            rawReviews = snap.docs.map(d => ({
+                id: d.id,
+                ...(d.data() as any),
+                listId,
+            } as ReviewEntity));
         } else {
             const constraints: any[] = [];
             if (userId) constraints.push(where('userId', '==', userId));
@@ -247,10 +265,11 @@ export interface UseReviewsOptions {
     followingIds?: string[];
     limit?: number;
     sinceDate?: Date;
+    enabled?: boolean;
 }
 
 export const useReviews = (options: UseReviewsOptions | 'recent' | 'trending' | 'following' = 'recent') => {
-    const { type = 'recent', userId, listId, followingIds, limit: customLimit, sinceDate } =
+    const { type = 'recent', userId, listId, followingIds, limit: customLimit, sinceDate, enabled = true } =
         typeof options === 'string' ? { type: options } : options;
 
     const qc = useQueryClient();
@@ -262,7 +281,7 @@ export const useReviews = (options: UseReviewsOptions | 'recent' | 'trending' | 
             followingIds: (followingIds ?? []).join(','),
             sinceDate: sinceDate?.getTime() ?? null,
         }],
-        enabled: !(type === 'following' && (!followingIds || followingIds.length === 0)),
+        enabled: enabled && !(type === 'following' && (!followingIds || followingIds.length === 0)),
         staleTime: type === 'following' ? 0 : 5 * 60 * 1000,
         gcTime: type === 'following' ? 0 : 10 * 60 * 1000,
         initialPageParam: null as any,

--- a/frontend/src/pages/DeveloperPage.tsx
+++ b/frontend/src/pages/DeveloperPage.tsx
@@ -8,7 +8,7 @@ import { db, functions, storage } from '../firebase';
 import { collection, collectionGroup, query, where, getDocs, doc, getDoc, getDocFromServer, limit as firestoreLimit, setDoc, updateDoc, deleteDoc, writeBatch, arrayUnion, onSnapshot, orderBy } from 'firebase/firestore';
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { useQueryClient } from '@tanstack/react-query';
-import { Terminal, Search, AlertCircle, RefreshCw, List as ListIcon, MapPin, Layers, Database, CloudLightning, Tag, CheckCircle, X, Upload, Flag, MessageSquare, Palette, Users, SlidersHorizontal, ExternalLink, RefreshCcw, FileDown, ClipboardList, Activity, Building2, Sparkles } from 'lucide-react';
+import { Terminal, Search, AlertCircle, RefreshCw, List as ListIcon, MapPin, MapPinned, Layers, Database, CloudLightning, Tag, CheckCircle, X, Upload, Flag, MessageSquare, Palette, Users, SlidersHorizontal, ExternalLink, RefreshCcw, FileDown, ClipboardList, Activity, BarChart3, Building2, Sparkles } from 'lucide-react';
 import { invalidateDoc } from '../lib/queryCache';
 
 const FUNCTIONS_REGION = 'europe-west1';
@@ -22,6 +22,8 @@ const UsersManagerTab = React.lazy(() => import('../components/developer/UsersMa
 const DeveloperItemModal = React.lazy(() => import('../components/developer/DeveloperItemModal').then(module => ({ default: module.DeveloperItemModal })));
 const UserDataExportTab = React.lazy(() => import('../components/developer/UserDataExportTab').then(module => ({ default: module.UserDataExportTab })));
 const ApiUsageTab = React.lazy(() => import('../components/developer/ApiUsageTab').then(module => ({ default: module.ApiUsageTab })));
+const PageAnalyticsTab = React.lazy(() => import('../components/developer/PageAnalyticsTab').then(module => ({ default: module.PageAnalyticsTab })));
+const GeoAnalyticsTab = React.lazy(() => import('../components/developer/GeoAnalyticsTab').then(module => ({ default: module.GeoAnalyticsTab })));
 const BusinessClaimsManagerTab = React.lazy(() => import('../components/developer/BusinessClaimsManagerTab').then(module => ({ default: module.BusinessClaimsManagerTab })));
 const BusinessManagersTab = React.lazy(() => import('../components/developer/BusinessManagersTab').then(module => ({ default: module.BusinessManagersTab })));
 const PlansManagerTab = React.lazy(() => import('../components/developer/PlansManagerTab').then(module => ({ default: module.PlansManagerTab })));
@@ -29,7 +31,7 @@ const ProProposalsTab = React.lazy(() => import('../components/developer/ProProp
 const BackupsTab = React.lazy(() => import('../components/developer/BackupsTab').then(module => ({ default: module.BackupsTab })));
 const ReviewsConsolidationCard = React.lazy(() => import('../components/developer/ReviewsConsolidationCard').then(module => ({ default: module.ReviewsConsolidationCard })));
 
-type DeveloperActiveTab = 'console' | 'algolia' | 'maintenance' | 'gamification' | 'reports' | 'businessClaims' | 'businessManagers' | 'plans' | 'proProposals' | 'backups' | 'branding' | 'others' | 'proyectos' | 'lists' | 'places' | 'reviews' | 'tags' | 'usuarios' | 'rgpd' | 'audit' | 'apiusage';
+type DeveloperActiveTab = 'console' | 'algolia' | 'maintenance' | 'gamification' | 'reports' | 'businessClaims' | 'businessManagers' | 'plans' | 'proProposals' | 'backups' | 'branding' | 'others' | 'proyectos' | 'lists' | 'places' | 'reviews' | 'tags' | 'usuarios' | 'rgpd' | 'audit' | 'apiusage' | 'analytics' | 'geoAnalytics';
 
 const DeveloperTabFallback: React.FC = () => (
     <div className="rounded-xl border border-white/10 bg-[var(--lt-card-strong)]/60 p-8 text-center text-sm text-gray-400">
@@ -58,7 +60,7 @@ export const DeveloperPage: React.FC = () => {
     const { profile, loading: loadingProfile } = useUserProfile(user?.uid);
     const [searchParams] = useSearchParams();
     const requestedTab = searchParams.get('tab');
-    const initialTab: DeveloperActiveTab = requestedTab === 'businessClaims' || requestedTab === 'businessManagers' || requestedTab === 'plans' ? requestedTab : 'console';
+    const initialTab: DeveloperActiveTab = requestedTab === 'businessClaims' || requestedTab === 'businessManagers' || requestedTab === 'plans' || requestedTab === 'analytics' || requestedTab === 'geoAnalytics' ? requestedTab : 'console';
     const highlightClaimId = searchParams.get('claimId');
     const [activeTab, setActiveTab] = useState<DeveloperActiveTab>(initialTab);
     // Reactive: un usuario al que se le acaba de quitar el rol 'jefe' pierde
@@ -724,7 +726,7 @@ export const DeveloperPage: React.FC = () => {
 
                     {/* Sidebar Nav */}
                     <nav className={`
-                        fixed md:static inset-y-0 left-0 z-40 w-64 bg-[#121624] border-r border-white/5 flex flex-col pt-20 md:pt-6 shrink-0 transition-transform duration-300 ease-in-out
+                        fixed md:static inset-y-0 left-0 z-40 w-64 bg-[#121624] border-r border-white/5 flex flex-col overflow-y-auto pb-6 pt-20 md:pt-6 shrink-0 transition-transform duration-300 ease-in-out
                         ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
                     `}>
                         <div className="px-6 mb-6 md:hidden">
@@ -783,7 +785,7 @@ export const DeveloperPage: React.FC = () => {
                             onClick={() => { setActiveTab('proProposals'); setIsSidebarOpen(false); }}
                             className={`flex items-center gap-3 px-6 py-3 border-l-2 transition-all ${activeTab === 'proProposals' ? 'border-indigo-400 bg-indigo-400/5 text-white' : 'border-transparent text-gray-500 hover:text-gray-300'}`}
                         >
-                            <ClipboardList className="w-5 h-5" /> Propuestas Pro
+                            <ClipboardList className="w-5 h-5" /> Patrocinios y Pro
                         </button>
                         <button
                             onClick={() => { setActiveTab('backups'); setIsSidebarOpen(false); }}
@@ -856,6 +858,18 @@ export const DeveloperPage: React.FC = () => {
                             className={`flex items-center gap-3 px-6 py-3 border-l-2 transition-all ${activeTab === 'apiusage' ? 'border-[var(--lt-accent)] bg-[var(--lt-accent-soft)] text-white' : 'border-transparent text-gray-500 hover:text-gray-300'}`}
                         >
                             <Activity className="w-5 h-5" /> API Usage
+                        </button>
+                        <button
+                            onClick={() => { setActiveTab('analytics'); setIsSidebarOpen(false); }}
+                            className={`flex items-center gap-3 px-6 py-3 border-l-2 transition-all ${activeTab === 'analytics' ? 'border-violet-400 bg-violet-400/5 text-white' : 'border-transparent text-gray-500 hover:text-gray-300'}`}
+                        >
+                            <BarChart3 className="w-5 h-5" /> Analítica páginas
+                        </button>
+                        <button
+                            onClick={() => { setActiveTab('geoAnalytics'); setIsSidebarOpen(false); }}
+                            className={`flex items-center gap-3 px-6 py-3 border-l-2 transition-all ${activeTab === 'geoAnalytics' ? 'border-cyan-400 bg-cyan-400/5 text-white' : 'border-transparent text-gray-500 hover:text-gray-300'}`}
+                        >
+                            <MapPinned className="w-5 h-5" /> Mapas analíticos
                         </button>
                     </nav>
 
@@ -2369,6 +2383,16 @@ export const DeveloperPage: React.FC = () => {
                                     <ApiUsageTab />
                                 </DeveloperLazyPanel>
                             </div>
+                        )}
+                        {activeTab === 'analytics' && (
+                            <DeveloperLazyPanel>
+                                <PageAnalyticsTab />
+                            </DeveloperLazyPanel>
+                        )}
+                        {activeTab === 'geoAnalytics' && (
+                            <DeveloperLazyPanel>
+                                <GeoAnalyticsTab />
+                            </DeveloperLazyPanel>
                         )}
                     </main >
                 </div >

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -1011,10 +1011,21 @@ export const GroupPage: React.FC = () => {
                     route: groupRoute,
                     url: groupShareUrl,
                     imageUrl: stats?.mainPhoto || undefined,
+                    imageUrls: stats?.photos || [],
                     score: stats?.avg,
                     reviewCount: stats?.count,
                     criteriaStats: stats
-                        ? [...stats.ponderable, ...stats.nonPonderable]
+                        ? stats.ponderable
+                            .slice(0, 6)
+                            .map((criterion) => ({
+                                key: criterion.key,
+                                label: criterion.label,
+                                score: criterion.avg,
+                                count: criterion.count,
+                            }))
+                        : [],
+                    nonPonderableStats: stats
+                        ? stats.nonPonderable
                             .slice(0, 6)
                             .map((criterion) => ({
                                 key: criterion.key,

--- a/frontend/src/pages/ListPage.tsx
+++ b/frontend/src/pages/ListPage.tsx
@@ -20,7 +20,7 @@ import { useLike } from '../hooks/useLike';
 import { useLocation } from '../hooks/useLocation';
 import { doc, getDoc, collection, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
-import { buildCriteriaStats } from '../utils/shareCriteria';
+import { buildShareCriteriaGroups } from '../utils/shareCriteria';
 import { buildPublicRouteUrl } from '../utils/publicUrl';
 import { EntityHero } from '../components/EntityHero';
 import { SponsoredItemsCarousel } from '../components/business/SponsoredItemsCarousel';
@@ -884,6 +884,15 @@ export const ListPage: React.FC = () => {
         ? `${listTypeLabel} de ${parentListName}`
         : listTypeLabel;
     const listShareImage = list.thumbnailUrl || list.mainImageUrl || list.photoUrl || list.coverUrl || list.imageUrl || undefined;
+    const listShareImages = Array.from(new Set([
+        listShareImage,
+        ...reviews.flatMap((review) => [
+            ...(review.photoUrls || []),
+            review.photoUrl,
+            review.placeMainImage,
+        ]),
+    ].filter((value): value is string => Boolean(value))));
+    const listShareCriteria = buildShareCriteriaGroups(list.criteriaAverages, list.criteriaDefinition);
 
     return (
         <div className="min-h-screen bg-[var(--lt-bg)] pb-20 transition-colors duration-300">
@@ -1420,10 +1429,13 @@ export const ListPage: React.FC = () => {
                     route: `/list/${list.id}`,
                     url: listShareUrl,
                     imageUrl: listShareImage,
+                    imageUrls: listShareImages,
                     score: list.averageRating || list.avgScore,
                     reviewCount: list.reviewCount,
+                    authorId: list.userId,
                     authorName: list.authorName,
-                    criteriaStats: buildCriteriaStats(list.criteriaAverages, list.criteriaDefinition),
+                    criteriaStats: listShareCriteria.ponderable,
+                    nonPonderableStats: listShareCriteria.nonPonderable,
                 }}
             />
 

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -40,7 +40,7 @@ export const PrivacyPage: React.FC = () => {
                     </Link>
 
                     <div className="bg-[var(--lt-card-strong)]/60 border border-white/10 rounded-3xl p-6 sm:p-8 mb-6">
-                        <p className="text-xs text-gray-500 mb-6">Última actualización: 12 de abril de 2026</p>
+                        <p className="text-xs text-gray-500 mb-6">Última actualización: 20 de agosto de 2026</p>
 
                         <p className="text-gray-300 text-sm leading-relaxed mb-8">
                             En Listopic nos tomamos muy en serio la privacidad de nuestros usuarios. Esta política explica qué datos recogemos, cómo los usamos y cuáles son tus derechos, de acuerdo con el Reglamento General de Protección de Datos (RGPD) de la Unión Europea y la legislación española aplicable.
@@ -54,8 +54,8 @@ export const PrivacyPage: React.FC = () => {
                         <Section title="2. Datos que recogemos">
                             <p><span className="text-white font-medium">Datos de cuenta:</span> nombre, dirección de correo electrónico y foto de perfil, obtenidos mediante Google Sign-In o registro manual con contraseña.</p>
                             <p><span className="text-white font-medium">Contenido generado por el usuario:</span> listas, reseñas, valoraciones, comentarios y fotografías que publicas en la app.</p>
-                            <p><span className="text-white font-medium">Datos de uso:</span> actividad dentro de la app (listas visitadas, reseñas realizadas, interacciones sociales).</p>
-                            <p><span className="text-white font-medium">Datos de ubicación:</span> únicamente si concedes permiso explícito, para mostrar lugares cercanos a tu posición.</p>
+                            <p><span className="text-white font-medium">Datos de uso:</span> actividad dentro de la app y analítica agregada de páginas (ruta visitada, origen general de la navegación, tipo de dispositivo, compartidos y si existe una sesión autenticada). No guardamos la IP ni un historial individual de navegación en este sistema de analítica.</p>
+                            <p><span className="text-white font-medium">Datos de ubicación:</span> únicamente si concedes permiso explícito, para mostrar lugares cercanos y elaborar estadísticas geográficas agregadas. Para la analítica, la coordenada se redondea en el dispositivo a una cuadrícula aproximada de 0,1 grados; el servidor no recibe ni almacena la posición precisa y solo muestra zonas que alcanzan un mínimo de sesiones.</p>
                             <p><span className="text-white font-medium">Datos técnicos:</span> identificador de instalación y sistema operativo, recogidos automáticamente por Firebase para el correcto funcionamiento del servicio.</p>
                         </Section>
 
@@ -102,7 +102,8 @@ export const PrivacyPage: React.FC = () => {
                         </Section>
 
                         <Section title="8. Uso de Cookies">
-                            <p>Listopic utiliza exclusivamente cookies técnicas y de sesión estrictamente necesarias para el funcionamiento de la aplicación, como mantener tu sesión de usuario activa y segura (gestionadas por Google Firebase). No utilizamos cookies de terceros para publicidad, rastreo ni análisis de comportamiento. Por ello, conforme a la normativa de protección de datos (RGPD/LSSI), no es necesario un banner de consentimiento expreso para cookies.</p>
+                            <p>Listopic utiliza exclusivamente cookies técnicas y de sesión necesarias para el funcionamiento de la aplicación, como mantener tu sesión de usuario activa y segura (gestionadas por Google Firebase). No utilizamos cookies de terceros para publicidad ni analítica.</p>
+                            <p>Para evitar contar varias veces una misma visita, nuestra analítica propia crea un identificador aleatorio en el almacenamiento de sesión del dispositivo. En el servidor solo se utiliza una huella no reversible y temporal, que caduca automáticamente; no se usa para publicidad, seguimiento entre sitios ni para identificar personalmente al usuario.</p>
                         </Section>
 
                         <Section title="9. Tus derechos">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -91,6 +91,7 @@ import {
   normalizeEarnedBadgeIds,
 } from "../utils/gamification";
 import { buildPublicRouteUrl } from "../utils/publicUrl";
+import { getSelectedProfileReviewListId, selectProfileReviewResults } from "../utils/profileReviewFilter";
 import { EntityHero } from "../components/EntityHero";
 
 interface ListRatingStats {
@@ -386,12 +387,25 @@ export const ProfilePage: React.FC = () => {
 
   const {
     reviews: fetchedReviews,
-    loading: loadingReviews,
+    loading: baseLoadingReviews,
     refresh: refreshReviews,
-    fetchMore,
-    hasMore,
-    loadingMore,
+    fetchMore: fetchMoreBaseReviews,
+    hasMore: hasMoreBaseReviews,
+    loadingMore: loadingMoreBaseReviews,
   } = useReviews({ type: "recent", userId: targetUserId, limit: reviewViewMode === "gallery" ? 10 : 3 });
+  const selectedReviewListId = getSelectedProfileReviewListId(reviewListFilter);
+  const filteredReviewQuery = useReviews({
+    type: "recent",
+    userId: targetUserId,
+    listId: selectedReviewListId,
+    limit: reviewViewMode === "gallery" ? 20 : 10,
+    enabled: Boolean(selectedReviewListId),
+  });
+  const isReviewListFilterActive = Boolean(selectedReviewListId);
+  const fetchMore = isReviewListFilterActive ? filteredReviewQuery.fetchMore : fetchMoreBaseReviews;
+  const hasMore = isReviewListFilterActive ? filteredReviewQuery.hasMore : hasMoreBaseReviews;
+  const loadingMore = isReviewListFilterActive ? filteredReviewQuery.loadingMore : loadingMoreBaseReviews;
+  const loadingReviews = isReviewListFilterActive ? filteredReviewQuery.loading : baseLoadingReviews;
   const [localReviews, setLocalReviews] = useState<any[]>([]);
 
   // Infinite Scroll Effect (Must be after useReviews)
@@ -740,7 +754,7 @@ export const ProfilePage: React.FC = () => {
 
   useEffect(() => {
     if (!targetUserId) return;
-    if (!isOwnProfile && loadingReviews) return;
+    if (!isOwnProfile && baseLoadingReviews) return;
     if (statsLoadedUserId === targetUserId) return;
 
     let cancelled = false;
@@ -1215,7 +1229,7 @@ export const ProfilePage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [isOwnProfile, loadingReviews, localReviews.length, profile?.reviewCount, profile?.reviewsCount, targetUserId, statsLoadedUserId, user?.uid]);
+  }, [isOwnProfile, baseLoadingReviews, localReviews.length, profile?.reviewCount, profile?.reviewsCount, targetUserId, statsLoadedUserId, user?.uid]);
 
   const handleDeleteReview = (id: string) => {
     setLocalReviews((prev) => prev.filter((r) => r.id !== id));
@@ -1365,10 +1379,11 @@ export const ProfilePage: React.FC = () => {
   );
 
   const sortedProfileReviews = useMemo(() => {
-    const filteredReviews =
-      reviewListFilter === "all"
-        ? localReviews
-        : localReviews.filter((r) => r.listId === reviewListFilter);
+    const filteredReviews = selectProfileReviewResults(
+      reviewListFilter,
+      localReviews,
+      filteredReviewQuery.reviews,
+    );
 
     const base = [...filteredReviews];
     if (reviewSortMode === "top_rated") {
@@ -1394,7 +1409,7 @@ export const ProfilePage: React.FC = () => {
         getReviewCreatedAtMillis(b.createdAt) -
         getReviewCreatedAtMillis(a.createdAt),
     );
-  }, [localReviews, reviewSortMode, reviewListFilter]);
+  }, [filteredReviewQuery.reviews, localReviews, reviewSortMode, reviewListFilter]);
 
   const availableListsForFilter = useMemo(() => {
     const listMap = new Map();
@@ -3453,6 +3468,15 @@ export const ProfilePage: React.FC = () => {
           route: `/profile/${targetUserId}`,
           url: profileShareUrl,
           imageUrl: profile.photoUrl || undefined,
+          imageUrls: profile.photoUrl ? [profile.photoUrl] : [],
+          profileStats: [
+            { key: "level", label: "Nivel", value: levelInfo.level },
+            { key: "reviews", label: "Reseñas", value: gamificationMetrics.reviewsCount },
+            { key: "photos", label: "Fotos", value: gamificationMetrics.photosCount },
+            { key: "places", label: "Lugares", value: gamificationMetrics.placeCount },
+            { key: "lists", label: "Listas", value: profileListsCount },
+            { key: "followers", label: "Seguidores", value: profile.followersCount || 0 },
+          ],
         }}
       />
       <ReportModal

--- a/frontend/src/services/AnalyticsService.ts
+++ b/frontend/src/services/AnalyticsService.ts
@@ -1,0 +1,224 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase';
+import type { ShareEntityPayload } from '../types/share';
+
+export type AnalyticsDevice = 'mobile' | 'tablet' | 'desktop';
+export type AnalyticsSource = 'direct' | 'internal' | 'search' | 'social' | 'external';
+export type AnalyticsShareChannel = 'whatsapp' | 'clipboard' | 'image' | 'chat';
+
+export interface AnalyticsBreakdown {
+    path: string;
+    title: string;
+    pageType: string;
+    totalViews: number;
+    uniqueSessions: number;
+    authenticatedViews: number;
+    anonymousViews: number;
+    totalShares: number;
+    shareActions: number;
+    byDevice: Record<string, number>;
+    bySource: Record<string, number>;
+    byShareChannel: Record<string, number>;
+    byShareEntityType: Record<string, number>;
+    firstViewedAtMs: number | null;
+    lastViewedAtMs: number | null;
+    lastSharedAtMs: number | null;
+}
+
+export interface AnalyticsDailyRow extends AnalyticsBreakdown {
+    date: string;
+}
+
+export interface PageAnalyticsResult {
+    path: string;
+    days: number;
+    total: AnalyticsBreakdown;
+    daily: AnalyticsDailyRow[];
+}
+
+export interface AnalyticsOverviewResult {
+    days: number;
+    fromDate: string;
+    coverageCapped: boolean;
+    allTime: AnalyticsBreakdown;
+    daily: AnalyticsDailyRow[];
+    topPages: AnalyticsBreakdown[];
+}
+
+export interface PlaceAnalyticsDaily {
+    date: string;
+    reviews: number;
+    totalShares: number;
+    shareActions: number;
+    byShareChannel: Record<string, number>;
+    byShareEntityType: Record<string, number>;
+}
+
+export interface BusinessPlaceAnalyticsResult {
+    placeId: string;
+    days: number;
+    page: PageAnalyticsResult;
+    relatedDaily: PlaceAnalyticsDaily[];
+}
+
+export interface AnalyticsHeatPoint {
+    id: string;
+    lat: number;
+    lng: number;
+    count: number;
+    label?: string;
+    placeId?: string;
+}
+
+export interface AnalyticsHeatmapsResult {
+    days: number;
+    fromDate: string;
+    privacyThreshold: number;
+    coverageCapped: boolean;
+    suppressedConnections: number;
+    connections: AnalyticsHeatPoint[];
+    reviews: AnalyticsHeatPoint[];
+}
+
+export interface ReviewHeatmapBackfillResult {
+    scanned: number;
+    aggregatedRows: number;
+    skipped: number;
+    coverageCapped: boolean;
+}
+
+const SESSION_STORAGE_KEY = 'listopicAnalyticsSession';
+let trackedInitialRoute = false;
+
+export const normalizeAnalyticsPath = (pathname: string): string => {
+    const withoutQuery = pathname.split(/[?#]/, 1)[0] || '/';
+    const normalized = withoutQuery.replace(/\/{2,}/g, '/').replace(/\/$/, '');
+    return normalized || '/';
+};
+
+export const isTrackableAnalyticsPath = (pathname: string): boolean => {
+    const path = normalizeAnalyticsPath(pathname);
+    return path === '/'
+        || path === '/search'
+        || path === '/users'
+        || /^\/list\/[^/]+$/.test(path)
+        || /^\/place\/[^/]+$/.test(path)
+        || /^\/group\/[^/]+(?:\/.*)?$/.test(path)
+        || /^\/profile\/[^/]+$/.test(path)
+        || ['/about', '/privacy', '/terms', '/child-safety', '/istari-core'].includes(path);
+};
+
+const newSessionId = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}_${Math.random().toString(36).slice(2)}`;
+};
+
+const newEventId = (): string => newSessionId();
+
+export const getAnalyticsSessionId = (): string => {
+    try {
+        const current = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+        if (current && current.length >= 16) return current;
+        const created = newSessionId();
+        window.sessionStorage.setItem(SESSION_STORAGE_KEY, created);
+        return created;
+    } catch {
+        return newSessionId();
+    }
+};
+
+const detectDevice = (): AnalyticsDevice => {
+    const width = window.innerWidth;
+    if (width < 768) return 'mobile';
+    if (width < 1100) return 'tablet';
+    return 'desktop';
+};
+
+const detectInitialSource = (): AnalyticsSource => {
+    if (!document.referrer) return 'direct';
+    try {
+        const referrer = new URL(document.referrer);
+        if (referrer.hostname === window.location.hostname) return 'internal';
+        if (/(google|bing|duckduckgo|yahoo|ecosia)\./i.test(referrer.hostname)) return 'search';
+        if (/(instagram|facebook|tiktok|twitter|x\.com|linkedin|pinterest)\./i.test(referrer.hostname)) return 'social';
+        return 'external';
+    } catch {
+        return 'external';
+    }
+};
+
+export const recordPageView = async (pathname: string): Promise<void> => {
+    if (import.meta.env.DEV || !isTrackableAnalyticsPath(pathname)) return;
+    const source = trackedInitialRoute ? 'internal' : detectInitialSource();
+    trackedInitialRoute = true;
+    const callable = httpsCallable(functions, 'recordPageView');
+    await callable({
+        path: normalizeAnalyticsPath(pathname),
+        title: document.title,
+        sessionId: getAnalyticsSessionId(),
+        device: detectDevice(),
+        source,
+    });
+};
+
+export const recordShareEvent = async (
+    entity: ShareEntityPayload,
+    channel: AnalyticsShareChannel,
+    count = 1,
+): Promise<void> => {
+    if (import.meta.env.DEV) return;
+    const path = normalizeAnalyticsPath(entity.route || window.location.pathname);
+    if (!isTrackableAnalyticsPath(path)) return;
+    const callable = httpsCallable(functions, 'recordShareEvent');
+    await callable({
+        path,
+        title: entity.title,
+        entityType: entity.type,
+        entityId: entity.id || '',
+        channel,
+        count,
+        eventId: newEventId(),
+    });
+};
+
+export const recordConnectionLocation = async (latitude: number, longitude: number): Promise<void> => {
+    if (import.meta.env.DEV || !Number.isFinite(latitude) || !Number.isFinite(longitude)) return;
+    // El servidor vuelve a aplicar la misma reduccion. Nunca enviamos la
+    // coordenada precisa al sistema de analitica.
+    const lat = Number((Math.round(latitude * 10) / 10).toFixed(1));
+    const lng = Number((Math.round(longitude * 10) / 10).toFixed(1));
+    const callable = httpsCallable(functions, 'recordConnectionLocation');
+    await callable({ lat, lng, sessionId: getAnalyticsSessionId() });
+};
+
+export const getPageAnalytics = async (pathname: string, days = 30): Promise<PageAnalyticsResult> => {
+    const callable = httpsCallable<{ path: string; days: number }, PageAnalyticsResult>(functions, 'getPageAnalytics');
+    const result = await callable({ path: normalizeAnalyticsPath(pathname), days });
+    return result.data;
+};
+
+export const getAnalyticsOverview = async (days = 30): Promise<AnalyticsOverviewResult> => {
+    const callable = httpsCallable<{ days: number }, AnalyticsOverviewResult>(functions, 'getAnalyticsOverview');
+    const result = await callable({ days });
+    return result.data;
+};
+
+export const getBusinessPlaceAnalytics = async (placeId: string, days = 30): Promise<BusinessPlaceAnalyticsResult> => {
+    const callable = httpsCallable<{ placeId: string; days: number }, BusinessPlaceAnalyticsResult>(functions, 'getBusinessPlaceAnalytics');
+    const result = await callable({ placeId, days });
+    return result.data;
+};
+
+export const getAnalyticsHeatmaps = async (days = 30): Promise<AnalyticsHeatmapsResult> => {
+    const callable = httpsCallable<{ days: number }, AnalyticsHeatmapsResult>(functions, 'getAnalyticsHeatmaps');
+    const result = await callable({ days });
+    return result.data;
+};
+
+export const backfillReviewHeatmap = async (): Promise<ReviewHeatmapBackfillResult> => {
+    const callable = httpsCallable<Record<string, never>, ReviewHeatmapBackfillResult>(functions, 'adminBackfillReviewHeatmap');
+    const result = await callable({});
+    return result.data;
+};

--- a/frontend/src/services/BusinessProService.test.ts
+++ b/frontend/src/services/BusinessProService.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+    computeSpotlightUnitPrice,
+    DEFAULT_SPOTLIGHT_PRICING,
+} from './BusinessProService';
+
+describe('computeSpotlightUnitPrice', () => {
+    it('calcula el precio por tramos de 0,2 km', () => {
+        expect(computeSpotlightUnitPrice(DEFAULT_SPOTLIGHT_PRICING, 0.2, 1)).toBe(0.08);
+        expect(computeSpotlightUnitPrice(DEFAULT_SPOTLIGHT_PRICING, 1, 1)).toBe(0.4);
+        expect(computeSpotlightUnitPrice(DEFAULT_SPOTLIGHT_PRICING, 2, 2)).toBe(1.6);
+    });
+
+    it('respeta el radio mínimo configurado', () => {
+        const pricing = { ...DEFAULT_SPOTLIGHT_PRICING, minRadiusKm: 0.6 };
+        expect(computeSpotlightUnitPrice(pricing, 0.2, 1)).toBe(0.24);
+    });
+
+    it('evita errores binarios al contar tramos decimales', () => {
+        expect(computeSpotlightUnitPrice(DEFAULT_SPOTLIGHT_PRICING, 1.2, 1)).toBe(0.48);
+    });
+});

--- a/frontend/src/services/BusinessProService.ts
+++ b/frontend/src/services/BusinessProService.ts
@@ -1,6 +1,7 @@
 import { collection, collectionGroup, doc, getDoc, getDocs, limit, query, where } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
-import { db, functions } from '../firebase';
+import { auth, db, functions } from '../firebase';
+import { getAnalyticsSessionId } from './AnalyticsService';
 
 // Datos Business Pro: lectura directa de Firestore (colecciones públicas de solo
 // lectura) y escritura vía callables que validan gestor + plan Pro activo.
@@ -347,6 +348,19 @@ export const reviewItemProposal = async (
 
 export type SponsoredPlacementStatus = 'requested' | 'active' | 'rejected' | 'ended';
 
+export interface SponsoredMetrics {
+    impressions: number;
+    clicks: number;
+}
+
+const mapSponsoredMetrics = (data: Record<string, unknown>): SponsoredMetrics => {
+    const metrics = data.metrics && typeof data.metrics === 'object' ? data.metrics as Record<string, unknown> : {};
+    return {
+        impressions: typeof metrics.impressions === 'number' && metrics.impressions > 0 ? metrics.impressions : 0,
+        clicks: typeof metrics.clicks === 'number' && metrics.clicks > 0 ? metrics.clicks : 0,
+    };
+};
+
 export interface SponsoredPlacement {
     id: string;
     placeId: string;
@@ -359,6 +373,7 @@ export interface SponsoredPlacement {
     endsAt?: string;
     status: SponsoredPlacementStatus;
     adminNotes?: string;
+    metrics: SponsoredMetrics;
     createdAtMs: number;
 }
 
@@ -376,18 +391,22 @@ const mapPlacement = (id: string, data: Record<string, unknown>): SponsoredPlace
         endsAt: typeof data.endsAt === 'string' ? data.endsAt : undefined,
         status: (['requested', 'active', 'rejected', 'ended'].includes(String(data.status)) ? data.status : 'requested') as SponsoredPlacementStatus,
         adminNotes: typeof data.adminNotes === 'string' ? data.adminNotes : undefined,
+        metrics: mapSponsoredMetrics(data),
         createdAtMs: typeof createdAt?.toMillis === 'function' ? createdAt.toMillis() : 0,
     };
 };
 
 export const getPlaceSponsoredPlacements = async (placeId: string): Promise<SponsoredPlacement[]> => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return [];
     const snap = await getDocs(query(
         collection(db, 'sponsoredPlacements'),
-        where('placeId', '==', placeId),
-        limit(50),
+        where('createdBy', '==', uid),
+        limit(100),
     ));
     return snap.docs
         .map((placementDoc) => mapPlacement(placementDoc.id, placementDoc.data() as Record<string, unknown>))
+        .filter((placement) => placement.placeId === placeId)
         .sort((a, b) => b.createdAtMs - a.createdAtMs);
 };
 
@@ -444,9 +463,10 @@ export const reviewSponsoredPlacement = async (
 // en el sorteo del carrusel (2 impulsos = doble probabilidad que 1).
 export const SPOTLIGHT_UNIT_SINGULAR = 'impulso';
 export const SPOTLIGHT_UNIT_PLURAL = 'impulsos';
+export const SPOTLIGHT_RADIUS_STEP_KM = 0.2;
 
 export interface SpotlightPricing {
-    pricePerKmPerWeek: number;
+    pricePerRadiusStepPerWeek: number;
     minRadiusKm: number;
     maxRadiusKm: number;
     maxUnitsPerCampaign: number;
@@ -454,8 +474,8 @@ export interface SpotlightPricing {
 }
 
 export const DEFAULT_SPOTLIGHT_PRICING: SpotlightPricing = {
-    pricePerKmPerWeek: 0.4,
-    minRadiusKm: 0.5,
+    pricePerRadiusStepPerWeek: 0.08,
+    minRadiusKm: 0.2,
     maxRadiusKm: 20,
     maxUnitsPerCampaign: 10,
     maxWeeks: 8,
@@ -469,14 +489,28 @@ export const getSpotlightPricing = async (): Promise<SpotlightPricing> => {
         const value = data[key];
         if (typeof value === 'number' && Number.isFinite(value) && value > 0) merged[key] = value;
     });
+    // Migra de forma transparente la configuración anterior expresada por km.
+    if (!(typeof data.pricePerRadiusStepPerWeek === 'number' && data.pricePerRadiusStepPerWeek > 0)
+        && typeof data.pricePerKmPerWeek === 'number' && data.pricePerKmPerWeek > 0) {
+        merged.pricePerRadiusStepPerWeek = Number((data.pricePerKmPerWeek * SPOTLIGHT_RADIUS_STEP_KM).toFixed(2));
+    }
+    merged.minRadiusKm = Number((Math.ceil(merged.minRadiusKm / SPOTLIGHT_RADIUS_STEP_KM) * SPOTLIGHT_RADIUS_STEP_KM).toFixed(1));
+    merged.maxRadiusKm = Number((Math.floor(merged.maxRadiusKm / SPOTLIGHT_RADIUS_STEP_KM) * SPOTLIGHT_RADIUS_STEP_KM).toFixed(1));
+    if (merged.maxRadiusKm < merged.minRadiusKm) merged.maxRadiusKm = merged.minRadiusKm;
     return merged;
 };
 
-// Precio por impulso = €/km·semana × radio × semanas. Barato a propósito:
-// la visibilidad extra se compra con más impulsos, no con tarifas más caras.
+// Precio por impulso = precio del tramo × nº de tramos de 0,2 km × semanas.
 export const computeSpotlightUnitPrice = (pricing: SpotlightPricing, radiusKm: number, weeks: number): number => {
     const effectiveRadius = Math.max(pricing.minRadiusKm, radiusKm);
-    return Number((pricing.pricePerKmPerWeek * effectiveRadius * weeks).toFixed(2));
+    const radiusSteps = Math.ceil((effectiveRadius / SPOTLIGHT_RADIUS_STEP_KM) - 1e-9);
+    return Number((pricing.pricePerRadiusStepPerWeek * radiusSteps * weeks).toFixed(2));
+};
+
+export const updateSpotlightPricing = async (pricing: SpotlightPricing): Promise<SpotlightPricing> => {
+    const callable = httpsCallable<SpotlightPricing, { pricing: SpotlightPricing }>(functions, 'adminUpdateSpotlightPricing');
+    const result = await callable(pricing);
+    return result.data.pricing;
 };
 
 export type ItemSpotlightStatus = 'requested' | 'active' | 'rejected' | 'ended';
@@ -501,6 +535,7 @@ export interface ItemSpotlight {
     endsAt?: string;
     status: ItemSpotlightStatus;
     adminNotes?: string;
+    metrics: SponsoredMetrics;
     createdAtMs: number;
 }
 
@@ -531,6 +566,7 @@ const mapSpotlight = (id: string, data: Record<string, unknown>): ItemSpotlight 
         endsAt: typeof data.endsAt === 'string' ? data.endsAt : undefined,
         status: (['requested', 'active', 'rejected', 'ended'].includes(String(data.status)) ? data.status : 'requested') as ItemSpotlightStatus,
         adminNotes: typeof data.adminNotes === 'string' ? data.adminNotes : undefined,
+        metrics: mapSponsoredMetrics(data),
         createdAtMs: typeof createdAt?.toMillis === 'function' ? createdAt.toMillis() : 0,
     };
 };
@@ -548,13 +584,16 @@ export const requestItemSpotlight = async (input: {
 };
 
 export const getPlaceItemSpotlights = async (placeId: string): Promise<ItemSpotlight[]> => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return [];
     const snap = await getDocs(query(
         collection(db, 'sponsoredItemSpotlights'),
-        where('placeId', '==', placeId),
-        limit(50),
+        where('createdBy', '==', uid),
+        limit(100),
     ));
     return snap.docs
         .map((spotlightDoc) => mapSpotlight(spotlightDoc.id, spotlightDoc.data() as Record<string, unknown>))
+        .filter((spotlight) => spotlight.placeId === placeId)
         .sort((a, b) => b.createdAtMs - a.createdAtMs);
 };
 
@@ -609,36 +648,49 @@ export const reviewItemSpotlight = async (
     await callable({ spotlightId, decision, adminNotes });
 };
 
-// Lugares con publicidad activa (emplazamientos o impulsos de platos), para
-// marcarlos en los mapas con la chincheta dorada. Cache en memoria de 5 min
-// para no repetir lecturas en cada mapa que se monta.
-let sponsoredPlaceIdsCache: { ids: Set<string>; fetchedAt: number } | null = null;
+export const recordSponsoredEvent = async (
+    campaignType: 'placement' | 'spotlight',
+    campaignId: string,
+    eventType: 'impression' | 'click',
+): Promise<void> => {
+    if (import.meta.env.DEV) return;
+    const callable = httpsCallable(functions, 'recordSponsoredEvent');
+    await callable({ campaignType, campaignId, eventType, sessionId: getAnalyticsSessionId() });
+};
 
-export const getSponsoredPlaceIds = async (): Promise<Set<string>> => {
-    if (sponsoredPlaceIdsCache && Date.now() - sponsoredPlaceIdsCache.fetchedAt < 5 * 60 * 1000) {
-        return sponsoredPlaceIdsCache.ids;
+// Solo los emplazamientos contratados para búsqueda reciben chincheta dorada.
+// Los de home se quedan en home y los impulsos de plato en su carrusel con
+// filtro geográfico; así una campaña no obtiene inventario que no ha comprado.
+let sponsoredSearchCampaignsCache: { campaigns: Map<string, string[]>; fetchedAt: number } | null = null;
+
+export const getSponsoredSearchCampaigns = async (): Promise<Map<string, string[]>> => {
+    if (sponsoredSearchCampaignsCache && Date.now() - sponsoredSearchCampaignsCache.fetchedAt < 5 * 60 * 1000) {
+        return sponsoredSearchCampaignsCache.campaigns;
     }
     const today = new Date().toISOString().slice(0, 10);
     const inDateWindow = (row: { startsAt?: string; endsAt?: string }) =>
         (!row.startsAt || row.startsAt <= today) && (!row.endsAt || row.endsAt >= today);
 
-    const [placementsSnap, spotlightsSnap] = await Promise.all([
-        getDocs(query(collection(db, 'sponsoredPlacements'), where('status', '==', 'active'), limit(100))).catch(() => null),
-        getDocs(query(collection(db, 'sponsoredItemSpotlights'), where('status', '==', 'active'), limit(100))).catch(() => null),
-    ]);
+    const placementsSnap = await getDocs(query(
+        collection(db, 'sponsoredPlacements'),
+        where('status', '==', 'active'),
+        limit(100),
+    )).catch(() => null);
 
-    const ids = new Set<string>();
+    const campaigns = new Map<string, string[]>();
     (placementsSnap?.docs || []).forEach((placementDoc) => {
         const row = mapPlacement(placementDoc.id, placementDoc.data() as Record<string, unknown>);
-        if (row.placeId && inDateWindow(row)) ids.add(row.placeId);
-    });
-    (spotlightsSnap?.docs || []).forEach((spotlightDoc) => {
-        const row = mapSpotlight(spotlightDoc.id, spotlightDoc.data() as Record<string, unknown>);
-        if (row.placeId && inDateWindow(row)) ids.add(row.placeId);
+        if (row.type !== 'search' || !row.placeId || !inDateWindow(row)) return;
+        campaigns.set(row.placeId, [...(campaigns.get(row.placeId) || []), row.id]);
     });
 
-    sponsoredPlaceIdsCache = { ids, fetchedAt: Date.now() };
-    return ids;
+    sponsoredSearchCampaignsCache = { campaigns, fetchedAt: Date.now() };
+    return campaigns;
+};
+
+export const getSponsoredPlaceIds = async (): Promise<Set<string>> => {
+    const campaigns = await getSponsoredSearchCampaigns();
+    return new Set(campaigns.keys());
 };
 
 // Sorteo ponderado sin reemplazo: cada campaña entra con peso = unidades, así

--- a/frontend/src/types/share.ts
+++ b/frontend/src/types/share.ts
@@ -15,6 +15,12 @@ export interface ShareCriteriaStat {
     count?: number;
 }
 
+export interface ShareProfileStat {
+    key: string;
+    label: string;
+    value: number | string;
+}
+
 export interface ShareEntityPayload {
     type: ShareEntityType;
     id?: string;
@@ -24,16 +30,22 @@ export interface ShareEntityPayload {
     route?: string;
     url: string;
     imageUrl?: string;
+    /** Galería de imágenes entre las que se puede elegir al crear la tarjeta. */
+    imageUrls?: string[];
     badgeLabel?: string;
     score?: number;
     reviewCount?: number;
+    authorId?: string;
     authorName?: string;
     authorPhoto?: string;
     authorUserType?: string | string[];
     city?: string;
     criteriaStats?: ShareCriteriaStat[];
+    /** Criterios extra: se dibujan como indicadores circulares, no como barras. */
+    nonPonderableStats?: ShareCriteriaStat[];
     referenceCriteriaStats?: ShareCriteriaStat[];
     referenceLabel?: string;
+    profileStats?: ShareProfileStat[];
     tags?: string[];
 }
 

--- a/frontend/src/utils/profileReviewFilter.test.ts
+++ b/frontend/src/utils/profileReviewFilter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getSelectedProfileReviewListId, selectProfileReviewResults } from './profileReviewFilter';
+
+describe('profile review list filtering', () => {
+    it('uses the independently queried list results instead of the partially loaded profile feed', () => {
+        const baseReviews = [
+            { id: 'loaded-a', listId: 'list-a' },
+            { id: 'loaded-b', listId: 'list-b' },
+        ];
+        const queriedListReviews = [
+            { id: 'loaded-a', listId: 'list-a' },
+            { id: 'not-loaded-yet', listId: 'list-a' },
+        ];
+
+        expect(selectProfileReviewResults('list-a', baseReviews, queriedListReviews))
+            .toEqual(queriedListReviews);
+    });
+
+    it('keeps the general paginated feed when no list is selected', () => {
+        const baseReviews = [{ id: 'base', listId: 'list-a' }];
+        expect(selectProfileReviewResults('all', baseReviews, [])).toEqual(baseReviews);
+        expect(getSelectedProfileReviewListId('all')).toBeUndefined();
+    });
+});

--- a/frontend/src/utils/profileReviewFilter.ts
+++ b/frontend/src/utils/profileReviewFilter.ts
@@ -1,0 +1,14 @@
+export const getSelectedProfileReviewListId = (filterValue: string): string | undefined => {
+    const normalized = filterValue.trim();
+    return normalized && normalized !== 'all' ? normalized : undefined;
+};
+
+export const selectProfileReviewResults = <T extends { listId?: string }>(
+    filterValue: string,
+    baseReviews: T[],
+    queriedListReviews: T[],
+): T[] => {
+    const selectedListId = getSelectedProfileReviewListId(filterValue);
+    if (!selectedListId) return baseReviews;
+    return queriedListReviews.filter((review) => review.listId === selectedListId);
+};

--- a/frontend/src/utils/shareCriteria.test.ts
+++ b/frontend/src/utils/shareCriteria.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCriteriaStats } from './shareCriteria';
+import { buildCriteriaStats, buildShareCriteriaGroups } from './shareCriteria';
 
 describe('buildCriteriaStats', () => {
     it('returns empty array when scores is undefined', () => {
@@ -63,5 +63,26 @@ describe('buildCriteriaStats', () => {
         const result = buildCriteriaStats({ bueno: NaN, malo: Infinity, ok: 5 });
         expect(result).toHaveLength(1);
         expect(result[0].key).toBe('ok');
+    });
+});
+
+describe('buildShareCriteriaGroups', () => {
+    it('separates ponderable criteria from circular extras', () => {
+        const definition = {
+            comida: { label: 'Comida', ponderable: true },
+            ruido: { label: 'Ruido', ponderable: false },
+            terraza: { label: 'Terraza', isPonderable: false },
+        };
+
+        const result = buildShareCriteriaGroups({ comida: 9, ruido: 4, terraza: 8 }, definition);
+
+        expect(result.ponderable.map((item) => item.key)).toEqual(['comida']);
+        expect(result.nonPonderable.map((item) => item.key)).toEqual(['ruido', 'terraza']);
+    });
+
+    it('treats criteria without an explicit flag as ponderable', () => {
+        const result = buildShareCriteriaGroups({ ambiente: 7 }, { ambiente: { label: 'Ambiente' } });
+        expect(result.ponderable).toHaveLength(1);
+        expect(result.nonPonderable).toEqual([]);
     });
 });

--- a/frontend/src/utils/shareCriteria.ts
+++ b/frontend/src/utils/shareCriteria.ts
@@ -1,7 +1,13 @@
 import type { ShareCriteriaStat } from '../types/share';
 
-type CriteriaDefinitionRecord = Record<string, { label?: string }>;
-type CriteriaDefinitionArray = Array<{ id?: string; label?: string }>;
+type CriteriaDefinitionItem = {
+    id?: string;
+    label?: string;
+    ponderable?: boolean;
+    isPonderable?: boolean;
+};
+type CriteriaDefinitionRecord = Record<string, CriteriaDefinitionItem>;
+type CriteriaDefinitionArray = CriteriaDefinitionItem[];
 type CriteriaDefinition = CriteriaDefinitionRecord | CriteriaDefinitionArray | null | undefined;
 
 const collator = new Intl.Collator('es', { sensitivity: 'base', numeric: true });
@@ -17,6 +23,18 @@ const getLabel = (definition: CriteriaDefinition, key: string) => {
     }
 
     return key;
+};
+
+const getDefinitionItem = (definition: CriteriaDefinition, key: string): CriteriaDefinitionItem | undefined => {
+    if (Array.isArray(definition)) {
+        return definition.find((item) => item?.id === key);
+    }
+    return definition && typeof definition === 'object' ? definition[key] : undefined;
+};
+
+const isPonderableCriterion = (definition: CriteriaDefinition, key: string) => {
+    const item = getDefinitionItem(definition, key);
+    return item ? item.ponderable !== false && item.isPonderable !== false : true;
 };
 
 export const buildCriteriaStats = (
@@ -66,4 +84,20 @@ export const buildCriteriaStats = (
         })
         .filter((entry): entry is ShareCriteriaStat => Boolean(entry))
         .slice(0, limit);
+};
+
+export const buildShareCriteriaGroups = (
+    scores?: Record<string, number>,
+    definition?: CriteriaDefinition,
+    limitPerGroup = 6,
+): { ponderable: ShareCriteriaStat[]; nonPonderable: ShareCriteriaStat[] } => {
+    const all = buildCriteriaStats(scores, definition, Number.MAX_SAFE_INTEGER);
+    return {
+        ponderable: all
+            .filter((entry) => isPonderableCriterion(definition, entry.key))
+            .slice(0, limitPerGroup),
+        nonPonderable: all
+            .filter((entry) => !isPonderableCriterion(definition, entry.key))
+            .slice(0, limitPerGroup),
+    };
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,6 +26,7 @@ module.exports = {
     ...require('./modules/business-pro'),
     ...require('./modules/business-items'),
     ...require('./modules/sponsored'),
+    ...require('./modules/analytics'),
     ...require('./modules/ssr-meta'),
     ...require('./modules/canonical-items'),
     ...require('./modules/reviews-consolidation'),

--- a/functions/modules/analytics.js
+++ b/functions/modules/analytics.js
@@ -1,0 +1,662 @@
+// Analitica propia y agregada. No guarda IP, UID ni historiales individuales.
+// La ubicacion de conexiones se reduce a una celda aproximada de 0,1 grados
+// antes de almacenarse y solo se muestra al alcanzar un umbral de privacidad.
+
+const crypto = require("crypto");
+const { onCall, HttpsError } = require("firebase-functions/v2/https");
+const { onSchedule } = require("firebase-functions/v2/scheduler");
+const { onDocumentCreated } = require("firebase-functions/v2/firestore");
+const logger = require("firebase-functions/logger");
+const { getFirestore, FieldValue, Timestamp } = require("firebase-admin/firestore");
+const { assertJefeAccess, rateLimit, rateLimitKey } = require("./lib/auth");
+const { hasActiveBusinessPro } = require("./lib/business-plan");
+
+const db = getFirestore();
+const ANALYTICS_TIME_ZONE = "Europe/Madrid";
+const VALID_DEVICES = new Set(["mobile", "tablet", "desktop"]);
+const VALID_SOURCES = new Set(["direct", "internal", "search", "social", "external"]);
+const VALID_SHARE_CHANNELS = new Set(["whatsapp", "clipboard", "image", "chat"]);
+const VALID_SHARE_ENTITY_TYPES = new Set(["place", "group", "list", "sublist", "profile", "app", "review", "link"]);
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]{16,128}$/;
+const EVENT_ID_PATTERN = /^[a-zA-Z0-9_-]{16,128}$/;
+const MAX_PERIOD_DAILY_DOCS = 10000;
+const MAX_HEATMAP_DOCS = 5000;
+const MAX_REVIEW_BACKFILL = 20000;
+const GEO_GRID_STEP_DEGREES = 0.1;
+const GEO_PRIVACY_THRESHOLD = 3;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const hash = (value) => crypto.createHash("sha256").update(value).digest("hex").slice(0, 40);
+const asString = (value, maxLength) => typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+
+function analyticsDate(date = new Date()) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: ANALYTICS_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+function dateDaysAgo(days) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  return analyticsDate(date);
+}
+
+function datesForPeriod(days) {
+  return Array.from({ length: days }, (_, index) => dateDaysAgo(days - index - 1));
+}
+
+function sanitizePath(value) {
+  const raw = asString(value, 500).split(/[?#]/, 1)[0];
+  const hasUnsafeCharacter = Array.from(raw).some((character) => character.charCodeAt(0) < 32 || character === "<" || character === ">");
+  if (!raw || !raw.startsWith("/") || hasUnsafeCharacter) {
+    throw new HttpsError("invalid-argument", "Ruta de pagina no valida.");
+  }
+  return raw.replace(/\/{2,}/g, "/").replace(/\/$/, "") || "/";
+}
+
+function pageTypeForPath(path) {
+  if (path === "/") return "home";
+  if (path === "/search") return "search";
+  if (/^\/list\/[^/]+$/.test(path)) return "list";
+  if (/^\/place\/[^/]+$/.test(path)) return "place";
+  if (/^\/group\/[^/]+(?:\/.*)?$/.test(path)) return "item";
+  if (/^\/profile\/[^/]+$/.test(path)) return "profile";
+  if (path === "/users") return "users";
+  if (["/about", "/privacy", "/terms", "/child-safety", "/istari-core"].includes(path)) return "information";
+  return "other";
+}
+
+function numericMap(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(Object.entries(value)
+    .filter(([, count]) => typeof count === "number" && Number.isFinite(count)));
+}
+
+function addNumericMap(target, source) {
+  Object.entries(source).forEach(([key, value]) => {
+    target[key] = (target[key] || 0) + value;
+  });
+}
+
+function serializeAnalyticsDoc(data = {}) {
+  return {
+    path: typeof data.path === "string" ? data.path : "",
+    title: typeof data.title === "string" ? data.title : "",
+    pageType: typeof data.pageType === "string" ? data.pageType : "other",
+    totalViews: Number(data.totalViews) || 0,
+    uniqueSessions: Number(data.uniqueSessions) || 0,
+    authenticatedViews: Number(data.authenticatedViews) || 0,
+    anonymousViews: Number(data.anonymousViews) || 0,
+    totalShares: Number(data.totalShares) || 0,
+    shareActions: Number(data.shareActions) || 0,
+    byDevice: numericMap(data.byDevice),
+    bySource: numericMap(data.bySource),
+    byShareChannel: numericMap(data.byShareChannel),
+    byShareEntityType: numericMap(data.byShareEntityType),
+    firstViewedAtMs: typeof data.firstViewedAt?.toMillis === "function" ? data.firstViewedAt.toMillis() : null,
+    lastViewedAtMs: typeof data.lastViewedAt?.toMillis === "function" ? data.lastViewedAt.toMillis() : null,
+    lastSharedAtMs: typeof data.lastSharedAt?.toMillis === "function" ? data.lastSharedAt.toMillis() : null,
+  };
+}
+
+function serializePlaceDaily(data = {}, date = "") {
+  return {
+    date: typeof data.date === "string" ? data.date : date,
+    reviews: Number(data.reviews) || 0,
+    totalShares: Number(data.totalShares) || 0,
+    shareActions: Number(data.shareActions) || 0,
+    byShareChannel: numericMap(data.byShareChannel),
+    byShareEntityType: numericMap(data.byShareEntityType),
+  };
+}
+
+function coordinate(value, min, max) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= min && number <= max ? number : null;
+}
+
+function quantizeCoordinate(value) {
+  return Number((Math.round(value / GEO_GRID_STEP_DEGREES) * GEO_GRID_STEP_DEGREES).toFixed(1));
+}
+
+function placeIdFromPath(path) {
+  const match = path.match(/^\/(?:place|group)\/([^/]+)/);
+  if (!match) return "";
+  try {
+    return asString(decodeURIComponent(match[1]), 300);
+  } catch (_) {
+    return asString(match[1], 300);
+  }
+}
+
+function reviewDate(data) {
+  if (typeof data?.createdAt?.toDate === "function") return analyticsDate(data.createdAt.toDate());
+  if (typeof data?.createdAt === "number") return analyticsDate(new Date(data.createdAt));
+  if (typeof data?.createdAt === "string") {
+    const parsed = new Date(data.createdAt);
+    if (!Number.isNaN(parsed.getTime())) return analyticsDate(parsed);
+  }
+  return analyticsDate();
+}
+
+function reviewGeo(data) {
+  const lat = coordinate(data?.placeLat ?? data?.lat, -90, 90);
+  const lng = coordinate(data?.placeLng ?? data?.lng, -180, 180);
+  if (lat === null || lng === null) return null;
+  return { lat, lng };
+}
+
+async function assertBusinessAnalyticsAccess(placeId, uid) {
+  if (!uid) throw new HttpsError("unauthenticated", "Debes iniciar sesion.");
+  if (!placeId) throw new HttpsError("invalid-argument", "Falta placeId.");
+
+  const placeSnap = await db.collection("places").doc(placeId).get();
+  if (!placeSnap.exists) throw new HttpsError("not-found", "El negocio no existe.");
+  const place = placeSnap.data() || {};
+
+  let isAdmin = false;
+  try {
+    await assertJefeAccess(uid);
+    isAdmin = true;
+  } catch (_) {
+    isAdmin = false;
+  }
+  const managers = Array.isArray(place.businessManagerIds) ? place.businessManagerIds : [];
+  const canManage = place.businessOwnerUserId === uid || managers.includes(uid);
+  if (!isAdmin && !canManage) throw new HttpsError("permission-denied", "No puedes consultar este negocio.");
+  if (!isAdmin && !hasActiveBusinessPro(place)) {
+    throw new HttpsError("permission-denied", "Las estadisticas avanzadas requieren Business Pro.");
+  }
+  return place;
+}
+
+const recordPageView = onCall({ invoker: "public" }, async (request) => {
+  const path = sanitizePath(request.data?.path);
+  const sessionId = asString(request.data?.sessionId, 128);
+  if (!SESSION_ID_PATTERN.test(sessionId)) {
+    throw new HttpsError("invalid-argument", "Sesion de analitica no valida.");
+  }
+
+  const device = VALID_DEVICES.has(request.data?.device) ? request.data.device : "desktop";
+  const source = VALID_SOURCES.has(request.data?.source) ? request.data.source : "direct";
+  const title = asString(request.data?.title, 140).replace(/[<>]/g, "");
+  const pageType = pageTypeForPath(path);
+  if (pageType === "other") {
+    throw new HttpsError("invalid-argument", "La ruta no pertenece a una pagina publica medible.");
+  }
+  const isAuthenticated = Boolean(request.auth?.uid);
+
+  const rawRateKey = rateLimitKey(request.rawRequest, request.auth);
+  const rate = await rateLimit("pageAnalytics", hash(rawRateKey), 120, 60);
+  if (!rate.allowed) throw new HttpsError("resource-exhausted", "Demasiadas visitas registradas.");
+
+  const date = analyticsDate();
+  const pageId = hash(path);
+  const sessionHash = hash(sessionId);
+  const pageTotalRef = db.collection("pageAnalyticsTotals").doc(pageId);
+  const pageDailyRef = db.collection("pageAnalyticsDaily").doc(`${date}_${pageId}`);
+  const globalTotalRef = db.collection("pageAnalyticsGlobal").doc("all");
+  const globalDailyRef = db.collection("pageAnalyticsGlobalDaily").doc(date);
+  const pageSessionRef = db.collection("pageAnalyticsSessionMarkers").doc(hash(`${date}|${pageId}|${sessionHash}`));
+  const globalSessionRef = db.collection("pageAnalyticsSessionMarkers").doc(hash(`${date}|all|${sessionHash}`));
+
+  await db.runTransaction(async (tx) => {
+    const [pageSessionSnap, globalSessionSnap, pageTotalSnap, globalTotalSnap] = await Promise.all([
+      tx.get(pageSessionRef),
+      tx.get(globalSessionRef),
+      tx.get(pageTotalRef),
+      tx.get(globalTotalRef),
+    ]);
+    const isNewPageSession = !pageSessionSnap.exists;
+    const isNewGlobalSession = !globalSessionSnap.exists;
+    const common = {
+      totalViews: FieldValue.increment(1),
+      uniqueSessions: FieldValue.increment(isNewPageSession ? 1 : 0),
+      authenticatedViews: FieldValue.increment(isAuthenticated ? 1 : 0),
+      anonymousViews: FieldValue.increment(isAuthenticated ? 0 : 1),
+      byDevice: { [device]: FieldValue.increment(1) },
+      bySource: { [source]: FieldValue.increment(1) },
+      lastViewedAt: FieldValue.serverTimestamp(),
+    };
+    tx.set(pageTotalRef, {
+      ...common,
+      path,
+      title: title || path,
+      pageType,
+      ...(!pageTotalSnap.exists ? { firstViewedAt: FieldValue.serverTimestamp() } : {}),
+    }, { merge: true });
+    tx.set(pageDailyRef, { ...common, pageId, path, title: title || path, pageType, date }, { merge: true });
+    tx.set(globalTotalRef, {
+      totalViews: FieldValue.increment(1),
+      uniqueSessions: FieldValue.increment(isNewGlobalSession ? 1 : 0),
+      authenticatedViews: FieldValue.increment(isAuthenticated ? 1 : 0),
+      anonymousViews: FieldValue.increment(isAuthenticated ? 0 : 1),
+      byDevice: { [device]: FieldValue.increment(1) },
+      bySource: { [source]: FieldValue.increment(1) },
+      lastViewedAt: FieldValue.serverTimestamp(),
+      ...(!globalTotalSnap.exists ? { firstViewedAt: FieldValue.serverTimestamp() } : {}),
+    }, { merge: true });
+    tx.set(globalDailyRef, {
+      date,
+      totalViews: FieldValue.increment(1),
+      uniqueSessions: FieldValue.increment(isNewGlobalSession ? 1 : 0),
+      authenticatedViews: FieldValue.increment(isAuthenticated ? 1 : 0),
+      anonymousViews: FieldValue.increment(isAuthenticated ? 0 : 1),
+      byDevice: { [device]: FieldValue.increment(1) },
+      bySource: { [source]: FieldValue.increment(1) },
+      lastViewedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+
+    const markerData = {
+      date,
+      expiresAt: Timestamp.fromMillis(Date.now() + (40 * DAY_MS)),
+    };
+    if (isNewPageSession) tx.set(pageSessionRef, markerData);
+    if (isNewGlobalSession) tx.set(globalSessionRef, markerData);
+  });
+
+  return { ok: true };
+});
+
+const recordShareEvent = onCall({ invoker: "public" }, async (request) => {
+  const path = sanitizePath(request.data?.path);
+  const pageType = pageTypeForPath(path);
+  const channel = asString(request.data?.channel, 20);
+  const entityType = asString(request.data?.entityType, 20);
+  const eventId = asString(request.data?.eventId, 128);
+  const title = asString(request.data?.title, 140).replace(/[<>]/g, "") || path;
+  const shareCount = Math.min(20, Math.max(1, Math.floor(Number(request.data?.count) || 1)));
+  if (pageType === "other" || !VALID_SHARE_CHANNELS.has(channel) || !VALID_SHARE_ENTITY_TYPES.has(entityType) || !EVENT_ID_PATTERN.test(eventId)) {
+    throw new HttpsError("invalid-argument", "Evento de compartido no valido.");
+  }
+
+  const rawRateKey = rateLimitKey(request.rawRequest, request.auth);
+  const rate = await rateLimit("shareAnalytics", hash(rawRateKey), 60, 60);
+  if (!rate.allowed) throw new HttpsError("resource-exhausted", "Demasiados compartidos registrados.");
+
+  const date = analyticsDate();
+  const pageId = hash(path);
+  const placeId = placeIdFromPath(path);
+  const markerRef = db.collection("shareEventMarkers").doc(hash(eventId));
+  const pageTotalRef = db.collection("pageAnalyticsTotals").doc(pageId);
+  const pageDailyRef = db.collection("pageAnalyticsDaily").doc(`${date}_${pageId}`);
+  const globalTotalRef = db.collection("pageAnalyticsGlobal").doc("all");
+  const globalDailyRef = db.collection("pageAnalyticsGlobalDaily").doc(date);
+  const placeDailyRef = placeId
+    ? db.collection("placeAnalyticsDaily").doc(`${date}_${hash(placeId)}`)
+    : null;
+
+  let counted = false;
+  await db.runTransaction(async (tx) => {
+    const markerSnap = await tx.get(markerRef);
+    if (markerSnap.exists) return;
+    counted = true;
+    const common = {
+      totalShares: FieldValue.increment(shareCount),
+      shareActions: FieldValue.increment(1),
+      byShareChannel: { [channel]: FieldValue.increment(shareCount) },
+      byShareEntityType: { [entityType]: FieldValue.increment(shareCount) },
+      lastSharedAt: FieldValue.serverTimestamp(),
+    };
+    tx.set(pageTotalRef, { ...common, path, title, pageType }, { merge: true });
+    tx.set(pageDailyRef, { ...common, pageId, path, title, pageType, date }, { merge: true });
+    tx.set(globalTotalRef, common, { merge: true });
+    tx.set(globalDailyRef, { ...common, date }, { merge: true });
+    if (placeDailyRef) {
+      tx.set(placeDailyRef, { ...common, date, placeId }, { merge: true });
+    }
+    tx.set(markerRef, {
+      date,
+      expiresAt: Timestamp.fromMillis(Date.now() + (40 * DAY_MS)),
+    });
+  });
+
+  return { counted, count: counted ? shareCount : 0 };
+});
+
+const recordConnectionLocation = onCall({ invoker: "public" }, async (request) => {
+  const sessionId = asString(request.data?.sessionId, 128);
+  const rawLat = coordinate(request.data?.lat, -90, 90);
+  const rawLng = coordinate(request.data?.lng, -180, 180);
+  if (!SESSION_ID_PATTERN.test(sessionId) || rawLat === null || rawLng === null) {
+    throw new HttpsError("invalid-argument", "Ubicacion de analitica no valida.");
+  }
+
+  const rawRateKey = rateLimitKey(request.rawRequest, request.auth);
+  const rate = await rateLimit("connectionGeoAnalytics", hash(rawRateKey), 10, 24 * 60 * 60);
+  if (!rate.allowed) throw new HttpsError("resource-exhausted", "Demasiados registros de ubicacion.");
+
+  const lat = quantizeCoordinate(rawLat);
+  const lng = quantizeCoordinate(rawLng);
+  const date = analyticsDate();
+  const cellId = `${lat.toFixed(1)}_${lng.toFixed(1)}`;
+  const markerRef = db.collection("connectionGeoMarkers").doc(hash(`${date}|${sessionId}`));
+  const dailyRef = db.collection("connectionGeoDaily").doc(`${date}_${hash(cellId)}`);
+  let counted = false;
+
+  await db.runTransaction(async (tx) => {
+    const markerSnap = await tx.get(markerRef);
+    if (markerSnap.exists) return;
+    counted = true;
+    tx.set(dailyRef, {
+      date,
+      cellId,
+      lat,
+      lng,
+      sessions: FieldValue.increment(1),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    tx.set(markerRef, {
+      date,
+      expiresAt: Timestamp.fromMillis(Date.now() + (40 * DAY_MS)),
+    });
+  });
+  return { counted };
+});
+
+const getPageAnalytics = onCall({ invoker: "public" }, async (request) => {
+  await assertJefeAccess(request.auth?.uid, "Solo un jefe puede consultar las estadisticas.");
+  const path = sanitizePath(request.data?.path);
+  const days = Math.min(90, Math.max(1, Math.floor(Number(request.data?.days) || 30)));
+  const pageId = hash(path);
+  const dates = datesForPeriod(days);
+  const refs = dates.map((date) => db.collection("pageAnalyticsDaily").doc(`${date}_${pageId}`));
+  const [totalSnap, ...dailySnaps] = await db.getAll(db.collection("pageAnalyticsTotals").doc(pageId), ...refs);
+
+  return {
+    path,
+    days,
+    total: serializeAnalyticsDoc(totalSnap.exists ? totalSnap.data() : { path, pageType: pageTypeForPath(path) }),
+    daily: dailySnaps.map((snap, index) => ({ date: dates[index], ...serializeAnalyticsDoc(snap.exists ? snap.data() : {}) })),
+  };
+});
+
+const getAnalyticsOverview = onCall({ invoker: "public" }, async (request) => {
+  await assertJefeAccess(request.auth?.uid, "Solo un jefe puede consultar las estadisticas.");
+  const days = Math.min(90, Math.max(1, Math.floor(Number(request.data?.days) || 30)));
+  const fromDate = dateDaysAgo(days - 1);
+  const dates = datesForPeriod(days);
+  const globalDailyRefs = dates.map((date) => db.collection("pageAnalyticsGlobalDaily").doc(date));
+
+  const [globalTotalSnap, pageDailySnap, ...globalDailySnaps] = await Promise.all([
+    db.collection("pageAnalyticsGlobal").doc("all").get(),
+    db.collection("pageAnalyticsDaily").where("date", ">=", fromDate).limit(MAX_PERIOD_DAILY_DOCS).get(),
+    ...globalDailyRefs.map((ref) => ref.get()),
+  ]);
+
+  const pages = new Map();
+  pageDailySnap.docs.forEach((docSnap) => {
+    const row = serializeAnalyticsDoc(docSnap.data());
+    const current = pages.get(row.path) || {
+      path: row.path,
+      title: row.title,
+      pageType: row.pageType,
+      totalViews: 0,
+      uniqueSessions: 0,
+      authenticatedViews: 0,
+      anonymousViews: 0,
+      totalShares: 0,
+      shareActions: 0,
+      byDevice: {},
+      bySource: {},
+      byShareChannel: {},
+      byShareEntityType: {},
+    };
+    current.title = row.title || current.title;
+    current.totalViews += row.totalViews;
+    current.uniqueSessions += row.uniqueSessions;
+    current.authenticatedViews += row.authenticatedViews;
+    current.anonymousViews += row.anonymousViews;
+    current.totalShares += row.totalShares;
+    current.shareActions += row.shareActions;
+    addNumericMap(current.byDevice, row.byDevice);
+    addNumericMap(current.bySource, row.bySource);
+    addNumericMap(current.byShareChannel, row.byShareChannel);
+    addNumericMap(current.byShareEntityType, row.byShareEntityType);
+    pages.set(row.path, current);
+  });
+
+  return {
+    days,
+    fromDate,
+    coverageCapped: pageDailySnap.size >= MAX_PERIOD_DAILY_DOCS,
+    allTime: serializeAnalyticsDoc(globalTotalSnap.exists ? globalTotalSnap.data() : {}),
+    daily: globalDailySnaps.map((snap, index) => ({ date: dates[index], ...serializeAnalyticsDoc(snap.exists ? snap.data() : {}) })),
+    topPages: Array.from(pages.values())
+      .sort((a, b) => b.totalViews - a.totalViews || b.totalShares - a.totalShares)
+      .slice(0, 100),
+  };
+});
+
+const getBusinessPlaceAnalytics = onCall({ invoker: "public" }, async (request) => {
+  const placeId = asString(request.data?.placeId, 300);
+  await assertBusinessAnalyticsAccess(placeId, request.auth?.uid);
+  const days = Math.min(90, Math.max(1, Math.floor(Number(request.data?.days) || 30)));
+  const dates = datesForPeriod(days);
+  const path = `/place/${placeId}`;
+  const pageId = hash(path);
+  const pageRefs = dates.map((date) => db.collection("pageAnalyticsDaily").doc(`${date}_${pageId}`));
+  const placeRefs = dates.map((date) => db.collection("placeAnalyticsDaily").doc(`${date}_${hash(placeId)}`));
+  const [totalSnap, ...dailySnaps] = await db.getAll(
+    db.collection("pageAnalyticsTotals").doc(pageId),
+    ...pageRefs,
+    ...placeRefs,
+  );
+  const pageSnaps = dailySnaps.slice(0, dates.length);
+  const placeSnaps = dailySnaps.slice(dates.length);
+  return {
+    placeId,
+    days,
+    page: {
+      path,
+      days,
+      total: serializeAnalyticsDoc(totalSnap.exists ? totalSnap.data() : { path, pageType: "place" }),
+      daily: pageSnaps.map((snap, index) => ({ date: dates[index], ...serializeAnalyticsDoc(snap.exists ? snap.data() : {}) })),
+    },
+    relatedDaily: placeSnaps.map((snap, index) => serializePlaceDaily(snap.exists ? snap.data() : {}, dates[index])),
+  };
+});
+
+const onReviewCreatedAnalytics = onDocumentCreated("lists/{listId}/reviews/{reviewId}", async (event) => {
+  const review = event.data?.data() || {};
+  const placeId = asString(review.placeId, 300);
+  const geo = reviewGeo(review);
+  if (!placeId || !geo) return;
+
+  const date = reviewDate(review);
+  const markerRef = db.collection("reviewAnalyticsMarkers").doc(hash(event.data.ref.path));
+  const geoRef = db.collection("reviewGeoDaily").doc(`${date}_${hash(placeId)}`);
+  const placeDailyRef = db.collection("placeAnalyticsDaily").doc(`${date}_${hash(placeId)}`);
+
+  await db.runTransaction(async (tx) => {
+    const markerSnap = await tx.get(markerRef);
+    if (markerSnap.exists) return;
+    tx.set(geoRef, {
+      date,
+      placeId,
+      placeName: asString(review.placeName, 140) || placeId,
+      lat: geo.lat,
+      lng: geo.lng,
+      reviews: FieldValue.increment(1),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    tx.set(placeDailyRef, {
+      date,
+      placeId,
+      reviews: FieldValue.increment(1),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    tx.set(markerRef, {
+      date,
+      expiresAt: Timestamp.fromMillis(Date.now() + (400 * DAY_MS)),
+    });
+  });
+});
+
+const getAnalyticsHeatmaps = onCall({ invoker: "public" }, async (request) => {
+  await assertJefeAccess(request.auth?.uid, "Solo un jefe puede consultar los mapas de analitica.");
+  const days = Math.min(365, Math.max(1, Math.floor(Number(request.data?.days) || 30)));
+  const fromDate = dateDaysAgo(days - 1);
+  const [connectionSnap, reviewSnap] = await Promise.all([
+    db.collection("connectionGeoDaily").where("date", ">=", fromDate).limit(MAX_HEATMAP_DOCS).get(),
+    db.collection("reviewGeoDaily").where("date", ">=", fromDate).limit(MAX_HEATMAP_DOCS).get(),
+  ]);
+
+  const connectionCells = new Map();
+  connectionSnap.docs.forEach((docSnap) => {
+    const row = docSnap.data();
+    const cellId = asString(row.cellId, 80);
+    const lat = coordinate(row.lat, -90, 90);
+    const lng = coordinate(row.lng, -180, 180);
+    if (!cellId || lat === null || lng === null) return;
+    const current = connectionCells.get(cellId) || { id: cellId, lat, lng, count: 0 };
+    current.count += Number(row.sessions) || 0;
+    connectionCells.set(cellId, current);
+  });
+
+  const reviewPlaces = new Map();
+  reviewSnap.docs.forEach((docSnap) => {
+    const row = docSnap.data();
+    const placeId = asString(row.placeId, 300);
+    const lat = coordinate(row.lat, -90, 90);
+    const lng = coordinate(row.lng, -180, 180);
+    if (!placeId || lat === null || lng === null) return;
+    const current = reviewPlaces.get(placeId) || {
+      id: placeId,
+      placeId,
+      label: asString(row.placeName, 140) || placeId,
+      lat,
+      lng,
+      count: 0,
+    };
+    current.count += Number(row.reviews) || 0;
+    reviewPlaces.set(placeId, current);
+  });
+
+  const allConnectionCells = Array.from(connectionCells.values());
+  const visibleConnections = allConnectionCells.filter((row) => row.count >= GEO_PRIVACY_THRESHOLD);
+  const suppressedConnections = allConnectionCells
+    .filter((row) => row.count < GEO_PRIVACY_THRESHOLD)
+    .reduce((sum, row) => sum + row.count, 0);
+
+  return {
+    days,
+    fromDate,
+    privacyThreshold: GEO_PRIVACY_THRESHOLD,
+    coverageCapped: connectionSnap.size >= MAX_HEATMAP_DOCS || reviewSnap.size >= MAX_HEATMAP_DOCS,
+    suppressedConnections,
+    connections: visibleConnections.sort((a, b) => b.count - a.count),
+    reviews: Array.from(reviewPlaces.values()).filter((row) => row.count > 0).sort((a, b) => b.count - a.count),
+  };
+});
+
+const adminBackfillReviewHeatmap = onCall({ invoker: "public", timeoutSeconds: 300, memory: "1GiB" }, async (request) => {
+  await assertJefeAccess(request.auth?.uid, "Solo un jefe puede reconstruir el mapa de resenas.");
+  const snapshot = await db.collectionGroup("reviews").limit(MAX_REVIEW_BACKFILL).get();
+  const groups = new Map();
+  let skipped = 0;
+
+  snapshot.docs.forEach((docSnap) => {
+    const review = docSnap.data() || {};
+    const placeId = asString(review.placeId, 300);
+    const geo = reviewGeo(review);
+    if (!placeId || !geo) {
+      skipped += 1;
+      return;
+    }
+    const date = reviewDate(review);
+    const key = `${date}|${placeId}`;
+    const current = groups.get(key) || {
+      date,
+      placeId,
+      placeName: asString(review.placeName, 140) || placeId,
+      lat: geo.lat,
+      lng: geo.lng,
+      reviews: 0,
+    };
+    current.reviews += 1;
+    groups.set(key, current);
+  });
+
+  const rows = Array.from(groups.values());
+  for (let offset = 0; offset < rows.length; offset += 200) {
+    const batch = db.batch();
+    rows.slice(offset, offset + 200).forEach((row) => {
+      const suffix = `${row.date}_${hash(row.placeId)}`;
+      batch.set(db.collection("reviewGeoDaily").doc(suffix), {
+        ...row,
+        backfilledAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+      batch.set(db.collection("placeAnalyticsDaily").doc(suffix), {
+        date: row.date,
+        placeId: row.placeId,
+        reviews: row.reviews,
+        backfilledAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    });
+    await batch.commit();
+  }
+
+  return {
+    scanned: snapshot.size,
+    aggregatedRows: rows.length,
+    skipped,
+    coverageCapped: snapshot.size >= MAX_REVIEW_BACKFILL,
+  };
+});
+
+async function deleteExpiredMarkers(collectionName) {
+  let deleted = 0;
+  for (let batchNumber = 0; batchNumber < 10; batchNumber += 1) {
+    const snapshot = await db.collection(collectionName)
+      .where("expiresAt", "<=", Timestamp.now())
+      .limit(400)
+      .get();
+    if (snapshot.empty) break;
+    const batch = db.batch();
+    snapshot.docs.forEach((docSnap) => batch.delete(docSnap.ref));
+    await batch.commit();
+    deleted += snapshot.size;
+    if (snapshot.size < 400) break;
+  }
+  return deleted;
+}
+
+const cleanupAnalyticsMarkers = onSchedule({
+  schedule: "15 3 * * *",
+  timeZone: ANALYTICS_TIME_ZONE,
+  timeoutSeconds: 300,
+}, async () => {
+  const [pageMarkers, sponsoredMarkers, shareMarkers, connectionMarkers, reviewMarkers] = await Promise.all([
+    deleteExpiredMarkers("pageAnalyticsSessionMarkers"),
+    deleteExpiredMarkers("sponsoredEventMarkers"),
+    deleteExpiredMarkers("shareEventMarkers"),
+    deleteExpiredMarkers("connectionGeoMarkers"),
+    deleteExpiredMarkers("reviewAnalyticsMarkers"),
+  ]);
+  logger.info("analytics: marcadores temporales eliminados", {
+    pageMarkers,
+    sponsoredMarkers,
+    shareMarkers,
+    connectionMarkers,
+    reviewMarkers,
+  });
+});
+
+module.exports = {
+  recordPageView,
+  recordShareEvent,
+  recordConnectionLocation,
+  getPageAnalytics,
+  getAnalyticsOverview,
+  getBusinessPlaceAnalytics,
+  getAnalyticsHeatmaps,
+  adminBackfillReviewHeatmap,
+  onReviewCreatedAnalytics,
+  cleanupAnalyticsMarkers,
+};

--- a/functions/modules/sponsored.js
+++ b/functions/modules/sponsored.js
@@ -9,10 +9,11 @@
 // Colección global `sponsoredPlacements/{id}` (lectura pública, escritura solo
 // por estas funciones).
 
+const crypto = require("crypto");
 const { onCall, HttpsError } = require("firebase-functions/v2/https");
 const logger = require("firebase-functions/logger");
-const { getFirestore, FieldValue } = require("firebase-admin/firestore");
-const { assertJefeAccess, writeAuditLog } = require("./lib/auth");
+const { getFirestore, FieldValue, Timestamp } = require("firebase-admin/firestore");
+const { assertJefeAccess, rateLimit, rateLimitKey, writeAuditLog } = require("./lib/auth");
 const { assertBusinessProAccess } = require("./business-pro");
 const { sendNotification } = require("./notifications");
 
@@ -94,6 +95,13 @@ const reviewSponsoredPlacement = onCall({ invoker: "public" }, async (request) =
   if (!placementSnap.exists) throw new HttpsError("not-found", "El emplazamiento no existe.");
   const placement = placementSnap.data() || {};
 
+  const allowedPlacementTransition = (decision === "activate" || decision === "reject")
+    ? placement.status === "requested"
+    : placement.status === "active";
+  if (!allowedPlacementTransition) {
+    throw new HttpsError("failed-precondition", "La campaña ya no está en un estado compatible con esa acción.");
+  }
+
   const nextStatus = decision === "activate" ? "active" : decision === "reject" ? "rejected" : "ended";
   await placementRef.set({
     status: nextStatus,
@@ -130,20 +138,22 @@ const reviewSponsoredPlacement = onCall({ invoker: "public" }, async (request) =
 // ── Impulsos: platos destacados por radio y tiempo ──────────────────────────
 //
 // El negocio compra "impulsos" para destacar un plato en un radio de X km
-// durante N semanas. Precio por impulso = €/km·semana × radio × semanas
-// (fórmula editable en Developer, config/sponsoredPricing; pensada barata:
-// 0,40 €/km·semana ≈ 0,20 € por semana y medio km). Quien quiera más
+// durante N semanas. El radio se vende en tramos de 0,2 km y el precio de
+// cada tramo es editable en Developer (config/sponsoredPricing). Quien quiera más
 // visibilidad no paga tarifas más caras: compra más impulsos, que son pesos
 // en el sorteo del carrusel — 2 impulsos = doble probabilidad que 1.
 // El reloj de la campaña arranca cuando el admin la activa.
 
+const SPOTLIGHT_RADIUS_STEP_KM = 0.2;
 const DEFAULT_SPOTLIGHT_PRICING = {
-  pricePerKmPerWeek: 0.4,
-  minRadiusKm: 0.5,
+  pricePerRadiusStepPerWeek: 0.08,
+  minRadiusKm: 0.2,
   maxRadiusKm: 20,
   maxUnitsPerCampaign: 10,
   maxWeeks: 8,
 };
+
+const roundRadius = (value) => Number(value.toFixed(1));
 
 async function getSpotlightPricing() {
   const snap = await db.collection("config").doc("sponsoredPricing").get().catch(() => null);
@@ -152,13 +162,84 @@ async function getSpotlightPricing() {
   Object.keys(DEFAULT_SPOTLIGHT_PRICING).forEach((key) => {
     if (typeof data[key] === "number" && Number.isFinite(data[key]) && data[key] > 0) merged[key] = data[key];
   });
+  // Compatibilidad con la fórmula anterior mientras existan documentos que
+  // solo tengan pricePerKmPerWeek.
+  if (!(typeof data.pricePerRadiusStepPerWeek === "number" && data.pricePerRadiusStepPerWeek > 0)
+      && typeof data.pricePerKmPerWeek === "number" && data.pricePerKmPerWeek > 0) {
+    merged.pricePerRadiusStepPerWeek = Number((data.pricePerKmPerWeek * SPOTLIGHT_RADIUS_STEP_KM).toFixed(2));
+  }
+  merged.minRadiusKm = roundRadius(Math.ceil(merged.minRadiusKm / SPOTLIGHT_RADIUS_STEP_KM) * SPOTLIGHT_RADIUS_STEP_KM);
+  merged.maxRadiusKm = roundRadius(Math.floor(merged.maxRadiusKm / SPOTLIGHT_RADIUS_STEP_KM) * SPOTLIGHT_RADIUS_STEP_KM);
+  if (merged.maxRadiusKm < merged.minRadiusKm) merged.maxRadiusKm = merged.minRadiusKm;
   return merged;
 }
 
 function computeSpotlightUnitPrice(pricing, radiusKm, weeks) {
   const effectiveRadius = Math.max(pricing.minRadiusKm, radiusKm);
-  return Number((pricing.pricePerKmPerWeek * effectiveRadius * weeks).toFixed(2));
+  const radiusSteps = Math.ceil((effectiveRadius / SPOTLIGHT_RADIUS_STEP_KM) - 1e-9);
+  return Number((pricing.pricePerRadiusStepPerWeek * radiusSteps * weeks).toFixed(2));
 }
+
+const adminUpdateSpotlightPricing = onCall({ invoker: "public" }, async (request) => {
+  const uid = request.auth?.uid;
+  await assertJefeAccess(uid, "Solo un administrador puede cambiar el precio de los impulsos.");
+
+  const pricePerRadiusStepPerWeek = Number(request.data?.pricePerRadiusStepPerWeek);
+  const minRadiusKm = Number(request.data?.minRadiusKm);
+  const maxRadiusKm = Number(request.data?.maxRadiusKm);
+  const maxUnitsPerCampaign = Number(request.data?.maxUnitsPerCampaign);
+  const maxWeeks = Number(request.data?.maxWeeks);
+
+  if (!Number.isFinite(pricePerRadiusStepPerWeek) || pricePerRadiusStepPerWeek < 0.01 || pricePerRadiusStepPerWeek > 100) {
+    throw new HttpsError("invalid-argument", "El precio por cada 0,2 km y semana debe estar entre 0,01 € y 100 €.");
+  }
+  const isRadiusStep = (value) => Number.isFinite(value)
+    && Math.abs((value / SPOTLIGHT_RADIUS_STEP_KM) - Math.round(value / SPOTLIGHT_RADIUS_STEP_KM)) < 1e-6;
+  if (!isRadiusStep(minRadiusKm) || minRadiusKm < SPOTLIGHT_RADIUS_STEP_KM || minRadiusKm > 100) {
+    throw new HttpsError("invalid-argument", "El radio mínimo debe ser un múltiplo de 0,2 km.");
+  }
+  if (!isRadiusStep(maxRadiusKm) || maxRadiusKm < minRadiusKm || maxRadiusKm > 100) {
+    throw new HttpsError("invalid-argument", "El radio máximo debe ser un múltiplo de 0,2 km y no puede ser menor que el mínimo.");
+  }
+  if (!Number.isInteger(maxUnitsPerCampaign) || maxUnitsPerCampaign < 1 || maxUnitsPerCampaign > 100) {
+    throw new HttpsError("invalid-argument", "El máximo de impulsos debe ser un entero entre 1 y 100.");
+  }
+  if (!Number.isInteger(maxWeeks) || maxWeeks < 1 || maxWeeks > 52) {
+    throw new HttpsError("invalid-argument", "El máximo de semanas debe ser un entero entre 1 y 52.");
+  }
+
+  const pricing = {
+    pricePerRadiusStepPerWeek: Number(pricePerRadiusStepPerWeek.toFixed(2)),
+    radiusStepKm: SPOTLIGHT_RADIUS_STEP_KM,
+    minRadiusKm: roundRadius(minRadiusKm),
+    maxRadiusKm: roundRadius(maxRadiusKm),
+    maxUnitsPerCampaign,
+    maxWeeks,
+    updatedBy: uid,
+    updatedAt: FieldValue.serverTimestamp(),
+    pricePerKmPerWeek: FieldValue.delete(),
+  };
+  await db.collection("config").doc("sponsoredPricing").set(pricing, { merge: true });
+  await writeAuditLog(uid, "sponsored.pricingUpdated", {
+    pricePerRadiusStepPerWeek: pricing.pricePerRadiusStepPerWeek,
+    radiusStepKm: SPOTLIGHT_RADIUS_STEP_KM,
+    minRadiusKm: pricing.minRadiusKm,
+    maxRadiusKm: pricing.maxRadiusKm,
+    maxUnitsPerCampaign,
+    maxWeeks,
+  });
+
+  return {
+    ok: true,
+    pricing: {
+      pricePerRadiusStepPerWeek: pricing.pricePerRadiusStepPerWeek,
+      minRadiusKm: pricing.minRadiusKm,
+      maxRadiusKm: pricing.maxRadiusKm,
+      maxUnitsPerCampaign,
+      maxWeeks,
+    },
+  };
+});
 
 function isoDatePlusDays(days) {
   const date = new Date();
@@ -167,6 +248,71 @@ function isoDatePlusDays(days) {
 }
 
 const MAX_OPEN_SPOTLIGHTS_PER_PLACE = 10;
+
+// Métricas deduplicadas por campaña, evento, sesión y día. Se cuenta una
+// impresión cuando la tarjeta entra realmente en el viewport, no solo al
+// descargar el documento de campaña.
+const recordSponsoredEvent = onCall({ invoker: "public" }, async (request) => {
+  const campaignType = asString(request.data?.campaignType, 20);
+  const campaignId = asString(request.data?.campaignId, 300);
+  const eventType = asString(request.data?.eventType, 20);
+  const sessionId = asString(request.data?.sessionId, 128);
+  if (!campaignId || !["placement", "spotlight"].includes(campaignType) || !["impression", "click"].includes(eventType)) {
+    throw new HttpsError("invalid-argument", "Evento patrocinado no válido.");
+  }
+  if (!/^[a-zA-Z0-9_-]{16,128}$/.test(sessionId)) {
+    throw new HttpsError("invalid-argument", "Sesión no válida.");
+  }
+
+  const rateKey = crypto.createHash("sha256")
+    .update(rateLimitKey(request.rawRequest, request.auth))
+    .digest("hex")
+    .slice(0, 40);
+  const rate = await rateLimit("sponsoredMetrics", rateKey, 180, 60);
+  if (!rate.allowed) throw new HttpsError("resource-exhausted", "Demasiados eventos patrocinados.");
+
+  const dateParts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Madrid", year: "numeric", month: "2-digit", day: "2-digit",
+  }).formatToParts(new Date());
+  const dateValues = Object.fromEntries(dateParts.map((part) => [part.type, part.value]));
+  const date = `${dateValues.year}-${dateValues.month}-${dateValues.day}`;
+  const collectionName = campaignType === "placement" ? "sponsoredPlacements" : "sponsoredItemSpotlights";
+  const campaignRef = db.collection(collectionName).doc(campaignId);
+  const dailyRef = campaignRef.collection("metricsDaily").doc(date);
+  const markerId = crypto.createHash("sha256")
+    .update(`${date}|${campaignType}|${campaignId}|${eventType}|${sessionId}`)
+    .digest("hex");
+  const markerRef = db.collection("sponsoredEventMarkers").doc(markerId);
+  const metricField = eventType === "impression" ? "impressions" : "clicks";
+
+  const result = await db.runTransaction(async (tx) => {
+    const [campaignSnap, markerSnap] = await Promise.all([tx.get(campaignRef), tx.get(markerRef)]);
+    if (!campaignSnap.exists) throw new HttpsError("not-found", "La campaña no existe.");
+    const campaign = campaignSnap.data() || {};
+    if (campaign.status !== "active") return { counted: false, reason: "inactive" };
+    if ((campaign.startsAt && campaign.startsAt > date) || (campaign.endsAt && campaign.endsAt < date)) {
+      return { counted: false, reason: "outside_date_window" };
+    }
+    if (markerSnap.exists) return { counted: false, reason: "duplicate" };
+
+    tx.set(campaignRef, {
+      [`metrics.${metricField}`]: FieldValue.increment(1),
+      "metrics.updatedAt": FieldValue.serverTimestamp(),
+    }, { merge: true });
+    tx.set(dailyRef, {
+      date,
+      [metricField]: FieldValue.increment(1),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    tx.set(markerRef, {
+      date,
+      expiresAt: Timestamp.fromMillis(Date.now() + (40 * 24 * 60 * 60 * 1000)),
+    });
+    return { counted: true };
+  });
+
+  return { ok: true, ...result };
+});
 
 const requestItemSpotlight = onCall({ invoker: "public" }, async (request) => {
   const uid = request.auth?.uid;
@@ -184,6 +330,9 @@ const requestItemSpotlight = onCall({ invoker: "public" }, async (request) => {
   }
   if (!Number.isFinite(radiusKm) || radiusKm < pricing.minRadiusKm || radiusKm > pricing.maxRadiusKm) {
     throw new HttpsError("invalid-argument", `El radio debe estar entre ${pricing.minRadiusKm} y ${pricing.maxRadiusKm} km.`);
+  }
+  if (Math.abs((radiusKm / SPOTLIGHT_RADIUS_STEP_KM) - Math.round(radiusKm / SPOTLIGHT_RADIUS_STEP_KM)) >= 1e-6) {
+    throw new HttpsError("invalid-argument", "El radio debe avanzar en tramos de 0,2 km.");
   }
   if (!Number.isInteger(weeks) || weeks < 1 || weeks > pricing.maxWeeks) {
     throw new HttpsError("invalid-argument", `La duración debe estar entre 1 y ${pricing.maxWeeks} semanas.`);
@@ -213,47 +362,54 @@ const requestItemSpotlight = onCall({ invoker: "public" }, async (request) => {
   }
 
   const unitPriceEur = computeSpotlightUnitPrice(pricing, radiusKm, weeks);
-
-  // Impulsos de regalo (otorgados desde Developer): se consumen antes de
-  // cobrar. Cuando haya micropagos, solo se facturarán los impulsos restantes.
-  const availableCredits = Number(place.spotlightCredits) > 0 ? Math.floor(Number(place.spotlightCredits)) : 0;
-  const creditsUsed = Math.min(availableCredits, units);
-  const billedUnits = units - creditsUsed;
-  const totalPriceEur = Number((unitPriceEur * billedUnits).toFixed(2));
-
-  if (creditsUsed > 0) {
-    await placeRef.set({
-      spotlightCredits: FieldValue.increment(-creditsUsed),
-      updatedAt: FieldValue.serverTimestamp(),
-    }, { merge: true });
-  }
-
   const spotlightRef = db.collection("sponsoredItemSpotlights").doc();
-  await spotlightRef.set({
-    placeId,
-    placeName: place.name || null,
-    placePhotoUrl: place.userPhotoUrl || place.mainImageUrl || null,
-    itemId,
-    itemName: item.canonicalName || itemId,
-    linkedListIds: Array.isArray(item.linkedListIds) ? item.linkedListIds.slice(0, 40) : [],
-    itemAverageRating: typeof item.stats?.averageRating === "number" ? item.stats.averageRating : null,
-    itemReviewCount: typeof item.stats?.reviewCount === "number" ? item.stats.reviewCount : 0,
-    center,
-    radiusKm,
-    units,
-    weeks,
-    unitPriceEur,
-    creditsUsed,
-    billedUnits,
-    totalPriceEur,
-    pricingSnapshot: pricing,
-    // El reloj arranca al activar: reviewItemSpotlight fija startsAt/endsAt.
-    startsAt: null,
-    endsAt: null,
-    status: "requested",
-    createdBy: uid,
-    createdAt: FieldValue.serverTimestamp(),
+  // El saldo y la campaña se escriben en una sola transacción para que dos
+  // solicitudes simultáneas no puedan gastar los mismos impulsos regalo.
+  const billing = await db.runTransaction(async (tx) => {
+    const freshPlaceSnap = await tx.get(placeRef);
+    if (!freshPlaceSnap.exists) throw new HttpsError("not-found", "El negocio no existe.");
+    const freshPlace = freshPlaceSnap.data() || {};
+    const availableCredits = Number(freshPlace.spotlightCredits) > 0
+      ? Math.floor(Number(freshPlace.spotlightCredits))
+      : 0;
+    const creditsUsed = Math.min(availableCredits, units);
+    const billedUnits = units - creditsUsed;
+    const totalPriceEur = Number((unitPriceEur * billedUnits).toFixed(2));
+
+    if (creditsUsed > 0) {
+      tx.set(placeRef, {
+        spotlightCredits: FieldValue.increment(-creditsUsed),
+        updatedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+    tx.set(spotlightRef, {
+      placeId,
+      placeName: freshPlace.name || place.name || null,
+      placePhotoUrl: freshPlace.userPhotoUrl || freshPlace.mainImageUrl || place.userPhotoUrl || place.mainImageUrl || null,
+      itemId,
+      itemName: item.canonicalName || itemId,
+      linkedListIds: Array.isArray(item.linkedListIds) ? item.linkedListIds.slice(0, 40) : [],
+      itemAverageRating: typeof item.stats?.averageRating === "number" ? item.stats.averageRating : null,
+      itemReviewCount: typeof item.stats?.reviewCount === "number" ? item.stats.reviewCount : 0,
+      center,
+      radiusKm,
+      units,
+      weeks,
+      unitPriceEur,
+      creditsUsed,
+      billedUnits,
+      totalPriceEur,
+      pricingSnapshot: pricing,
+      startsAt: null,
+      endsAt: null,
+      status: "requested",
+      createdBy: uid,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    return { creditsUsed, billedUnits, totalPriceEur };
   });
+
+  const { creditsUsed, totalPriceEur } = billing;
 
   await writeAuditLog(uid, "sponsored.itemSpotlightRequested", {
     spotlightId: spotlightRef.id,
@@ -327,6 +483,13 @@ const reviewItemSpotlight = onCall({ invoker: "public" }, async (request) => {
   if (!spotlightSnap.exists) throw new HttpsError("not-found", "La campaña no existe.");
   const spotlight = spotlightSnap.data() || {};
 
+  const allowedSpotlightTransition = (decision === "activate" || decision === "reject")
+    ? spotlight.status === "requested"
+    : spotlight.status === "active";
+  if (!allowedSpotlightTransition) {
+    throw new HttpsError("failed-precondition", "La campaña ya no está en un estado compatible con esa acción.");
+  }
+
   const nextStatus = decision === "activate" ? "active" : decision === "reject" ? "rejected" : "ended";
   const patch = {
     status: nextStatus,
@@ -340,7 +503,28 @@ const reviewItemSpotlight = onCall({ invoker: "public" }, async (request) => {
     patch.startsAt = isoDatePlusDays(0);
     patch.endsAt = isoDatePlusDays(weeks * 7);
   }
-  await spotlightRef.set(patch, { merge: true });
+  if (decision === "reject" && Number(spotlight.creditsUsed) > 0 && spotlight.creditsRefunded !== true) {
+    const creditsToRefund = Math.floor(Number(spotlight.creditsUsed));
+    const placeRef = db.collection("places").doc(spotlight.placeId);
+    await db.runTransaction(async (tx) => {
+      const freshSpotlightSnap = await tx.get(spotlightRef);
+      const freshSpotlight = freshSpotlightSnap.data() || {};
+      if (!freshSpotlightSnap.exists || freshSpotlight.status !== "requested") {
+        throw new HttpsError("failed-precondition", "La campaña ya ha sido procesada.");
+      }
+      tx.set(placeRef, {
+        spotlightCredits: FieldValue.increment(creditsToRefund),
+        updatedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+      tx.set(spotlightRef, {
+        ...patch,
+        creditsRefunded: true,
+        creditsRefundedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    });
+  } else {
+    await spotlightRef.set(patch, { merge: true });
+  }
 
   await writeAuditLog(uid, "sponsored.itemSpotlightReviewed", {
     spotlightId,
@@ -373,4 +557,6 @@ module.exports = {
   requestItemSpotlight,
   reviewItemSpotlight,
   adminGrantSpotlightCredits,
+  adminUpdateSpotlightPricing,
+  recordSponsoredEvent,
 };


### PR DESCRIPTION
Introduce a complete analytics subsystem and sponsored-campaign metrics across backend and frontend. Adds Firebase Functions for analytics (recordPageView, recordShareEvent, recordConnectionLocation, heatmaps, business/place analytics, backfill, and review hooks) and tightens Firestore rules to block direct client access to analytics collections. Implements frontend AnalyticsService and components (PageAnalyticsTracker, PageAnalyticsModal, PageAnalyticsTab, GeoAnalyticsTab) and integrates tracking into App, Navbar, maps, sponsor carousels and home spotlight. Enhances BusinessProService with campaign metrics, recordSponsoredEvent, sponsored-search mapping and radius-step pricing (SPOTLIGHT_RADIUS_STEP_KM), updates pricing computation and admin API. Improves sharing pipeline: criteria grouping, multi-image support, share-card renderer variants, and share-event recording. Adds profile review filtering helpers and unit tests for spotlight pricing and share criteria. Privacy and rate-limit safeguards included.